### PR TITLE
refactor(release): stable marker Hard 化 [#2141] + 消费文档对齐 [#2135] + v0.1.1 prep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,16 +247,18 @@ jobs:
           bash hack/verify-workspace.sh
 
       - name: Tag modules
-        # Snapshots tag the bare $TAG only. Stable mints the bare $TAG as the GitHub
-        # Release MARKER tag (NOT a module tag: post-#1565 no module sits at the repo
-        # root, so modrelease's --print-tag-paths correctly emits only the per-module
-        # <reldir>/vX.Y.Z library tags — see modrelease_test.go TestTagPaths). The
-        # workflow prepends the bare marker to those library tags and pushes the
-        # whole set --atomic so a partial set never lands. This restores the pre-#1565
-        # ref topology — a bare vX.Y.Z at the release commit alongside every library
-        # tag — which `gh release create --verify-tag`, goreleaser {{.Tag}}, and the
-        # verify-job resume sentinel all resolve against (k8s/gopls convention; #2134).
-        # Guarded by RELEASE-STABLE-MARKER-TAG-01.
+        # Snapshots tag the bare $TAG only. Stable consumes modrelease's
+        # --print-stable-tags — the SINGLE SOURCE for the push set: the bare $TAG
+        # MARKER tag FIRST (NOT a module tag: post-#1565 no module sits at the repo
+        # root) followed by the per-module <reldir>/vX.Y.Z library tags. The whole
+        # set is pushed --atomic so a partial set never lands. This restores the
+        # pre-#1565 ref topology — a bare vX.Y.Z at the release commit alongside
+        # every library tag — which `gh release create --verify-tag`, goreleaser
+        # {{.Tag}}, and the verify-job resume sentinel all resolve against
+        # (k8s/gopls convention; #2134). modrelease OWNS the marker (StableTags,
+        # byte-locked by STABLE-RELEASE-TAG-SET-01); the workflow's consumed shape
+        # is guarded by RELEASE-STABLE-MARKER-TAG-01 (#2141, Hard-ized from the
+        # prior shell hand-mint).
         #
         # Resume: the verify job's tag_exists check inspects only the bare MARKER tag.
         # The --atomic push makes marker + library tags land all-or-nothing, so the
@@ -274,24 +276,23 @@ jobs:
             git push origin "$TAG"
             exit 0
           fi
-          mapfile -t module_tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-tag-paths)
-          # Sanity floor only — the EXACT publishable set is Hard golden-locked by
-          # PUBLISHABLE-MODULE-SET-01 (modrelease testdata/publishable.golden). The
-          # >=2 here just catches modrelease returning empty/garbage at release time.
-          if [ "${#module_tags[@]}" -lt 2 ]; then
-            echo "::error::modrelease produced ${#module_tags[@]} library tag(s) for $TAG; expected the full publishable module set."
+          # SINGLE SOURCE: --print-stable-tags emits the full push set in push
+          # order — the bare $TAG marker FIRST + the publishable library tags.
+          # modrelease owns the marker (StableTags); the workflow no longer hand-mints
+          # it (was `tags=("$TAG" "${module_tags[@]}")`). The EXACT set is Hard
+          # golden-locked by STABLE-RELEASE-TAG-SET-01 (testdata/stable_tags.golden);
+          # this consumed shape is guarded by RELEASE-STABLE-MARKER-TAG-01.
+          mapfile -t tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-stable-tags)
+          # Sanity floor only (the EXACT set is the golden above): >=3 = marker +
+          # >=2 library tags, and the marker MUST be first — catches modrelease
+          # returning empty/garbage or a marker-less set at release time.
+          if [ "${#tags[@]}" -lt 3 ] || [ "${tags[0]}" != "$TAG" ]; then
+            echo "::error::modrelease --print-stable-tags must emit the bare marker '$TAG' first + the full publishable set; got ${#tags[@]} tag(s), first='${tags[0]:-}'."
             exit 1
           fi
-          # The bare $TAG is the GitHub Release MARKER tag, prepended to the per-module
-          # library tags. modrelease never emits it (post-#1565 no module sits at the
-          # repo root; see modrelease_test.go TestTagPaths), so the workflow mints it
-          # here — restoring the pre-#1565 ref topology that `gh release create
-          # --verify-tag`, goreleaser {{.Tag}}, and the verify-job resume sentinel
-          # resolve against (#2134, RELEASE-STABLE-MARKER-TAG-01).
-          tags=("$TAG" "${module_tags[@]}")
           # Operator-visible preview of the exact set about to be pushed.
           {
-            echo "### Release $TAG — marker tag + ${#module_tags[@]} library module tags"
+            echo "### Release $TAG — ${#tags[@]} synchronized tags (bare marker + $(( ${#tags[@]} - 1 )) library module tags)"
             printf -- '- %s\n' "${tags[@]}"
           } >>"$GITHUB_STEP_SUMMARY"
           # Push the now-verified pin commit to develop (only if one was created).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,6 +283,10 @@ jobs:
           # golden-locked by STABLE-RELEASE-TAG-SET-01 (testdata/stable_tags.golden);
           # this consumed shape is guarded by RELEASE-STABLE-MARKER-TAG-01.
           mapfile -t tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-stable-tags)
+          # NOTE: `<(...)` is a process substitution, NOT a pipe — its exit code is
+          # NOT propagated by `set -euo pipefail`. So a failed `go run` (build error,
+          # etc.) leaves `tags` an empty array WITHOUT aborting here; the sanity floor
+          # below is the SOLE fail-closed guard for that case. Do not remove it.
           # Sanity floor only (the EXACT set is the golden above): >=3 = marker +
           # >=2 library tags, and the marker MUST be first — catches modrelease
           # returning empty/garbage or a marker-less set at release time.
@@ -290,9 +294,11 @@ jobs:
             echo "::error::modrelease --print-stable-tags must emit the bare marker '$TAG' first + the full publishable set; got ${#tags[@]} tag(s), first='${tags[0]:-}'."
             exit 1
           fi
-          # Operator-visible preview of the exact set about to be pushed.
+          # Operator-visible preview of the exact set about to be pushed. The
+          # non-marker tags are the publishable module set (libraries + tools/generated),
+          # not external "library" modules only — hence "publishable module tags".
           {
-            echo "### Release $TAG — ${#tags[@]} synchronized tags (bare marker + $(( ${#tags[@]} - 1 )) library module tags)"
+            echo "### Release $TAG — ${#tags[@]} synchronized tags (bare marker + $(( ${#tags[@]} - 1 )) publishable module tags)"
             printf -- '- %s\n' "${tags[@]}"
           } >>"$GITHUB_STEP_SUMMARY"
           # Push the now-verified pin commit to develop (only if one was created).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-06-15
+
 ### Breaking Changes
 
 - **Go SDK module path (轴 A)**: the framework core module moved from the repo root
@@ -122,12 +124,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
-- **External consumability**: the repository is public, so the framework module
-  is consumable with plain `go get github.com/ghbvf/gocell@<tag>` — the `GOPRIVATE`
-  setup step was removed from the README and the external-cell quickstart (#1723).
-  Known limitation: `go install github.com/ghbvf/gocell/cmd/gocell@<tag>` does not
-  yet work (the satellite `cmd/gocell` module keeps a local `replace` and the
-  release pipeline cuts no submodule tag); install the CLI from source until #2045.
+- **External consumability**: the repository is public, so the framework is
+  consumable with plain `go get github.com/ghbvf/gocell/framework@<tag>` (post-#1565
+  the core moved to the `/framework` submodule — see Breaking Changes above) — the
+  `GOPRIVATE` setup step was removed from the README and the external-cell quickstart
+  (#1723). The CLI now also installs via `go install
+  github.com/ghbvf/gocell/cmd/gocell@<tag>` from any stable tag that ships the #2045
+  pipeline (the release strips the satellite `cmd/gocell` module's local `replace`
+  and cuts the `cmd/gocell/vX.Y.Z` submodule tag); earlier tags install from source.
 - `gocell scaffold assembly` runnable stub now blocks on signal (SIGINT/SIGTERM)
   instead of returning a "not implemented" error immediately. `go run ./cmd/{id}`
   will wait for signal rather than exiting with code 1. (#867, sub-item

--- a/Makefile
+++ b/Makefile
@@ -123,12 +123,13 @@ update-archtest-golden:
 	go test -tags=archtest ./tools/archtest -update -count=1
 
 # update-modrelease-golden regenerates testdata/publishable.golden
-# (PUBLISHABLE-MODULE-SET-01) and testdata/installable.golden
-# (INSTALLABLE-BINARY-SET-01), the byte-frozen derived module sets. Run after
-# intentionally adding/removing a go.work member, changing IsPublishable, or
-# changing installableBinaries.
+# (PUBLISHABLE-MODULE-SET-01), testdata/installable.golden
+# (INSTALLABLE-BINARY-SET-01), and testdata/stable_tags.golden
+# (STABLE-RELEASE-TAG-SET-01) — the byte-frozen derived module/tag sets. Run after
+# intentionally adding/removing a go.work member, changing IsPublishable,
+# installableBinaries, or the stable marker shape.
 update-modrelease-golden:
-	go test ./tools/modrelease -run 'TestPublishableModuleSet01|TestInstallableBinarySet01' -update -count=1
+	go test ./tools/modrelease -run 'TestPublishableModuleSet01|TestInstallableBinarySet01|TestStableReleaseTagSet01' -update -count=1
 
 # release-smoke runs the external-consumer go-get/build smoke for the
 # synchronized multi-module release (RELEASE-EXTERNAL-GET-01). Network-free at

--- a/README.md
+++ b/README.md
@@ -597,16 +597,20 @@ length before injection into context.
 
 ## Using in Your Project
 
-GoCell is a public Go module — no `GOPRIVATE` or auth setup is required.
+GoCell is public — no `GOPRIVATE` or auth setup is required. Post-#1565 the
+framework core is the dedicated `github.com/ghbvf/gocell/framework` submodule (the
+repo root holds only `go.work`, no module); pin every gocell satellite at the same
+synchronized `vX.Y.Z`.
 
 ```bash
 # Add the framework to your project (or pin a stable tag, e.g. @v0.1.0)
-go get github.com/ghbvf/gocell@latest
+go get github.com/ghbvf/gocell/framework@latest
 ```
 
-The `gocell` governance/codegen CLI is currently installed from source
-(`git clone … && go install ./cmd/gocell`); a standalone
-`go install github.com/ghbvf/gocell/cmd/gocell@vX.Y.Z` entry point is planned. See
+The `gocell` governance/codegen CLI installs via `go install
+github.com/ghbvf/gocell/cmd/gocell@vX.Y.Z` from any stable tag that ships the #2045
+release pipeline; for earlier tags or unreleased code, install from source (`git
+clone … && go install ./cmd/gocell`). See
 [docs/guides/cell-external-repo-quickstart.md](docs/guides/cell-external-repo-quickstart.md).
 
 ## Project Templates

--- a/docs/guides/cell-development-guide.md
+++ b/docs/guides/cell-development-guide.md
@@ -678,7 +678,7 @@ GoCell supports three Cell development modes:
 | Mode | Repository shape | Configuration |
 |------|-----------------|--------------|
 | **Monorepo** (gocell itself) | Same `go.mod` | Default conventional layout (no `.gocell/manifest.yaml`) |
-| **Operator-SDK** | External repo `go get github.com/ghbvf/gocell` | Place `.gocell/manifest.yaml` at the repo root with 1 module entry |
+| **Operator-SDK** | External repo `go get github.com/ghbvf/gocell/framework` | Place `.gocell/manifest.yaml` at the repo root with 1 module entry |
 | **Workspace** | `go.work` aggregating gocell + multiple cell modules | Place `.gocell/manifest.yaml` at the workspace root with multiple module entries |
 
 ### Conventional Layout (Default)

--- a/docs/guides/cli-version-compatibility.md
+++ b/docs/guides/cli-version-compatibility.md
@@ -1,6 +1,6 @@
 # CLI ↔ Framework 版本兼容性
 
-本文档说明 `gocell` CLI 与 `github.com/ghbvf/gocell` framework module 的版本对应关系。
+本文档说明 `gocell` CLI 与 `github.com/ghbvf/gocell/framework` framework module 的版本对应关系。
 
 ## 发布模型：原子同 tag
 
@@ -106,7 +106,7 @@ framework 版本超出声明范围将不被支持，届时 CLI 可能在启动�
 下表记录每次 stable release 的 CLI ↔ framework 兼容关系。**每次 stable release 追加一行**；
 不删除历史行（历史行是消费方升级决策的参考）。
 
-| gocell CLI version | Compatible framework (`github.com/ghbvf/gocell`) | Notes |
+| gocell CLI version | Compatible framework (`github.com/ghbvf/gocell/framework`) | Notes |
 |--------------------|-------------------------------------------------|-------|
 | v0.1.0 | >=v0.1.0 <v0.2.0 | First stable release（co-tagged，best-effort intent；预编译产物自首个搭载发布流水线的 release 起提供，此 tag 不含；`go install @version` 自首个搭载 #2045 流水线的 release 起可用，v0.1.0 本身可能早于该流水线） |
 
@@ -126,7 +126,7 @@ framework 版本超出声明范围将不被支持，届时 CLI 可能在启动�
 gocell version
 
 # 查看项目当前依赖的 framework 版本
-go list -m github.com/ghbvf/gocell
+go list -m github.com/ghbvf/gocell/framework
 
 # 确认 framework 版本在 compatible_framework_range 内
 ```

--- a/tools/archtest/archtest_ci_shard_count_test.go
+++ b/tools/archtest/archtest_ci_shard_count_test.go
@@ -315,11 +315,14 @@ func stripInlineComment(line string) string {
 
 // runCommandLines splits a workflow step's `run:` block into logical shell
 // command lines: shell comments are stripped (stripInlineComment) and backslash
-// line-continuations are joined. The shard-denominator assertion binds to these
-// — NOT the raw run string — so (a) a commented example above a real shard-less
-// invocation cannot false-green the guard, and (b) the real archtest-nightly.yml
-// invocation, which puts `verify archtest` and `--shard=N/24` on separate
-// continued lines, is still seen as ONE command line.
+// line-continuations are joined. It is the shared comment-stripping/line-joining
+// helper for the workflow-scanning archtests (ARCHTEST-CI-EXPLICIT-SHARD-COUNT-01
+// here, plus archtest_ci_gowork_test.go and RELEASE-STABLE-MARKER-TAG-01's marker
+// scan): they all bind to these logical lines — NOT the raw run string — so
+// (a) a commented example above a real invocation cannot false-green the guard,
+// and (b) a real invocation split across backslash-continued lines (e.g.
+// archtest-nightly.yml's `verify archtest` + `--shard=N/24`) is still seen as ONE
+// command line.
 func runCommandLines(run string) []string {
 	var cmds []string
 	var cur strings.Builder

--- a/tools/archtest/release_stable_marker_tag_test.go
+++ b/tools/archtest/release_stable_marker_tag_test.go
@@ -20,22 +20,34 @@ import (
 // release's git tags. The marker invariant binds to THIS step's run block.
 const tagModulesStepName = "Tag modules"
 
-// markerMintRe matches the stable push-set construction that PREPENDS the bare
-// $TAG marker to the modrelease-derived library tags:
+// consumeStableTagsRe matches the stable push-set construction that CONSUMES
+// modrelease's single-source stable tag set into the push array:
+//
+//	mapfile -t tags < <(... --print-stable-tags)
+//
+// Post-#2141 modrelease OWNS the bare vX.Y.Z marker (StableTags, byte-locked by
+// STABLE-RELEASE-TAG-SET-01); the workflow consumes that golden set verbatim
+// rather than hand-minting the marker. Matching the flag literal is sufficient —
+// it is the one token that proves the single source is consumed. Comment-stripped
+// command lines are matched (runCommandLines), so a commented example cannot
+// satisfy the guard.
+var consumeStableTagsRe = regexp.MustCompile(`--print-stable-tags`)
+
+// shellMintMarkerRe matches the PRE-#2141 hand-mint shape that prepended the bare
+// $TAG marker to modrelease's library tags in shell:
 //
 //	tags=("$TAG" "${module_tags[@]}")
 //
-// Whitespace-tolerant inside the array literal; the leading "$TAG" element is the
-// load-bearing assertion — the bare vX.Y.Z GitHub Release marker the workflow
-// must mint ITSELF, since modrelease emits only <subdir>/vX.Y.Z library tags
-// post-#1565. Comment-stripped command lines are matched (runCommandLines), so a
-// commented example cannot satisfy the guard.
-var markerMintRe = regexp.MustCompile(`tags=\(\s*"\$TAG"`)
+// Post-#2141 the marker lives in modrelease's StableTags (Hard golden), NOT shell
+// text — so this shape is BANNED: its reappearance means marker authority drifted
+// back out of modrelease into un-golden-locked workflow shell. Whitespace-tolerant
+// inside the array literal; comment-stripped lines bind it to real command text.
+var shellMintMarkerRe = regexp.MustCompile(`tags=\(\s*"\$TAG"`)
 
 // staleAssertionMarker is the pre-#1565 broken guard's error string: it required
-// the bare $TAG to appear in modrelease's derived tag set, which always exits 1
-// post-#1565 (modrelease correctly never emits a bare tag). Its reappearance is a
-// regression — locked out alongside the positive marker-mint assertion.
+// the bare $TAG to appear in modrelease's derived (library-only) tag set, which
+// always exits 1 post-#1565 (--print-tag-paths correctly never emits a bare tag).
+// Its reappearance is a regression — banned alongside the shell hand-mint.
 const staleAssertionMarker = "root tag $TAG missing from derived tag set"
 
 type markerWorkflow struct {
@@ -52,57 +64,54 @@ type markerStep struct {
 }
 
 // TestReleaseStableMarkerTag enforces RELEASE-STABLE-MARKER-TAG-01 across every
-// .github/workflows/*.y{a,}ml: the stable "Tag modules" step must mint the bare
-// $TAG as the GitHub Release marker tag (prepended to the modrelease-derived
-// library tag set) and must NOT carry the pre-#1565 "$TAG must be in the derived
-// set" assertion.
+// .github/workflows/*.y{a,}ml: the stable "Tag modules" step must CONSUME
+// modrelease's single-source `--print-stable-tags` (the bare $TAG marker FIRST +
+// library tags), must NOT hand-mint the marker in shell (`tags=("$TAG" …)`), and
+// must NOT carry the pre-#1565 "$TAG must be in the derived set" assertion.
 //
 // Why it matters: #1565 moved the core into framework/, so the repo root holds no
-// module and modrelease's TagPaths correctly emits only <subdir>/vX.Y.Z library
-// tags — never a bare vX.Y.Z (TestTagPaths, modrelease_test.go). But the bare
-// vX.Y.Z is the repo-level RELEASE MARKER that `gh release create --verify-tag`,
-// goreleaser {{.Tag}}, and the verify-job resume sentinel (`refs/tags/$tag`) all
-// resolve against (k8s/gopls convention: bare = release marker, <subdir>/vX = the
-// go-get module tag). The pre-#1565 workflow expected modrelease to emit that bare
-// tag and asserted its presence — so every stable release dispatch exits 1 (#2134,
-// latent: pre-release / develop CI never exercises this path). The fix restores
-// the pre-#1565 git ref topology by minting the marker in the workflow; this guard
-// keeps that mint from silently regressing.
+// module and modrelease's TagPaths emits only <subdir>/vX.Y.Z library tags — never
+// a bare vX.Y.Z. But the bare vX.Y.Z is the repo-level RELEASE MARKER that
+// `gh release create --verify-tag`, goreleaser {{.Tag}}, and the verify-job resume
+// sentinel (`refs/tags/$tag`) all resolve against (k8s/gopls convention: bare =
+// release marker, <subdir>/vX = the go-get module tag). #2134 first restored the
+// marker by HAND-MINTING it in workflow shell (`tags=("$TAG" …)`), guarded by this
+// test's prior Medium content-scan. #2141 Hard-ized that: modrelease now OWNS the
+// marker via [modrelease.StableTags], byte-locked by STABLE-RELEASE-TAG-SET-01
+// (testdata/stable_tags.golden). The workflow consumes that golden set verbatim;
+// this guard now keeps the CONSUMED shape from regressing (back to hand-mint, to a
+// marker-less library-only consume, or to the stale assertion).
 //
-// The deeper purpose is AI-robustness against the #1565→#2134 failure CLASS:
-// release semantics living in un-CI-guarded shell that drifts when the module
-// layout changes. modrelease's library + installable tag sets are already Hard
-// golden-locked (PUBLISHABLE-MODULE-SET-01 / publishable.golden, installable.golden);
-// the bare marker was the one release ref with no CI-time guard — its only check,
-// `gh release create --verify-tag`, fires at RELEASE time, not in the PR that
-// breaks it (the same latency that let #2134 ship green through #2125). This static
-// scan pulls the marker invariant into CI.
-//
-// AI-robust grade: Medium content-scan (machine-checkable; dropping the marker
-// mint or re-adding the stale assertion is a reviewer-visible diff that fails this
-// test). Hard is reachable but not low-cost — it would require modrelease to own
-// the full stable tag set (a `--print-stable-tags` golden the workflow consumes
-// verbatim), re-merging the marker into modrelease's surface (in tension with
-// "modrelease = pure module tags") + 3 files; tracked as backlog Hard-ization
-// issue #2141 per ai-robust.md §审查要求.
+// AI-robust grade: this guard is Medium content-scan of the workflow's CONSUMED
+// shape (a YAML/shell seam the type system can't express). The Hard guarantee —
+// that the marker + library set is exactly correct — moved to the golden
+// (STABLE-RELEASE-TAG-SET-01, Hard): together they form a closed funnel, golden
+// upstream (the SET) + this scan downstream (the workflow actually consumes it,
+// not a re-derived/hand-minted substitute). Dropping `--print-stable-tags`, adding
+// a `tags=("$TAG" …)` hand-mint, or re-adding the stale assertion is a
+// reviewer-visible diff that fails this test.
 //
 // Blind spot (disclosed):
 //   - This scans the run-block TEXT, not the executed git pushes — it proves the
-//     marker is constructed into the push array, not that the push succeeds. Push
-//     success / tag-set atomicity is covered at release time by the --atomic push +
+//     step consumes the single source, not that the push succeeds. Push success /
+//     tag-set atomicity is covered at release time by the --atomic push +
 //     `gh release create --verify-tag` + the "Validate satellite tag set (stable
 //     resume)" step.
-//   - markerMintRe binds to the `tags=("$TAG" …)` array-literal form. A maintainer
-//     who rewrites the push set into append form (e.g. `tags+=("$TAG")`) would evade
-//     the positive match; the Hard-ization (#2141) closes this by deriving the set
-//     from modrelease + golden instead of scanning shell text.
+//   - consumeStableTagsRe binds to the `--print-stable-tags` flag literal. A
+//     maintainer who pipes the flag through an intermediate var / wrapper script
+//     could consume the single source without the literal appearing in this step's
+//     run block (evading the positive match); the golden still locks the SET.
+//   - shellMintMarkerRe binds to the `tags=("$TAG" …)` array-literal form; an
+//     append form (`tags+=("$TAG")`) would evade the hand-mint ban — but with the
+//     marker now sourced from the golden-locked --print-stable-tags, re-hand-minting
+//     is a pointless regression the consume check already steers away from.
 //   - Only the "Tag modules" step is scanned; the sibling "Validate satellite tag
-//     set (stable resume)" step (which re-derives the library tags on resume) is NOT
-//     guarded here — its correctness rides on the same modrelease source plus the
-//     release-time peel-to-marker-commit check.
-//   - A maintainer who renames "Tag modules" or moves the mint to a new step evades
-//     the positive check but trips the anti-vacuity tally loudly (require.Positive),
-//     not silently.
+//     set (stable resume)" step (which re-derives the library tags via
+//     --print-tag-paths on resume) is NOT guarded here — its correctness rides on
+//     the same modrelease source plus the release-time peel-to-marker-commit check.
+//   - A maintainer who renames "Tag modules" or moves the consume to a new step
+//     evades the positive check but trips the anti-vacuity tally loudly
+//     (require.Positive), not silently.
 //
 // ref: kubernetes/kubernetes (bare vX.Y.Z = release marker; staging modules tag
 //
@@ -150,19 +159,26 @@ func validateReleaseStableMarkerTag(name string, body []byte) (int, error) {
 			}
 			matched++
 			joined := strings.Join(runCommandLines(step.Run), "\n")
-			if !markerMintRe.MatchString(joined) {
+			if !consumeStableTagsRe.MatchString(joined) {
 				return matched, fmt.Errorf("RELEASE-STABLE-MARKER-TAG-01: %s job %q step %q does not "+
-					"mint the bare $TAG release marker — expected the stable push set to PREPEND it: "+
-					"`tags=(\"$TAG\" \"${module_tags[@]}\")`. modrelease emits only <subdir>/vX.Y.Z "+
-					"library tags post-#1565, so the workflow must mint the bare vX.Y.Z marker itself; "+
-					"it is what `gh release create --verify-tag`, goreleaser {{.Tag}}, and the verify-job "+
-					"resume sentinel resolve against. See #2134.", name, jobName, markerStepLabel(step))
+					"CONSUME modrelease's single-source stable tag set — expected `mapfile -t tags < "+
+					"<(go run ./tools/modrelease/cmd --version \"$TAG\" --print-stable-tags)`. Post-#2141 "+
+					"modrelease OWNS the bare vX.Y.Z marker (StableTags, byte-locked by "+
+					"STABLE-RELEASE-TAG-SET-01); the workflow must consume that golden set, not re-derive "+
+					"the library tags and hand-mint the marker. See #2141.", name, jobName, markerStepLabel(step))
+			}
+			if shellMintMarkerRe.MatchString(joined) {
+				return matched, fmt.Errorf("RELEASE-STABLE-MARKER-TAG-01: %s job %q step %q HAND-MINTS the "+
+					"bare $TAG marker (`tags=(\"$TAG\" …)`) — post-#2141 the marker is owned by modrelease "+
+					"StableTags (Hard golden testdata/stable_tags.golden), NOT shell text. Consume "+
+					"--print-stable-tags instead of prepending the marker in the workflow. See #2141.",
+					name, jobName, markerStepLabel(step))
 			}
 			if strings.Contains(joined, staleAssertionMarker) {
 				return matched, fmt.Errorf("RELEASE-STABLE-MARKER-TAG-01: %s job %q step %q still "+
-					"contains the pre-#1565 assertion %q, which fails every stable release: modrelease "+
-					"correctly never emits a bare tag, so requiring it in the derived set always exits 1. "+
-					"Remove it; the bare $TAG is minted as the Release marker instead. See #2134.",
+					"contains the pre-#1565 assertion %q, which fails every stable release: modrelease's "+
+					"--print-tag-paths correctly never emits a bare tag, so requiring it there always exits "+
+					"1. Remove it; the marker comes from --print-stable-tags. See #2134/#2141.",
 					name, jobName, markerStepLabel(step), staleAssertionMarker)
 			}
 		}
@@ -190,54 +206,52 @@ func markerJobNames(m map[string]markerJob) []string {
 
 // --- synthetic fixtures: red (must fail) ---------------------------------
 
-// TestReleaseStableMarkerTag_RejectsMissingMarker covers the broken shapes: the
-// stable step pushes only modrelease's library tags without minting the bare $TAG
-// marker, and/or carries the pre-#1565 stale assertion.
-func TestReleaseStableMarkerTag_RejectsMissingMarker(t *testing.T) {
+// TestReleaseStableMarkerTag_RejectsHandMintAndStale covers the broken shapes:
+// the stable step hand-mints the marker in shell instead of consuming
+// --print-stable-tags, consumes only the library-only surface (marker missing),
+// or carries the pre-#1565 stale assertion.
+func TestReleaseStableMarkerTag_RejectsHandMintAndStale(t *testing.T) {
 	cases := map[string]string{
-		// The current (pre-fix) shape: maps modrelease's tags, asserts the bare $TAG
-		// is among them, pushes only those — no marker minted.
-		"no-marker-with-stale-assertion": `jobs:
+		// Pre-#2141 hand-mint: derives library tags via --print-tag-paths then
+		// prepends the bare $TAG in shell. Banned — marker must come from modrelease.
+		"hand-mints-marker": `jobs:
+  release:
+    steps:
+      - name: Tag modules
+        run: |
+          mapfile -t module_tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-tag-paths)
+          tags=("$TAG" "${module_tags[@]}")
+          git push origin --atomic "${tags[@]}"
+`,
+		// Consumes only the library-only --print-tag-paths and never the stable
+		// set: the marker is missing entirely (does not consume the single source).
+		"no-stable-consume": `jobs:
   release:
     steps:
       - name: Tag modules
         run: |
           mapfile -t tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-tag-paths)
+          git push origin --atomic "${tags[@]}"
+`,
+		// Consumes the stable set correctly BUT re-introduces the pre-#1565 stale
+		// assertion: the regression-lock must still fire independently.
+		"stable-consume-but-stale-assertion": `jobs:
+  release:
+    steps:
+      - name: Tag modules
+        run: |
+          mapfile -t tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-stable-tags)
           case " ${tags[*]} " in
             *" $TAG "*) ;;
             *) echo "::error::root tag $TAG missing from derived tag set."; exit 1 ;;
           esac
           git push origin --atomic "${tags[@]}"
 `,
-		// Marker absent even without the stale assertion: still a violation.
-		"no-marker": `jobs:
-  release:
-    steps:
-      - name: Tag modules
-        run: |
-          mapfile -t module_tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-tag-paths)
-          git push origin --atomic "${module_tags[@]}"
-`,
-		// Marker minted correctly BUT the stale assertion re-introduced: the
-		// regression-lock must still fire (the broken case must never reappear).
-		"marker-but-stale-assertion": `jobs:
-  release:
-    steps:
-      - name: Tag modules
-        run: |
-          mapfile -t module_tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-tag-paths)
-          case " ${module_tags[*]} " in
-            *" $TAG "*) ;;
-            *) echo "::error::root tag $TAG missing from derived tag set."; exit 1 ;;
-          esac
-          tags=("$TAG" "${module_tags[@]}")
-          git push origin --atomic "${tags[@]}"
-`,
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {
 			matched, err := validateReleaseStableMarkerTag("fixture.yml", []byte(body))
-			require.Error(t, err, "missing marker / stale assertion (%s) must be rejected", name)
+			require.Error(t, err, "hand-mint / missing consume / stale assertion (%s) must be rejected", name)
 			require.Positive(t, matched, "fixture must be recognized as a Tag modules step")
 		})
 	}
@@ -245,38 +259,44 @@ func TestReleaseStableMarkerTag_RejectsMissingMarker(t *testing.T) {
 
 // --- synthetic fixtures: green (must pass + be non-vacuous) ---------------
 
-func TestReleaseStableMarkerTag_AcceptsMintedMarker(t *testing.T) {
+func TestReleaseStableMarkerTag_AcceptsStableTagsConsume(t *testing.T) {
 	cases := map[string]string{
-		"marker-prepended": `jobs:
+		"consumes-stable-tags": `jobs:
   release:
     steps:
       - name: Tag modules
         run: |
-          mapfile -t module_tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-tag-paths)
-          if [ "${#module_tags[@]}" -lt 2 ]; then exit 1; fi
-          tags=("$TAG" "${module_tags[@]}")
+          mapfile -t tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-stable-tags)
+          if [ "${#tags[@]}" -lt 3 ] || [ "${tags[0]}" != "$TAG" ]; then exit 1; fi
           for tag in "${tags[@]}"; do git tag -a "$tag" -m "Release $tag"; done
           git push origin --atomic "${tags[@]}"
 `,
-		// Whitespace tolerance inside the array literal.
-		"marker-prepended-spaced": `jobs:
+		// Real-shaped: the snapshot branch tags the bare $TAG directly while the
+		// stable branch consumes --print-stable-tags. The snapshot `git tag -a "$TAG"`
+		// must NOT trip the shell-mint ban (it is not the `tags=("$TAG" …)` form).
+		"snapshot-branch-plus-stable-consume": `jobs:
   release:
     steps:
       - name: Tag modules
         run: |
-          tags=(  "$TAG" "${module_tags[@]}")
+          if [ "$PRERELEASE" = "true" ]; then
+            git tag -a "$TAG" -m "Release $TAG"
+            git push origin "$TAG"
+            exit 0
+          fi
+          mapfile -t tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-stable-tags)
           git push origin --atomic "${tags[@]}"
 `,
-		// Anti-vacuity / F3-class false-positive guard: a commented historical
-		// mention of the stale assertion must NOT trip the regression-lock
-		// (comment-stripping in runCommandLines binds it to actual command text).
-		"commented-stale-assertion": `jobs:
+		// Anti-vacuity / false-positive guard: a commented historical mention of the
+		// stale assertion AND the old hand-mint must NOT trip the bans (comment-
+		// stripping in runCommandLines binds them to actual command text).
+		"commented-historical-shapes": `jobs:
   release:
     steps:
       - name: Tag modules
         run: |
-          # historical note: we used to assert "root tag $TAG missing from derived tag set"
-          tags=("$TAG" "${module_tags[@]}")
+          # historical: we used to "root tag $TAG missing from derived tag set" via tags=("$TAG" ...)
+          mapfile -t tags < <(go run ./tools/modrelease/cmd --version "$TAG" --print-stable-tags)
           git push origin --atomic "${tags[@]}"
 `,
 	}

--- a/tools/modrelease/cmd/main.go
+++ b/tools/modrelease/cmd/main.go
@@ -1,11 +1,13 @@
 // Command modrelease drives the synchronized multi-module release transform for
 // the GoCell workspace. With --version it rewrites every publishable library
 // module's internal require versions in place (keeping replace); with
-// --print-tag-paths it emits the per-module git tags (one per line) for the
-// release workflow's tag loop; with --print-installable-tags it emits the
-// installable binary git tags; with --installable it strips replace+pins
-// internal requires in every installable binary module; with --dry-run it
-// previews the set and tags without writing. It is invoked by
+// --print-tag-paths it emits the per-module library git tags (one per line) for
+// the release workflow's resume-verification path; with --print-stable-tags it
+// emits the FULL stable push set (the bare vX.Y.Z marker first + library tags)
+// that the workflow's "Tag modules" step consumes; with --print-installable-tags
+// it emits the installable binary git tags; with --installable it strips
+// replace+pins internal requires in every installable binary module; with
+// --dry-run it previews the set and tags without writing. It is invoked by
 // .github/workflows/release.yml.
 package main
 
@@ -36,6 +38,7 @@ func p(format string, a ...any) { _, _ = fmt.Fprintf(os.Stdout, format, a...) }
 type flags struct {
 	version              string
 	printTags            bool
+	printStableTags      bool
 	printInstallableTags bool
 	installable          bool
 	dryRun               bool
@@ -44,7 +47,9 @@ type flags struct {
 func parseFlags() (flags, error) {
 	version := flag.String("version", "", "release version tag, e.g. v1.2.3 (required)")
 	printTags := flag.Bool("print-tag-paths", false,
-		"print per-module git tags (one per line) instead of bumping")
+		"print per-module library git tags (one per line) instead of bumping")
+	printStableTags := flag.Bool("print-stable-tags", false,
+		"print the full stable push set (bare vX.Y.Z marker first + library tags) for release.yml mapfile")
 	printInstallableTags := flag.Bool("print-installable-tags", false,
 		"print installable binary git tags (one per line) for release.yml mapfile")
 	installable := flag.Bool("installable", false,
@@ -59,6 +64,7 @@ func parseFlags() (flags, error) {
 	return flags{
 		version:              *version,
 		printTags:            *printTags,
+		printStableTags:      *printStableTags,
 		printInstallableTags: *printInstallableTags,
 		installable:          *installable,
 		dryRun:               *dryRun,
@@ -78,6 +84,8 @@ func run() error {
 	switch {
 	case f.printTags:
 		return printTagPaths(root, f.version)
+	case f.printStableTags:
+		return printStableTagPaths(root, f.version)
 	case f.printInstallableTags:
 		return printInstallableTagPaths(root, f.version)
 	case f.dryRun:
@@ -97,6 +105,21 @@ func printTagPaths(root, version string) error {
 	// log isn't flooded.
 	slog.SetLogLoggerLevel(slog.LevelWarn)
 	tags, err := modrelease.TagPaths(root, version)
+	if err != nil {
+		return err
+	}
+	for _, t := range tags {
+		p("%s\n", t)
+	}
+	return nil
+}
+
+// printStableTagPaths emits the full stable push set one per line: the bare
+// vX.Y.Z marker FIRST, then library tags. Silences INFO logs so the output is
+// machine-parseable by release.yml's `mapfile -t tags`.
+func printStableTagPaths(root, version string) error {
+	slog.SetLogLoggerLevel(slog.LevelWarn)
+	tags, err := modrelease.StableTags(root, version)
 	if err != nil {
 		return err
 	}

--- a/tools/modrelease/cmd/main.go
+++ b/tools/modrelease/cmd/main.go
@@ -61,6 +61,20 @@ func parseFlags() (flags, error) {
 	if *version == "" {
 		return flags{}, fmt.Errorf("--version is required (e.g. --version v1.2.3)")
 	}
+	// The mode flags are mutually exclusive — run()'s switch silently honors the
+	// first set case, so passing two (e.g. --print-stable-tags --print-tag-paths)
+	// would quietly emit the wrong tag set into release.yml's `mapfile`. Reject
+	// rather than pick one arbitrarily. (No flag set = the default bump mode.)
+	modes := 0
+	for _, set := range []bool{*printTags, *printStableTags, *printInstallableTags, *installable, *dryRun} {
+		if set {
+			modes++
+		}
+	}
+	if modes > 1 {
+		return flags{}, fmt.Errorf("--print-tag-paths / --print-stable-tags / --print-installable-tags / " +
+			"--installable / --dry-run are mutually exclusive; pass at most one")
+	}
 	return flags{
 		version:              *version,
 		printTags:            *printTags,
@@ -189,7 +203,10 @@ func preview(root, version string) error {
 	if err != nil {
 		return err
 	}
-	tags, err := modrelease.TagPaths(root, version)
+	// The fresh stable push set is StableTags (bare marker first + library tags),
+	// matching what release.yml's "Tag modules" step consumes via --print-stable-tags
+	// — so dry-run previews the marker, not just the library tags.
+	stable, err := modrelease.StableTags(root, version)
 	if err != nil {
 		return err
 	}
@@ -206,8 +223,8 @@ func preview(root, version string) error {
 	for _, m := range mods {
 		p("  %s (%s)\n", m.Dir, m.ImportPath)
 	}
-	p("would create %d library tags:\n", len(tags))
-	for _, t := range tags {
+	p("fresh stable release would push %d tags (bare marker first + %d library):\n", len(stable), len(stable)-1)
+	for _, t := range stable {
 		p("  %s\n", t)
 	}
 	p("%d installable binaries would have replace stripped and internal requires pinned to %s:\n",

--- a/tools/modrelease/modrelease.go
+++ b/tools/modrelease/modrelease.go
@@ -320,6 +320,36 @@ func TagPaths(root, version string) ([]string, error) {
 	return out, nil
 }
 
+// StableTags returns the FULL git tag set a stable release pushes, in push
+// order: the bare vX.Y.Z release MARKER tag FIRST, followed by every publishable
+// library module tag from [TagPaths].
+//
+// The marker is the repo-level release ref that `gh release create --verify-tag`,
+// goreleaser {{.Tag}}, and the verify-job resume sentinel all resolve against
+// (k8s/gopls convention: bare vX.Y.Z = release marker, <subdir>/vX.Y.Z = the
+// go-get module tag). Post-#1565 no module sits at the repo root, so [TagPaths]
+// never emits the bare marker; StableTags mints it via the SAME [tagPathFor]
+// root-ref convention ("." → bare version), so the "<bare version> = release
+// marker" shape is single-sourced, not a re-spelled literal.
+//
+// This is the single source the release workflow's "Tag modules" step consumes
+// (modrelease/cmd --print-stable-tags); it replaces the pre-#2141 shell-minted
+// `tags=("$TAG" "${module_tags[@]}")` construction, and testdata/stable_tags.golden
+// byte-locks the resulting set (STABLE-RELEASE-TAG-SET-01, Hard).
+//
+// Contrast [TagPaths] (--print-tag-paths): library tags ONLY, no marker — still
+// used by the release workflow's stable-resume verification path, which proves
+// every library tag peels to the marker commit (the marker itself is verified
+// separately via `git rev-parse "$TAG"`).
+func StableTags(root, version string) ([]string, error) {
+	libTags, err := TagPaths(root, version)
+	if err != nil {
+		return nil, err
+	}
+	marker := tagPathFor(".", version)
+	return append([]string{marker}, libTags...), nil
+}
+
 // installableBinaries is the frozen closed set of workspace use-dirs that are
 // go-install-able binaries. It is the single source for [InstallableBinaries]
 // and [InstallableTagPaths]. To add a new installable binary, append its

--- a/tools/modrelease/modrelease.go
+++ b/tools/modrelease/modrelease.go
@@ -335,7 +335,10 @@ func TagPaths(root, version string) ([]string, error) {
 // This is the single source the release workflow's "Tag modules" step consumes
 // (modrelease/cmd --print-stable-tags); it replaces the pre-#2141 shell-minted
 // `tags=("$TAG" "${module_tags[@]}")` construction, and testdata/stable_tags.golden
-// byte-locks the resulting set (STABLE-RELEASE-TAG-SET-01, Hard).
+// byte-locks the resulting set (STABLE-RELEASE-TAG-SET-01, Hard) — including the
+// marker's bare-version shape, which is frozen by that whole-set golden, not by an
+// independent guard on tagPathFor. TestStableReleaseTagSet01_MarkerFirst additionally
+// proves StableTags == [marker] ++ [TagPaths].
 //
 // Contrast [TagPaths] (--print-tag-paths): library tags ONLY, no marker — still
 // used by the release workflow's stable-resume verification path, which proves

--- a/tools/modrelease/publishable_golden_test.go
+++ b/tools/modrelease/publishable_golden_test.go
@@ -44,7 +44,8 @@ const publishableModuleSetRule = "PUBLISHABLE-MODULE-SET-01"
 // updateGolden regenerates testdata/publishable.golden (via `make
 // update-modrelease-golden`). Test-scope only; modrelease is not imported as a
 // dependency, so this flag cannot collide with a consumer's own -update.
-var updateGolden = flag.Bool("update", false, "regenerate testdata/publishable.golden")
+var updateGolden = flag.Bool("update", false,
+	"regenerate the modrelease testdata goldens (publishable.golden, installable.golden, stable_tags.golden)")
 
 // goldenTagPathRE matches a well-formed synchronized tag: a bare version for the
 // root, or "<reldir>/vX.Y.Z" for a satellite. Rejects "..", absolute paths.

--- a/tools/modrelease/stable_tags_golden_test.go
+++ b/tools/modrelease/stable_tags_golden_test.go
@@ -1,0 +1,143 @@
+package modrelease
+
+// INVARIANT: STABLE-RELEASE-TAG-SET-01
+//
+// The stable release push set — the bare vX.Y.Z release MARKER tag FIRST,
+// followed by every publishable library module tag — is DERIVED by [StableTags]
+// (marker via [tagPathFor] + [TagPaths]) and byte-locked into
+// testdata/stable_tags.golden. This is a codegen-funnel+golden guard
+// (ai-robust §载体 #1, Hard): adding/removing/renaming a go.work member, changing
+// IsPublishable, or changing the marker shape shifts the derived set, the golden
+// goes stale, and CI fails on the byte diff — the drift cannot be silent.
+// Regenerate intentionally with `make update-modrelease-golden`.
+//
+// # Grading: Hard (golden byte-freeze of a derived set)
+//
+// The SET is derived from go.work (the single source the toolchain compiles) +
+// the [tagPathFor] root-ref convention, and the OUTPUT bytes are frozen. This
+// supersedes the pre-#2141 Medium content-scan that asserted the workflow
+// hand-minted the marker in shell (RELEASE-STABLE-MARKER-TAG-01): the marker now
+// lives in modrelease's StableTags surface, golden-locked here, and the workflow
+// merely CONSUMES `--print-stable-tags` (consumed-shape still Medium-guarded by
+// the repointed RELEASE-STABLE-MARKER-TAG-01). See #2141.
+//
+// # Anti-vacuity + synthetic red case (ai-robust §archtest 文件命名)
+//
+//   - Anti-vacuity: TestStableReleaseTagSet01 asserts len >= 3 (marker + >= 2
+//     library tags), that the FIRST element is the bare vX.Y.Z marker, and that
+//     the core framework tag is present — so a mis-resolved / empty / marker-less
+//     set cannot pass green.
+//   - Synthetic proof: TestStableReleaseTagSet01_MarkerFirst asserts StableTags ==
+//     [bare marker] ++ TagPaths, i.e. the marker is prepended and the library tail
+//     equals the library-only surface — proving StableTags is not a vacuous alias
+//     of either surface.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const stableReleaseTagSetRule = "STABLE-RELEASE-TAG-SET-01"
+
+// renderStableTags serializes the stable push set in the same style as
+// renderPublishable/renderInstallable so golden generation is consistent. The
+// set is version-bearing, so the golden bakes testVersion (v1.2.3).
+func renderStableTags(tags []string) string {
+	var b strings.Builder
+	b.WriteString("# Stable release tag set — DERIVED: bare vX.Y.Z marker FIRST + publishable library tags.\n")
+	b.WriteString("# Rendered at version " + testVersion + ". Regenerate intentionally: make update-modrelease-golden\n")
+	for _, t := range tags {
+		fmt.Fprintf(&b, "%s\n", t)
+	}
+	return b.String()
+}
+
+// TestStableReleaseTagSet01 is the golden byte-freeze guard for the stable
+// release push set (STABLE-RELEASE-TAG-SET-01, Hard).
+func TestStableReleaseTagSet01(t *testing.T) {
+	root := workspaceRootForTest(t)
+
+	tags, err := StableTags(root, testVersion)
+	if err != nil {
+		t.Fatalf("%s: StableTags: %v", stableReleaseTagSetRule, err)
+	}
+
+	// Anti-vacuity: marker + the real publishable set is >= 3; the marker must be
+	// the FIRST element (bare vX.Y.Z), and the core framework tag must be present.
+	if len(tags) < 3 {
+		t.Fatalf("%s: anti-vacuity failed: derived %d stable tags, want >= 3 (marker + >= 2 library)", stableReleaseTagSetRule, len(tags))
+	}
+	if tags[0] != testVersion {
+		t.Fatalf("%s: anti-vacuity failed: first tag %q is not the bare vX.Y.Z marker %q", stableReleaseTagSetRule, tags[0], testVersion)
+	}
+	if !containsString(tags, "framework/"+testVersion) {
+		t.Fatalf("%s: anti-vacuity failed: core framework tag framework/%s absent from %v", stableReleaseTagSetRule, testVersion, tags)
+	}
+
+	got := renderStableTags(tags)
+	goldenPath := filepath.Clean(filepath.Join("testdata", "stable_tags.golden"))
+	if *updateGolden {
+		if err := os.WriteFile(goldenPath, []byte(got), 0o644); err != nil {
+			t.Fatalf("%s: write golden: %v", stableReleaseTagSetRule, err)
+		}
+		t.Logf("%s: wrote %s (%d tags)", stableReleaseTagSetRule, goldenPath, len(tags))
+		return
+	}
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("%s: read golden (run `make update-modrelease-golden`): %v", stableReleaseTagSetRule, err)
+	}
+	if got != string(want) {
+		t.Errorf("%s: stable release tag set drifted from testdata/stable_tags.golden.\n"+
+			"A go.work member was added/removed/renamed, IsPublishable changed, or the marker shape changed. "+
+			"If intentional, run `make update-modrelease-golden`.\n--- got ---\n%s\n--- want ---\n%s",
+			stableReleaseTagSetRule, got, string(want))
+	}
+}
+
+// TestStableReleaseTagSet01_MarkerFirst proves StableTags == [bare marker] ++
+// TagPaths: the marker is prepended and the tail equals the library-only surface.
+// This keeps StableTags from being a vacuous alias of either surface.
+func TestStableReleaseTagSet01_MarkerFirst(t *testing.T) {
+	root := workspaceRootForTest(t)
+
+	libTags, err := TagPaths(root, testVersion)
+	if err != nil {
+		t.Fatalf("%s: TagPaths: %v", stableReleaseTagSetRule, err)
+	}
+	stable, err := StableTags(root, testVersion)
+	if err != nil {
+		t.Fatalf("%s: StableTags: %v", stableReleaseTagSetRule, err)
+	}
+
+	// The library surface must NOT contain the bare marker (post-#1565 no root
+	// module), so StableTags genuinely adds it.
+	if containsString(libTags, testVersion) {
+		t.Fatalf("%s: TagPaths unexpectedly emits the bare marker %q — StableTags would be a no-op prepend", stableReleaseTagSetRule, testVersion)
+	}
+	if len(stable) != len(libTags)+1 {
+		t.Fatalf("%s: StableTags len %d != TagPaths len %d + 1 (marker)", stableReleaseTagSetRule, len(stable), len(libTags))
+	}
+	if stable[0] != testVersion {
+		t.Errorf("%s: StableTags[0] = %q, want bare marker %q first", stableReleaseTagSetRule, stable[0], testVersion)
+	}
+	for i, lt := range libTags {
+		if stable[i+1] != lt {
+			t.Errorf("%s: StableTags[%d] = %q, want library tag %q (tail must equal TagPaths)", stableReleaseTagSetRule, i+1, stable[i+1], lt)
+		}
+	}
+}
+
+// TestStableTagsRejectsBadVersion confirms StableTags rejects malformed versions
+// (it routes through TagPaths → validReleaseVersion).
+func TestStableTagsRejectsBadVersion(t *testing.T) {
+	root := workspaceRootForTest(t)
+	for _, bad := range []string{"1.2.3", "v1.2", "v1.2.3-rc1+meta", "", "v2.0.0"} {
+		if _, err := StableTags(root, bad); err == nil {
+			t.Errorf("%s: StableTags must reject version %q", stableReleaseTagSetRule, bad)
+		}
+	}
+}

--- a/tools/modrelease/testdata/stable_tags.golden
+++ b/tools/modrelease/testdata/stable_tags.golden
@@ -1,0 +1,22 @@
+# Stable release tag set — DERIVED: bare vX.Y.Z marker FIRST + publishable library tags.
+# Rendered at version v1.2.3. Regenerate intentionally: make update-modrelease-golden
+v1.2.3
+adapters/adapterutil/v1.2.3
+adapters/grpc/v1.2.3
+adapters/mqtt/v1.2.3
+adapters/oidc/v1.2.3
+adapters/otel/v1.2.3
+adapters/postgres/v1.2.3
+adapters/prometheus/v1.2.3
+adapters/rabbitmq/v1.2.3
+adapters/ratelimit/v1.2.3
+adapters/redis/v1.2.3
+adapters/s3/v1.2.3
+adapters/vault/v1.2.3
+adapters/websocket/v1.2.3
+cellmodules/v1.2.3
+corecells/v1.2.3
+framework/v1.2.3
+generated/v1.2.3
+tests/v1.2.3
+tools/v1.2.3


### PR DESCRIPTION
## Summary

modrelease 自有 `--print-stable-tags` + golden，把 stable release marker tag 从 release.yml shell 手拼 **Hard 化**为单源派生（#2141）；README/CHANGELOG 外部消费入口对齐 framework module + #2045 CLI 安装（#2135）；CHANGELOG `[Unreleased] → [0.1.1]` release-prep。

## Why / 背景

- **#2141**：stable marker tag 此前在 release.yml shell 手拼（`tags=("$TAG" "${module_tags[@]}")`），靠 Medium archtest 内容扫描守（盲区：append 形式 `tags+=` 可绕）。modrelease 已对 library/installable tag 集做 Hard golden，唯独 marker 走 Medium scan——本 PR 把 marker 并入 modrelease `StableTags` 并 golden 字节锁，消除盲区。
- **#2135**：`README.md:604` 仍 `go get github.com/ghbvf/gocell@latest`（#1565 后 root module 已删，core 在 `/framework` submodule）+ 称 CLI `go install` 为 "planned"（#2045 已落地、可用）。
- **v0.1.1 release-prep**：CHANGELOG `[Unreleased] → [0.1.1]`（release version 真源 = git tag，CHANGELOG 手维护、不被 pipeline 读，纯簿记）。
- **releases CI 转绿（确认项，无代码）**：用户指的 run `27490613392`（06-14 Release 失败）根因 = release.yml 当时 pin 捏造的 goreleaser-action SHA `…9050d`（`gh api` 422 不存在）。已由 `ce84a700b (#2120)` 修正为真实 v6.3.0 SHA `…0552`，06-15 schedule run `27529927024` 实证 verify job 转绿。**已解决，本 PR 无相关代码改动**；完整 stable goreleaser 路径将在切 v0.1.1 时实跑。

## Refs

- Closes #2141
- Closes #2135
- ADR `docs/architecture/202606131200-1088`（轴 A Go-API SemVer）；marker 起源 #2134；installable pipeline #2045；framework split #1565
- ref: kubernetes/kubernetes + golang.org/x/tools gopls（bare `vX.Y.Z` = release marker 约定）

## Risk / 兼容性

- release.yml stable 「Tag modules」**fresh** push-set 改为消费 `--print-stable-tags`（删 shell 手拼 marker + marker-first/`>=3` sanity）；**resume** 路径保留 `--print-tag-paths`（纯 library 逐 tag 验 peel 到 marker commit）不变。
- **首次端到端实跑验证 = 切 v0.1.1**（stable 路径仅 `workflow_dispatch` 跑，scheduled snapshot 不触发）。release.yml 自带 resume 半发布态恢复，单点失败可 re-dispatch。
- 无 wire / Go-API 破坏；纯 release 工具链 + 文档。
- `RELEASE-STABLE-MARKER-TAG-01` **repoint**（语义：「workflow hand-mint marker」→「workflow 消费 `--print-stable-tags` 单源、不再 hand-mint」），Medium；Hard 保证移到新 golden `STABLE-RELEASE-TAG-SET-01`——golden 上游（tag 集）+ 消费扫描下游（workflow 真消费）= 闭环 funnel。

## Test plan

- [x] `go build ./...`（tools module）+ `verify-workspace.sh` 本地通过
- [x] `go test ./tools/modrelease/...` 通过（含 `stable_tags.golden` RED→GREEN + marker-first 非空证明）
- [x] `golangci-lint run`：新增改动 `--new-from-rev origin/develop` = **0 issues**
- [x] `go test -tags archtest ./archtest/`：marker repoint + golden 绿（唯一 FAIL = develop 既有 `TestProjectionConsumerBaseWiring`，他人处理、非本 PR）
- [x] `modrelease/cmd --version v0.1.1 --print-stable-tags` 实测 marker `v0.1.1` 在首位

🤖 Generated with [Claude Code](https://claude.com/claude-code)
