### PR TITLE
fix(release): stable pin 扩到全 workspace 成员，修 go work sync drift + goreleaser-action v7 [#2212]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,11 +208,15 @@ jobs:
           cache-dependency-path: "**/go.sum"
 
       - name: Pin internal requires & commit (stable only)
-        # Synchronized multi-module release (#1843): pin every publishable LIBRARY
-        # module's internal requires v0.0.0 -> vX.Y.Z (keeping replace) on a local
-        # commit — the single tag target for root and all satellites. It is NEITHER
-        # pushed NOR tagged here: the pinned tree is first re-verified (next step),
-        # so the released commit is never an unverified tree (F1). Snapshots skip.
+        # Synchronized multi-module release (#1843): pin EVERY workspace member's
+        # internal requires v0.0.0 -> vX.Y.Z (keeping replace) on a local commit —
+        # the pin set, a superset of the tagged publishable set. Pinning the full
+        # membership (incl. examples/*, cmd/*, tests/* subdirs) makes the next
+        # step's `go work sync` a no-op, so the pinned tree is drift-free (#2212 —
+        # a publishable-only pin left those members at v0.0.0 and `go work sync`
+        # drifted them). It is NEITHER pushed NOR tagged here: the pinned tree is
+        # first re-verified (next step), so the released commit is never an
+        # unverified tree (F1). Snapshots skip.
         if: needs.verify.outputs.tag_exists != 'true' && needs.verify.outputs.prerelease != 'true'
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,8 +164,8 @@ jobs:
         if: steps.resolve.outputs.skip != 'true'
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
-          version: 'v2.16.0' # pinned (F6); bump via dependabot
-          install-only: true
+          version: 'v2.16.0' # pinned (F6); bump via dependabot — CLI version decoupled from action via install-only
+          install-only: true # v7.2.2 keeps version+install-only inputs (verified vs v6); v7 major bump is node20->node24 runtime only
 
       - name: goreleaser config check (pre-tag, no side effects)
         if: steps.resolve.outputs.skip != 'true'
@@ -214,9 +214,11 @@ jobs:
         # membership (incl. examples/*, cmd/*, tests/* subdirs) makes the next
         # step's `go work sync` a no-op, so the pinned tree is drift-free (#2212 —
         # a publishable-only pin left those members at v0.0.0 and `go work sync`
-        # drifted them). It is NEITHER pushed NOR tagged here: the pinned tree is
-        # first re-verified (next step), so the released commit is never an
-        # unverified tree (F1). Snapshots skip.
+        # drifted them). cmd/gocell is in this pin set with its replace KEPT; the
+        # separate "Release installable CLI" step strips replace on its own child
+        # commit/tree (#2045) — orthogonal, no conflict. It is NEITHER pushed NOR
+        # tagged here: the pinned tree is first re-verified (next step), so the
+        # released commit is never an unverified tree (F1). Snapshots skip.
         if: needs.verify.outputs.tag_exists != 'true' && needs.verify.outputs.prerelease != 'true'
         run: |
           set -euo pipefail
@@ -228,7 +230,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           go run ./tools/modrelease/cmd --version "$TAG"
           if git diff --quiet; then
-            echo "::warning::modrelease pinned no requires (already at $TAG?) — tagging $SHA as-is." \
+            echo "::warning::modrelease changed nothing — every member already pinned to $TAG (resume path) or carries no internal require; tagging $SHA as-is." \
               | tee -a "$GITHUB_STEP_SUMMARY"
           else
             git commit -am "release($TAG): pin internal module requires"
@@ -393,8 +395,8 @@ jobs:
         if: needs.verify.outputs.prerelease != 'true'
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
-          version: 'v2.16.0' # pinned (F6); bump via dependabot
-          install-only: true
+          version: 'v2.16.0' # pinned (F6); bump via dependabot — CLI version decoupled from action via install-only
+          install-only: true # v7.2.2 keeps version+install-only inputs (verified vs v6); v7 major bump is node20->node24 runtime only
 
       - name: Pre-publish version smoke (no side effects, stable only)
         # F1/C1: validate the ldflags-injected version BEFORE any publish side

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
       # first and goreleaser would only fail afterwards, leaving an orphan tag.
       - name: Install goreleaser
         if: steps.resolve.outputs.skip != 'true'
-        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: 'v2.16.0' # pinned (F6); bump via dependabot
           install-only: true
@@ -391,7 +391,7 @@ jobs:
 
       - name: Install goreleaser (stable only)
         if: needs.verify.outputs.prerelease != 'true'
-        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: 'v2.16.0' # pinned (F6); bump via dependabot
           install-only: true

--- a/tools/modrelease/cmd/main.go
+++ b/tools/modrelease/cmd/main.go
@@ -1,6 +1,6 @@
 // Command modrelease drives the synchronized multi-module release transform for
-// the GoCell workspace. With --version it rewrites every publishable library
-// module's internal require versions in place (keeping replace); with
+// the GoCell workspace. With --version it pins every workspace member's internal
+// require versions in place (the pin set, keeping replace); with
 // --print-tag-paths it emits the per-module library git tags (one per line) for
 // the release workflow's resume-verification path; with --print-stable-tags it
 // emits the FULL stable push set (the bare vX.Y.Z marker first + library tags)
@@ -107,7 +107,7 @@ func run() error {
 	case f.installable:
 		return stripInstallable(root, f.version)
 	default:
-		return bumpLibraries(root, f.version)
+		return pinInternalRequires(root, f.version)
 	}
 }
 
@@ -157,21 +157,23 @@ func printInstallableTagPaths(root, version string) error {
 	return nil
 }
 
-// bumpLibraries rewrites internal requires for all publishable library modules.
-func bumpLibraries(root, version string) error {
+// pinInternalRequires pins internal requires for every workspace member (the pin
+// set — a superset of the publishable tag set), so the release `go work sync`
+// finds nothing to rewrite (#2212).
+func pinInternalRequires(root, version string) error {
 	results, err := modrelease.BumpTree(root, version)
 	if err != nil {
 		return err
 	}
-	bumped := 0
+	pinned := 0
 	for _, res := range results {
 		if len(res.Requires) > 0 {
-			bumped++
-			p("bumped %s: %v -> %s\n", res.Dir, res.Requires, version)
+			pinned++
+			p("pinned %s: %v -> %s\n", res.Dir, res.Requires, version)
 		}
 	}
-	p("modrelease: bumped internal requires in %d/%d publishable modules to %s\n",
-		bumped, len(results), version)
+	p("modrelease: pinned internal requires in %d/%d workspace members to %s\n",
+		pinned, len(results), version)
 	return nil
 }
 
@@ -199,7 +201,9 @@ func stripInstallable(root, version string) error {
 }
 
 func preview(root, version string) error {
-	mods, err := modrelease.PublishableModules(root)
+	// Pin set = every workspace member (a superset of the publishable tag set);
+	// --version pins them all so the release `go work sync` is drift-free (#2212).
+	pinMods, err := workspace.Modules(root)
 	if err != nil {
 		return err
 	}
@@ -218,9 +222,9 @@ func preview(root, version string) error {
 	if err != nil {
 		return err
 	}
-	p("modrelease --dry-run: %d publishable modules would bump internal requires to %s\n",
-		len(mods), version)
-	for _, m := range mods {
+	p("modrelease --dry-run: %d workspace members (pin set) would have internal requires pinned to %s "+
+		"(members with no internal require are no-ops):\n", len(pinMods), version)
+	for _, m := range pinMods {
 		p("  %s (%s)\n", m.Dir, m.ImportPath)
 	}
 	p("fresh stable release would push %d tags (bare marker first + %d library):\n", len(stable), len(stable)-1)

--- a/tools/modrelease/cmd/main.go
+++ b/tools/modrelease/cmd/main.go
@@ -7,8 +7,8 @@
 // that the workflow's "Tag modules" step consumes; with --print-installable-tags
 // it emits the installable binary git tags; with --installable it strips
 // replace+pins internal requires in every installable binary module; with
-// --dry-run it previews the set and tags without writing. It is invoked by
-// .github/workflows/release.yml.
+// --dry-run it previews the pin set, stable tags, and installable tags without
+// writing. It is invoked by .github/workflows/release.yml.
 package main
 
 import (
@@ -55,7 +55,7 @@ func parseFlags() (flags, error) {
 	installable := flag.Bool("installable", false,
 		"strip replace+pin internal requires in every installable binary module")
 	dryRun := flag.Bool("dry-run", false,
-		"preview the publishable set and tags without writing go.mod files")
+		"preview the pin set, stable tags, and installable tags without writing go.mod files")
 	flag.Parse()
 
 	if *version == "" {

--- a/tools/modrelease/installable_golden_test.go
+++ b/tools/modrelease/installable_golden_test.go
@@ -209,7 +209,8 @@ func TestInstallableStripTransform01(t *testing.T) {
 //	(a) output has 0 replace lines
 //	(b) every pinned internal require path is in PublishableModules(root)
 //
-// (INSTALLABLE-REQUIRES-PUBLISHABLE-01, Hard).
+// (INSTALLABLE-REQUIRES-PUBLISHABLE-01, Medium — see §Grading above; this is a
+// dynamic runtime scan, not a Hard byte/type freeze).
 func TestInstallableRequiresPublishable01(t *testing.T) {
 	const rule = "INSTALLABLE-REQUIRES-PUBLISHABLE-01"
 

--- a/tools/modrelease/modrelease.go
+++ b/tools/modrelease/modrelease.go
@@ -1,8 +1,21 @@
 // Package modrelease is the synchronized multi-module release tool for the
-// GoCell workspace. It rewrites the internal `require` versions of every
-// publishable LIBRARY module to a single release version and derives the
-// per-module git tag set, so satellites become externally consumable via
+// GoCell workspace. It rewrites the internal `require` versions of the workspace
+// members to a single release version and derives the per-module git tag set, so
+// publishable satellites become externally consumable via
 // `go get <module>@vX.Y.Z`.
+//
+// Two distinct concerns, two distinct member sets (do NOT conflate):
+//
+//   - PIN set ([BumpTree]) — EVERY go.work member with an internal require. The
+//     release pin commit must rewrite them all so the workflow's `go work sync`
+//     (hack/verify-workspace.sh) is a no-op and the pinned tree is drift-free
+//     (#2212). This is a SUPERSET of the tag set: it includes the non-publishable
+//     members (examples/*, cmd/*, tests/* subdirs) that go work sync would
+//     otherwise rewrite to the release version, leaving uncommitted drift.
+//   - TAG set ([PublishableModules]/[TagPaths]/[StableTags]) — only the
+//     externally-published LIBRARY members (see [IsPublishable]) get a
+//     `<reldir>/vX.Y.Z` git tag. A non-publishable member is pinned but never
+//     tagged.
 //
 // # Why
 //
@@ -28,11 +41,14 @@
 // touches require versions only; replace lines carry no version and are never
 // matched.
 //
-// # Scope: library modules only (publishable set) + installable binaries
+// # Scope: pin set (all members) + tag set (publishable) + installable binaries
 //
-// The publishable library set is every go.work member EXCEPT examples/*, tests/*,
-// and cmd/* (see [IsPublishable]). The publishable set is handled by [BumpTree] and
-// [TagPaths] which preserve replace directives (OTel-canonical shape).
+// The pin set is every go.work member ([BumpTree], via workspace.Modules); the
+// tag set is every member EXCEPT examples/*, tests/*, and cmd/* (see
+// [IsPublishable], via [PublishableModules]/[TagPaths]). Both preserve replace
+// directives (OTel-canonical shape) — the version-only rewrite is identical; only
+// the member set differs (pin ⊇ tag). A member with no internal require is a
+// no-op in the pin set (it is iterated but nothing is rewritten).
 //
 // # Installable binaries
 //
@@ -259,10 +275,23 @@ func bumpRequireLine(line []byte, re *regexp.Regexp, version string) ([]byte, st
 	return []byte(string(m[1]) + path + string(m[3]) + version + string(m[5])), path
 }
 
-// BumpTree rewrites the internal require versions of every publishable module
-// under root to version, in place. The platform module prefix is read from
-// root/go.mod (never a hardcoded literal). Returns one Result per publishable
-// module, in go.work order.
+// BumpTree rewrites the internal require versions of every workspace MEMBER
+// under root to version, in place — the PIN set. The platform module prefix is
+// read from root/go.mod (never a hardcoded literal). Returns one Result per
+// member, in go.work order (a member with no internal require yields an empty
+// Result.Requires and is left untouched on disk).
+//
+// The pin set is the full go.work membership (workspace.Modules), a SUPERSET of
+// the publishable tag set ([PublishableModules]): it deliberately includes the
+// non-publishable members (examples/*, cmd/*, tests/* subdirs) so that after the
+// release pin commit the workflow's `go work sync` finds nothing to rewrite and
+// the pinned tree is drift-free. Pinning only the publishable set left those
+// members at v0.0.0, which `go work sync` then rewrote to the release version,
+// producing uncommitted drift that failed the stable release (#2212). The
+// version-only rewrite preserves replace directives (OTel-canonical shape), so a
+// pinned-but-not-tagged member (e.g. cmd/gocell, which the separate
+// [StripReplaceAndPin] installable path tags from its own stripped tree) keeps
+// its develop-branch replaces intact.
 func BumpTree(root, version string) ([]Result, error) {
 	if err := validReleaseVersion(version); err != nil {
 		return nil, err
@@ -271,9 +300,9 @@ func BumpTree(root, version string) ([]Result, error) {
 	if err != nil {
 		return nil, fmt.Errorf("modrelease: read root module path: %w", err)
 	}
-	mods, err := PublishableModules(root)
+	mods, err := workspace.Modules(root)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("modrelease: enumerate workspace: %w", err)
 	}
 	re := internalRequireRE(prefix)
 	results := make([]Result, 0, len(mods))

--- a/tools/modrelease/modrelease.go
+++ b/tools/modrelease/modrelease.go
@@ -23,9 +23,11 @@
 // `require github.com/ghbvf/gocell[/path] v0.0.0` + a local
 // `replace … => ../relative`. `v0.0.0` is an unpublished placeholder: an external
 // consumer's `go get github.com/ghbvf/gocell/adapters/postgres@<tag>` cannot
-// resolve it. The release rewrites every internal require to the real release
-// version (v0.0.0 / pseudo / a prior real version → vX.Y.Z) and tags each module
-// `<reldir>/vX.Y.Z`.
+// resolve it. The release pins every workspace member's internal requires to the
+// real release version (v0.0.0 / pseudo / a prior real version → vX.Y.Z) and tags
+// ONLY the publishable modules `<reldir>/vX.Y.Z` — non-publishable members
+// (examples/*, cmd/*, tests/* subdirs) are pinned but never tagged, per the
+// pin-set ⊇ tag-set split above.
 //
 // # Keep replace (NOT stripped)
 //

--- a/tools/modrelease/modrelease.go
+++ b/tools/modrelease/modrelease.go
@@ -292,6 +292,15 @@ func bumpRequireLine(line []byte, re *regexp.Regexp, version string) ([]byte, st
 // pinned-but-not-tagged member (e.g. cmd/gocell, which the separate
 // [StripReplaceAndPin] installable path tags from its own stripped tree) keeps
 // its develop-branch replaces intact.
+//
+// go.sum is unaffected: every internal require carries a local `replace … =>
+// ../relative`, so the bumped require resolves to the on-disk sibling, not the
+// module proxy — no checksum is computed or recorded for it. The full-member pin
+// therefore leaves BOTH go.mod (require versions already at the release version)
+// and go.sum (no internal sum entries) matching what `go work sync` would write,
+// so the workflow's drift check (hack/verify-workspace.sh diffs go.mod AND
+// go.sum) is clean. The release-verification drift gate empirically confirms
+// this on the real tree.
 func BumpTree(root, version string) ([]Result, error) {
 	if err := validReleaseVersion(version); err != nil {
 		return nil, err

--- a/tools/modrelease/modrelease_test.go
+++ b/tools/modrelease/modrelease_test.go
@@ -259,7 +259,10 @@ func TestBumpTree(t *testing.T) {
 
 	// pin set ⊇ tag set: every publishable (tag-set) member appears in the
 	// pin-set results, so the pin commit can never be a strict subset of the
-	// tagged tree (the #2212 failure mode).
+	// tagged tree (the #2212 failure mode). Both BumpTree results and
+	// PublishableModules derive Dir from the same workspace.Modules enumeration
+	// (go.work use-dirs, filepath.Clean'd — no "./" prefix), so the map lookup
+	// keys align and this comparison is not vacuous.
 	pub, err := PublishableModules(root)
 	if err != nil {
 		t.Fatalf("PublishableModules: %v", err)

--- a/tools/modrelease/modrelease_test.go
+++ b/tools/modrelease/modrelease_test.go
@@ -182,9 +182,19 @@ func TestIsPublishable(t *testing.T) {
 	}
 }
 
-// TestBumpTree exercises the actual release entry: it bumps every PUBLISHABLE
-// member of a synthetic workspace (root + adapters), leaves a denied member
-// (examples/*) untouched, preserves replace, and stamps Result.Dir.
+// TestBumpTree exercises the actual release entry (the PIN set): it rewrites the
+// internal requires of EVERY workspace MEMBER of a synthetic workspace — the
+// publishable libraries AND the non-publishable members that `go work sync`
+// would otherwise rewrite (examples/*, cmd/*, tests/* subdirs) — preserving
+// replace and stamping Result.Dir. The pin set is a SUPERSET of the publishable
+// TAG set ([PublishableModules]/[TagPaths]).
+//
+// #2212: pinning ONLY the publishable set left tests/*, cmd/*, examples/*
+// internal requires at v0.0.0, so the release `Verify pinned tree` step's
+// `go work sync` rewrote them to the release version and `git diff --exit-code`
+// found uncommitted drift, failing the first stable release since #1565. The pin
+// set must cover every member with an internal require so `go work sync` is a
+// no-op after the pin commit.
 func TestBumpTree(t *testing.T) {
 	root := t.TempDir()
 	write := func(rel, content string) {
@@ -198,42 +208,70 @@ func TestBumpTree(t *testing.T) {
 		}
 	}
 	write("go.mod", "module github.com/ghbvf/gocell\n\ngo 1.25\n")
-	write("go.work", "go 1.25\n\nuse (\n\t.\n\t./adapters/a\n\t./adapters/b\n\t./examples/demo\n)\n")
+	// go.work includes the non-publishable members go work sync rewrites:
+	// examples/demo, cmd/foo (a binary), tests/integration (a tests/ subdir).
+	write("go.work", "go 1.25\n\nuse (\n\t.\n\t./adapters/a\n\t./adapters/b\n"+
+		"\t./examples/demo\n\t./cmd/foo\n\t./tests/integration\n)\n")
 	write("adapters/a/go.mod", "module github.com/ghbvf/gocell/adapters/a\n\ngo 1.25\n\n"+
 		"require github.com/ghbvf/gocell v0.0.0\n\nreplace github.com/ghbvf/gocell => ../../\n")
 	write("adapters/b/go.mod", "module github.com/ghbvf/gocell/adapters/b\n\ngo 1.25\n\n"+
 		"require (\n\tgithub.com/ghbvf/gocell v0.0.0\n\tgithub.com/ghbvf/gocell/adapters/a v0.0.0\n)\n")
 	write("examples/demo/go.mod", "module github.com/ghbvf/gocell/examples/demo\n\ngo 1.25\n\n"+
-		"require github.com/ghbvf/gocell v0.0.0\n")
+		"require github.com/ghbvf/gocell v0.0.0\n\nreplace github.com/ghbvf/gocell => ../../\n")
+	write("cmd/foo/go.mod", "module github.com/ghbvf/gocell/cmd/foo\n\ngo 1.25\n\n"+
+		"require github.com/ghbvf/gocell v0.0.0\n\nreplace github.com/ghbvf/gocell => ../../\n")
+	write("tests/integration/go.mod", "module github.com/ghbvf/gocell/tests/integration\n\ngo 1.25\n\n"+
+		"require github.com/ghbvf/gocell/adapters/a v0.0.0\n\n"+
+		"replace github.com/ghbvf/gocell/adapters/a => ../../adapters/a\n")
 
 	results, err := BumpTree(root, testVersion)
 	if err != nil {
 		t.Fatalf("BumpTree: %v", err)
-	}
-	// Publishable = root + adapters/a + adapters/b (examples/demo denied).
-	if len(results) != 3 {
-		t.Fatalf("want 3 publishable results, got %d: %+v", len(results), results)
 	}
 	for _, r := range results {
 		if r.Dir == "" {
 			t.Errorf("Result.Dir not stamped: %+v", r)
 		}
 	}
-	a := mustRead(t, filepath.Join(root, "adapters", "a", "go.mod"))
-	if !strings.Contains(a, "require github.com/ghbvf/gocell v1.2.3") {
-		t.Errorf("adapters/a require not bumped:\n%s", a)
+
+	// Every member with an internal require must be bumped — publishable AND
+	// the non-publishable members go work sync would otherwise drift (#2212).
+	// Each carries a replace that must be preserved.
+	for _, m := range []struct{ dir, replace string }{
+		{"adapters/a", "replace github.com/ghbvf/gocell => ../../"},
+		{"examples/demo", "replace github.com/ghbvf/gocell => ../../"},
+		{"cmd/foo", "replace github.com/ghbvf/gocell => ../../"},
+		{"tests/integration", "replace github.com/ghbvf/gocell/adapters/a => ../../adapters/a"},
+	} {
+		got := mustRead(t, filepath.Join(root, filepath.FromSlash(m.dir), "go.mod"))
+		if strings.Contains(got, "v0.0.0") {
+			t.Errorf("%s internal require not pinned (still v0.0.0) — pin set must cover non-publishable members (#2212):\n%s", m.dir, got)
+		}
+		if !strings.Contains(got, m.replace) {
+			t.Errorf("%s replace must be preserved:\n%s", m.dir, got)
+		}
 	}
-	if !strings.Contains(a, "replace github.com/ghbvf/gocell => ../../") {
-		t.Errorf("adapters/a replace must be preserved:\n%s", a)
-	}
+	// adapters/b has two internal requires; both must bump.
 	b := mustRead(t, filepath.Join(root, "adapters", "b", "go.mod"))
 	if strings.Contains(b, "v0.0.0") {
 		t.Errorf("adapters/b still has v0.0.0 (both internal requires must bump):\n%s", b)
 	}
-	// Denied member is left as-is.
-	demo := mustRead(t, filepath.Join(root, "examples", "demo", "go.mod"))
-	if !strings.Contains(demo, "v0.0.0") {
-		t.Errorf("examples/demo is denied and must be untouched, got:\n%s", demo)
+
+	// pin set ⊇ tag set: every publishable (tag-set) member appears in the
+	// pin-set results, so the pin commit can never be a strict subset of the
+	// tagged tree (the #2212 failure mode).
+	pub, err := PublishableModules(root)
+	if err != nil {
+		t.Fatalf("PublishableModules: %v", err)
+	}
+	resultDirs := make(map[string]bool, len(results))
+	for _, r := range results {
+		resultDirs[r.Dir] = true
+	}
+	for _, m := range pub {
+		if !resultDirs[m.Dir] {
+			t.Errorf("publishable (tag-set) member %q missing from pin-set results — pin must be a superset of tag", m.Dir)
+		}
 	}
 
 	// Invalid version rejected before touching the tree.


### PR DESCRIPTION
## Summary

分离 modrelease 的「pin 集」与「tag 集」：`BumpTree` 把内部 require pin 扩到**全部 workspace 成员**（含 `tests/*`、`cmd/*`、`examples/*`），修复 #1565（framework module 拆分）后首次 stable release 被 `go work sync` drift 阻断的缺口；并附带升级 `goreleaser-action` v6.3.0→v7.2.2。

## Why / 背景

stable release（切 v0.1.1，`workflow_dispatch`）在 `release.yml` 的 **`Verify pinned tree (stable only)`** step 失败（run 27552834614）：`Pin internal requires & commit` 跑 `modrelease.BumpTree` 只 pin **publishable** 成员（`IsPublishable` 排除 `examples/*`、`cmd/*`、`tests/*` 子模块），随后 `hack/verify-workspace.sh` 的 `go work sync` 把**全部**成员的内部 require 同步到发布版本，`git diff --exit-code` 在被漏成员（`tests/integration`、`tests/testutil/pgshare` 等）发现未提交 drift → 阻断（`Tag modules` 及之后全部 skip）。

**根因**：modrelease 把「**tag 集**」（publishable，要打 `<reldir>/vX.Y.Z` tag）与「**pin 集**」（go-work 一致性所需 = 所有有内部 require 的成员）混用 `PublishableModules` 派生。两者本是不同关注点——pin 须覆盖全成员，tag 只覆盖 publishable。

**预期结果**：pin commit 后全成员内部 require 已是发布版本，`go work sync` 成为 no-op、pinned tree 无 drift，v0.1.1 可切版。

## Refs

Closes #2212
ref: open-telemetry/opentelemetry-go-build-tools multimod replaceModVersion

## Risk / 兼容性

- 纯发布工具链 + CI 配置变更，**无 wire/contract 影响、无 migration**。
- `BumpTree` 语义扩大（publishable→全成员）：唯一调用方是 `release.yml` pin step（经 cmd `pinInternalRequires`）。`TagPaths`/`StableTags`/`InstallableBinaries`（tag/installable 集）**不变，golden 不动**。
- `cmd/gocell` 双路径不冲突：develop pin commit **保留 replace**；发布期 `--installable` 的 `StripReplaceAndPin` 在另一棵 throwaway tagging tree **剥离 replace**（正交，不同树）。
- `goreleaser-action` v6→v7 major：`with`（`version: 'v2.16.0'` + `install-only`）在 v7.2.2 仍支持、均 optional；仅 runner node20→node24，CLI v2.16.0 由 install-only 安装、与 action 版本解耦，`.goreleaser.yaml` v2 schema 不受影响。
- **合并后须经授权 re-dispatch v0.1.1** 做端到端最终验证（首次跑通 #1565 后 stable pipeline + #2141 `--print-stable-tags`）。

## 守卫 / 扇出（AI-robust 评级）

- pin 集扩展守卫：`TestBumpTree` 行为回归（**Medium** 快速本地反馈，锁 tests/cmd/examples 被 pin + pin 集 ⊇ tag 集）+ `release.yml` 的 `go work sync` drift 闸 fail-closed（**Hard** 运行期，即暴露 #2212 的那道闸）。**无需新增 golden/archtest**：pin 集 = go.work 成员，已由 `workspace.Modules` 单源，再加 golden 只是重复 go.work。
- package godoc §Scope + `release.yml` pin step 注释同步「pin 集 ⊇ tag 集」概念（L3）。
- ADR 检查：`202606131200-1088` 仅记 `StripReplaceAndPin` 安装路径（#2045），无「bump=publishable」不变式 → 无需 amend。

## Test plan

- [x] `go -C tools build ./...` + `make check-build` 全模块通过
- [x] `go -C tools test ./modrelease/...` 通过（`TestBumpTree` 全成员 pin GREEN；先 RED 提交锁失败模式）
- [x] `golangci-lint run ./modrelease/...` 0 issues
- [x] 端到端 drift 复现+验证：`modrelease --version v0.1.1`（pin 29/30 成员）→ `go work sync` → `git diff --exit-code` **干净**（go.mod + go.sum）
- [x] `hack/verify-workspace.sh` all checks passed；archtest `CI-PINNING-WORKFLOW-DIGEST-01` + `RELEASE-STABLE-MARKER-TAG-01` green
- [ ] 合并后授权 re-dispatch v0.1.1 端到端（首次验证 #2141）
