### PR TITLE
docs(governance): EPIC #1831 PR-8 文档批 — quickstart 对齐 + admin-invariant §3.6 + role 命名 ADR/archtest [#987][#639][#1404]

### DIFF
--- a/docs/architecture/202605101400-adr-admin-invariant.md
+++ b/docs/architecture/202605101400-adr-admin-invariant.md
@@ -180,20 +180,30 @@ destructive Down 由 Go 层 sealed `DestructiveDownPermit`（`adapters/postgres/
 
 **回滚后运维验证**
 
-回滚完成后执行以下 SQL 确认仍存在至少一个 effective admin：
+自 migration 050 起，effective-admin invariant 是 **per-tenant** 的——每个 tenant 至少
+需要一个 active admin，全局计数非零可能掩盖某个 tenant 已无可用 admin 的情况。因此
+回滚验证必须按 tenant 分组，不能依赖全局计数。
+
+回滚完成后，执行以下 SQL 列出「没有 active admin 的 tenant」（结果不为空即为危险集）：
 
 ```sql
-SELECT count(*) FROM role_assignments ra
-  JOIN users u ON u.id = ra.user_id
- WHERE ra.role_id='admin' AND u.status='active';
+SELECT u.tenant_id,
+       count(*) FILTER (WHERE ra.role_id = 'admin' AND u.status = 'active') AS active_admins
+  FROM users u
+  LEFT JOIN role_assignments ra
+    ON ra.tenant_id = u.tenant_id AND ra.user_id = u.id
+ GROUP BY u.tenant_id
+HAVING count(*) FILTER (WHERE ra.role_id = 'admin' AND u.status = 'active') = 0;
 ```
 
-若结果为 0，必须在回滚完成前手动 reactivate 一个 admin，或（若系统从未初始化）经
-`/api/v1/access/setup/admin` 恢复。
+结果中出现的任一 tenant（active_admins = 0）必须为该 tenant reactivate 一个 admin，
+或（该 tenant 从未初始化）经 `/api/v1/access/setup/admin` 恢复。若只需检查单个
+tenant，在 `FROM users u` 后加 `WHERE u.tenant_id = '<target>'` 即可。
 
 **参考**
 
 - `adapters/postgres/migrations/024_effective_admin_invariant.sql`（Up 强化 + Down WARNING）
+- `adapters/postgres/migrations/050_accesscore_tenant_id.sql`（per-tenant invariant 重建）
 - `adapters/postgres/migrations/019_roles.sql`（`last_admin_protected_fn` 弱语义）
 - `adapters/postgres/migrator.go`（`DestructiveDownPermit` sealed 门控）
 - issue #1248（destructive-down permit 设计）；来源 PR #1396（关联 issue #1054 / #740）

--- a/docs/architecture/202605101400-adr-admin-invariant.md
+++ b/docs/architecture/202605101400-adr-admin-invariant.md
@@ -96,7 +96,7 @@ func (g *LastAdminGuard) CheckRemove(ctx context.Context, userID string, hasAdmi
 改用：
 
 - 应用层 `LastAdminGuard.CheckRemove` 在 tx 内执行
-- DB 兜底：`role_assignments` 表上加 `BEFORE DELETE` trigger（行级），当被删行 `role='admin'` 且 `(SELECT COUNT(*) FROM role_assignments WHERE role='admin') = 1` 时 `RAISE EXCEPTION 'last_admin_protected'`；trigger 在 count 前持有 transaction-scoped advisory lock，序列化 direct SQL / cascade delete 并发
+- DB 兜底：`role_assignments` 表上加 `BEFORE DELETE` trigger（行级），当被删行 `role_id='admin'` 且 `(SELECT COUNT(*) FROM role_assignments WHERE role_id='admin') = 1` 时 `RAISE EXCEPTION 'last_admin_protected'`；trigger 在 count 前持有 transaction-scoped advisory lock，序列化 direct SQL / cascade delete 并发
 - trigger 不替代应用层校验（应用层错误码更精准），是 DB 兜底防直连 SQL 误删
 
 > 注：migration 024（S4.0）进一步把本节的 admin 计数收紧为「effective admin = active AND admin role」，其 Up 强化 / Down 弱化语义见 §3.6。
@@ -177,6 +177,19 @@ destructive Down 由 Go 层 sealed `DestructiveDownPermit`（`adapters/postgres/
 `Migrator.Down` 的 `permit` 位置参，唯一构造器 `AllowDestructiveDown`）门控：包外无法伪造，
 非授权调用方无法触达 Down 路径（issue #1248）。migration 024 内的三行 inline WARNING 与本节
 描述同源。
+
+**回滚后运维验证**
+
+回滚完成后执行以下 SQL 确认仍存在至少一个 effective admin：
+
+```sql
+SELECT count(*) FROM role_assignments ra
+  JOIN users u ON u.id = ra.user_id
+ WHERE ra.role_id='admin' AND u.status='active';
+```
+
+若结果为 0，必须在回滚完成前手动 reactivate 一个 admin，或（若系统从未初始化）经
+`/api/v1/access/setup/admin` 恢复。
 
 **参考**
 

--- a/docs/architecture/202605101400-adr-admin-invariant.md
+++ b/docs/architecture/202605101400-adr-admin-invariant.md
@@ -99,6 +99,8 @@ func (g *LastAdminGuard) CheckRemove(ctx context.Context, userID string, hasAdmi
 - DB 兜底：`role_assignments` 表上加 `BEFORE DELETE` trigger（行级），当被删行 `role='admin'` 且 `(SELECT COUNT(*) FROM role_assignments WHERE role='admin') = 1` 时 `RAISE EXCEPTION 'last_admin_protected'`；trigger 在 count 前持有 transaction-scoped advisory lock，序列化 direct SQL / cascade delete 并发
 - trigger 不替代应用层校验（应用层错误码更精准），是 DB 兜底防直连 SQL 误删
 
+> 注：migration 024（S4.0）进一步把本节的 admin 计数收紧为「effective admin = active AND admin role」，其 Up 强化 / Down 弱化语义见 §3.6。
+
 ### 3.3 setup endpoint lifecycle
 
 setup endpoint 形态在 S3+S5 PR 落地，但语义本 ADR 锁定：
@@ -131,6 +133,57 @@ POST /api/v1/access/setup/admin  → 201 if count(admin)==0
 ### 3.5 与 PR262 / typed AuthPlan 的关系
 
 本 ADR 是**纯产品语义决议**，不引入 typed Go primitive（admin 不变量是 cell 业务规则，不是跨 cell 协议）。runtime/auth 不出现 `AdminProtocol` 之类的 sealed type。
+
+### 3.6 Migration 024：S4.0 强化与 Down 弱化语义
+
+**Up 强化（S4.0）**
+
+migration 024（`adapters/postgres/migrations/024_effective_admin_invariant.sql`）把 §3.2
+描述的弱不变量（migration 019：计任何持有 `role_id='admin'` 的 `role_assignments` 行，含
+`users.status='locked'` 或 `'suspended'` 的用户）**收紧**为 S4.0 强不变量：
+
+> **effective admin = `users.status='active'` AND 持有 `role_id='admin'` 的 `role_assignments` 行**
+
+具体机制：
+
+- 在 `role_assignments` 上新建 `BEFORE DELETE` trigger（`effective_admin_invariant_on_role_assignments`）。
+- 在 `users` 上新建 `BEFORE UPDATE OR DELETE` trigger（`effective_admin_invariant_on_users`），
+  捕获 migration 019 触发器完全看不到的 `UPDATE users SET status='locked'` 路径。
+- 两个 trigger 共用单一函数 `effective_admin_invariant_fn()`，持同一 advisory lock key
+  与应用层 CTE 序列化。
+- migration 019 的 `last_admin_protected` trigger 及其函数在 Up 顶部被显式 DROP，
+  不保留兼容 shim（S4.0 彻底不向后兼容原则）。
+
+关闭的 loophole：019 弱计数允许 `DELETE FROM users WHERE id = <active admin>` 在
+`role_assignments` 触发器完全无感知的情况下成功（users 表的 DELETE 只在 024 之后才被守卫），
+从而留下系统中仅有一个 locked/suspended admin、HTTP 恢复路径全部失效的状态。
+
+**Down 弱化（S4.0 hazard 重开）**
+
+024 的 Down 段回滚到 019 的 `last_admin_protected_fn()`：
+
+```
+-- WARNING: rolling back weakens the at-least-one-admin invariant — a locked
+-- admin would once again count as a usable holder, re-opening the S4.0 hazard.
+-- Destructive-down gate is enforced in Go (Migrator.Down + DestructiveDownPermit); see issue #1248.
+```
+
+回滚后，`users` 表上的 trigger 被 DROP，locked/suspended admin 重新计入 admin 持有者总数
+→ **S4.0 hazard 重开**（active admin 可被删除且 locked admin 顶替其位置、系统失去可用 admin）。
+
+**门控**
+
+destructive Down 由 Go 层 sealed `DestructiveDownPermit`（`adapters/postgres/migrator.go` 中
+`Migrator.Down` 的 `permit` 位置参，唯一构造器 `AllowDestructiveDown`）门控：包外无法伪造，
+非授权调用方无法触达 Down 路径（issue #1248）。migration 024 内的三行 inline WARNING 与本节
+描述同源。
+
+**参考**
+
+- `adapters/postgres/migrations/024_effective_admin_invariant.sql`（Up 强化 + Down WARNING）
+- `adapters/postgres/migrations/019_roles.sql`（`last_admin_protected_fn` 弱语义）
+- `adapters/postgres/migrator.go`（`DestructiveDownPermit` sealed 门控）
+- issue #1248（destructive-down permit 设计）；来源 PR #1396（关联 issue #1054 / #740）
 
 ---
 

--- a/docs/architecture/202606151430-639-adr-role-naming-convention.md
+++ b/docs/architecture/202606151430-639-adr-role-naming-convention.md
@@ -45,7 +45,7 @@ GoCell 在 corecells 与 examples 中存在两类 role 字符串常量：
    RoleAdmin = "admin"  // 对齐 framework/runtime/auth.RoleAdmin
    ```
 
-   alias 不引入新含义，只是在本地给平台保留值一个有意义的常量名。
+   alias 不引入新含义，只是在本地给平台保留值一个有意义的常量名。alias 的合法用途仅限把平台保留常量引入本 cell 的常量域（如作 `auth.RequireRole` 入参或常量引用）；禁止用作手写字符串比较的授权分支（由 `PERMISSION-BASED-AUTHZ-01` 覆盖）。
 
 4. **`"role:"` 前缀命名空间与 permission action 命名空间正交**：`framework/pkg/authz/permission.go` 中的 `"role:read"` 是 permission action（动词：读取 role 资源），不是 role 字符串，不受本约定约束。
 

--- a/docs/architecture/202606151430-639-adr-role-naming-convention.md
+++ b/docs/architecture/202606151430-639-adr-role-naming-convention.md
@@ -1,0 +1,84 @@
+# ADR: Role 命名约定（业务 role: 前缀 / 平台裸名）
+
+**Date**: 2026-06-15
+**Status**: Accepted
+**Related ADRs**:
+
+- `docs/architecture/202605101400-adr-admin-invariant.md`（admin 不变量；平台保留 admin 角色的语义来源）
+- `docs/architecture/202606121400-1348-adr-pr10a-authz-wiring.md`（ABAC 授权接线；role 与 permission 的概念隔离）
+
+---
+
+## 1. Context
+
+GoCell 在 corecells 与 examples 中存在两类 role 字符串常量：
+
+1. **平台保留 role**：`"admin"` / `"superadmin"`，定义于 `framework/runtime/auth/roles.go`（`RoleAdmin` / `RoleSuperAdmin`），被 principal → RowScope 派生（admin → tenant、superadmin → all）和 PDP baseline 规则直接消费。
+2. **业务 / 应用 role**：由各 cell 或 example 自定义，例如 `"role:operator"`、`"role:device"`、`"role:customer"`。
+
+在 PR#267 落地时，这条分身约定仅靠 `examples/iotdevice/cells/devicecell/internal/dto/authz.go` 中一条注释（Soft 约定）守卫。没有 ADR 记录决策，没有机器可执行的 enforcement。
+
+此外，`framework/pkg/authz/permission.go` 中存在形如 `"role:read"` 的 permission action 字符串——其前缀形式与业务 role 相同，但语义完全独立（permission action，不是 role）。需要在 ADR 层面明确两者正交，防止歧义。
+
+本 ADR 补录该命名约定并升级 enforcement 为 Medium（archtest `ROLE-PREFIX-NAMESPACED-01`）。
+
+---
+
+## 2. Decision
+
+### 2.1 命名规则
+
+1. **业务 / 应用 role 常量必须带 `"role:"` 前缀**，例如：
+   - `"role:operator"`、`"role:device"`（`examples/iotdevice`）
+   - `"role:customer"`（`examples/todoorder`）
+
+2. **平台保留 role 使用裸名，单源 `framework/runtime/auth/roles.go`**：
+   - `RoleAdmin = "admin"`
+   - `RoleSuperAdmin = "superadmin"`
+
+   这两个值不加 `"role:"` 前缀，以保持与 PDP baseline 规则、JWT claim、RowScope 派生逻辑的一致性。
+
+3. **业务 cell 若需等同于平台保留 role，使用裸值 alias**，例如：
+
+   ```go
+   // examples/iotdevice/cells/devicecell/internal/dto/authz.go
+   RoleAdmin = "admin"  // 对齐 framework/runtime/auth.RoleAdmin
+   ```
+
+   alias 不引入新含义，只是在本地给平台保留值一个有意义的常量名。
+
+4. **`"role:"` 前缀命名空间与 permission action 命名空间正交**：`framework/pkg/authz/permission.go` 中的 `"role:read"` 是 permission action（动词：读取 role 资源），不是 role 字符串，不受本约定约束。
+
+### 2.2 Alternatives Considered
+
+| 方案 | 评价 | 否决理由 |
+|---|---|---|
+| 全裸名（业务 role 不加前缀）| 简洁 | 业务 role 可与 `"admin"` / `"superadmin"` 平台保留名静默碰撞；无命名空间隔离，语义不自文档化 |
+| 全 `"role:"` 含平台（`RoleAdmin = "role:admin"`）| 统一前缀 | 破坏 JWT claim 格式、RowScope 派生判断、PDP baseline 规则中对 `"admin"` 的硬编码匹配；与 `ROLE-ADMIN-LITERAL-01` 的 `roleAdminAllowRels` 冲突，影响 auth.RoleAdmin 单源约束 |
+
+---
+
+## 3. Consequences
+
+### 3.1 Enforcement
+
+本 ADR 对应两条 archtest 规则共同执行：
+
+- **`ROLE-ADMIN-LITERAL-01`**（既有，Medium）：禁止在 `runtime/auth/roles.go` 之外的文件复制定义 `const *Admin* = "admin"` 形式的常量，强制消费方使用 `auth.RoleAdmin` 常量。
+- **`ROLE-PREFIX-NAMESPACED-01`**（新增，Medium）：扫描 `corecells/` + `examples/` 中所有以 `Role` 开头的导出字符串常量，断言其值要么以 `"role:"` 开头，要么属于 sanctioned 平台裸值集合 `{"admin", "superadmin"}`。含 anti-vacuity 与 RED/GREEN synthetic fixture。
+
+评级均为 **Medium**：AST 字面量扫描 + anti-vacuity，符合 AI-robust 治理章程最低门槛。符号、盲区与评级证明见 `tools/archtest/role_prefix_namespaced_test.go` godoc，不在本 ADR 复述。
+
+### 3.2 对 principal → RowScope 派生的影响
+
+principal → RowScope 派生逻辑（admin → tenant、superadmin → all）依赖的是 JWT claim 中 role 字段的**字符串值**，与本约定正交——平台 role 值保持裸名 `"admin"` / `"superadmin"`，派生行为不受影响。
+
+---
+
+## References
+
+- `framework/runtime/auth/roles.go` — 平台保留 role 的权威定义（`RoleAdmin`、`RoleSuperAdmin`）
+- `tools/archtest/role_prefix_namespaced_test.go` — `ROLE-PREFIX-NAMESPACED-01` archtest（符号、盲区、anti-vacuity）
+- `tools/archtest/role_admin_literal_test.go` — `ROLE-ADMIN-LITERAL-01` archtest（admin 裸名复制 ban）
+- `.claude/rules/gocell/tenancy.md` — principal → RowScope 派生规则（admin → tenant、superadmin → all）
+- PR#267 — role 命名约定首次出现（iotdevice authz.go 注释）

--- a/docs/architecture/202606151430-639-adr-role-naming-convention.md
+++ b/docs/architecture/202606151430-639-adr-role-naming-convention.md
@@ -47,6 +47,8 @@ GoCell 在 corecells 与 examples 中存在两类 role 字符串常量：
 
    alias 不引入新含义，只是在本地给平台保留值一个有意义的常量名。alias 的合法用途仅限把平台保留常量引入本 cell 的常量域（如作 `auth.RequireRole` 入参或常量引用）；禁止用作手写字符串比较的授权分支（由 `PERMISSION-BASED-AUTHZ-01` 覆盖）。
 
+   **alias 必须复用 canonical 常量名**：允许的 alias 组合精确为 `RoleAdmin = "admin"` 和 `RoleSuperAdmin = "superadmin"`——常量名与值必须同时匹配。以其它标识符名承载裸平台值（如 `RoleOperator = "admin"`）被 `ROLE-PREFIX-NAMESPACED-01` 判为违规（权限提升守卫）：此类写法让任意业务常量静默获得平台 admin 语义，是 false-negative 提权向量。
+
 4. **`"role:"` 前缀命名空间与 permission action 命名空间正交**：`framework/pkg/authz/permission.go` 中的 `"role:read"` 是 permission action（动词：读取 role 资源），不是 role 字符串，不受本约定约束。
 
 ### 2.2 Alternatives Considered

--- a/docs/ops/local-docker-deploy.md
+++ b/docs/ops/local-docker-deploy.md
@@ -26,7 +26,7 @@ Compose v2 ships bundled with Docker Desktop and with the `docker-compose-plugin
 package on Linux. The `make local-up` target calls `docker compose` (v2 syntax).
 
 
-## Quick Start (5 steps)
+## Quick Start (6 steps)
 
 Run these commands from the repository root in a single terminal. Each step
 takes a few seconds; the whole sequence finishes in under 5 minutes.
@@ -354,7 +354,7 @@ The super-admin cross-tenant audit read capability (`gocell_audit_admin` pool) i
 
    ```bash
    docker compose -f docker-compose.local.yml --env-file .env.local exec corebundle \
-     curl -fsS "http://127.0.0.1:9091/readyz?verbose" | grep audit_admin
+     sh -c 'curl -fsS -H "X-Readyz-Token: $GOCELL_READYZ_VERBOSE_TOKEN" "http://127.0.0.1:9091/readyz?verbose"' | grep audit_admin
    ```
 
    A healthy output contains `"postgres_audit_admin_restricted_ready": "ok"`.

--- a/docs/ops/local-docker-deploy.md
+++ b/docs/ops/local-docker-deploy.md
@@ -108,11 +108,53 @@ A successful response is HTTP 201 and a JSON body containing an RS256-signed
 access token and a refresh token. For example:
 
 ```json
-{"data": {"accessToken": "eyJ...", "refreshToken": "eyJ...", "expiresIn": 900}}
+{
+  "data": {
+    "accessToken": "eyJ...",
+    "refreshToken": "eyJ...",
+    "expiresAt": "2026-06-15T13:15:49Z",
+    "sessionId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "userId": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "passwordResetRequired": false
+  }
+}
 ```
 
 Use the `accessToken` as a `Bearer` token in the `Authorization` header for all
 subsequent calls to `/api/v1/*` endpoints.
+
+### Step 6: Verify the audit hash chain
+
+With the admin Bearer token from step 5 (admin carries the `audit:read` permission),
+query the audit ledger:
+
+```bash
+TOKEN="<paste accessToken here>"
+curl -s -H "Authorization: Bearer $TOKEN" \
+  'http://localhost:8080/api/v1/audit/entries?limit=10' | jq .
+```
+
+Because the admin token carries `audit:read`, omitting `actorId` performs a
+**permissioned ledger-wide read** — the response includes entries from all actors.
+You should see at least two event types produced by the steps above:
+
+- `event.user.created.v1` — published by the `system` actor during `setup/admin` (step 4)
+- `event.session.created.v1` — published when you logged in (step 5)
+
+**`actorId` query parameter semantics:**
+
+- Omit `actorId` — permissioned ledger-wide read; requires `audit:read` permission.
+- `?actorId=<your userId>` — explicit self-read; exempt from the permission gate (the
+  caller is reading their own rows).
+- `?actorId=system` — filters to system-actor events only (setup, migrations, and
+  other platform operations).
+
+To see only system-actor events (useful for verifying what setup/admin wrote):
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  'http://localhost:8080/api/v1/audit/entries?actorId=system&limit=10' | jq .
+```
 
 
 ## Topology

--- a/docs/ops/local-docker-deploy.md
+++ b/docs/ops/local-docker-deploy.md
@@ -44,7 +44,7 @@ cd gocell
 bash scripts/gen-deploy-secrets.sh
 ```
 
-The script generates 13 values in `.env.local` (see §Secrets table for the
+The script generates 14 values in `.env.local` (see §Secrets table for the
 full list). The file is set to `chmod 600` automatically. The script exits
 with code 1 if `.env.local` already exists, so it is safe to run without
 checking first.
@@ -145,9 +145,14 @@ You should see at least two event types produced by the steps above:
 
 - Omit `actorId` — permissioned ledger-wide read; requires `audit:read` permission.
 - `?actorId=<your userId>` — explicit self-read; exempt from the permission gate (the
-  caller is reading their own rows).
+  caller is reading their own rows). Note: this exemption applies only at the routing
+  gate layer; data-layer row visibility is still governed independently by the
+  principal's RowScope (self → only the caller's own rows).
 - `?actorId=system` — filters to system-actor events only (setup, migrations, and
-  other platform operations).
+  other platform operations). Unlike `?actorId=<your userId>`, this does NOT trigger
+  the self-read exemption (the caller's subject is a UUID and can never equal the
+  string `"system"`); the request still requires `audit:read` permission (satisfied
+  here by the admin token).
 
 To see only system-actor events (useful for verifying what setup/admin wrote):
 

--- a/examples/iotdevice/cells/devicecell/internal/dto/authz.go
+++ b/examples/iotdevice/cells/devicecell/internal/dto/authz.go
@@ -7,6 +7,6 @@ const (
 	RoleDevice   = "role:device"
 	// RoleAdmin grants administrative access to the iotdevice cell endpoints.
 	// Value matches the platform-wide admin role (no "role:" prefix), aligned
-	// with corecells/configcore/internal/dto.RoleAdmin.
+	// with framework/runtime/auth.RoleAdmin (the single authoritative definition).
 	RoleAdmin = "admin"
 )

--- a/tools/archtest/internal/roleprefixfixture/fixture.go
+++ b/tools/archtest/internal/roleprefixfixture/fixture.go
@@ -13,9 +13,7 @@
 //   - RoleGood      = "role:operator"  — correctly namespaced business role.
 //   - RoleAdminAlias = "admin"         — sanctioned platform role alias.
 //   - RoleSuperAdmin  = "superadmin"   — sanctioned platform role alias.
-//   - RoleUnrelated   = "something"    — identifier does NOT start with "Role",
-//     so the scanner ignores it entirely (naming-pattern exemption).
-//   - constNoRolePrefix = "bare"       — unexported, does not start with "Role";
+//   - notARole = "bare"               — unexported, does not start with "Role";
 //     ignored by the Role* naming filter.
 package roleprefixfixture
 

--- a/tools/archtest/internal/roleprefixfixture/fixture.go
+++ b/tools/archtest/internal/roleprefixfixture/fixture.go
@@ -1,0 +1,41 @@
+//go:build archtest_fixture
+
+// Package roleprefixfixture is the RED/GREEN fixture for
+// ROLE-PREFIX-NAMESPACED-01. It proves the AST scanner fires on bare-name
+// business role constants and passes through correctly namespaced or
+// sanctioned platform-alias values.
+//
+// RED (must be flagged — exactly 1):
+//   - RoleBad = "operator"  — bare name, not "role:"-prefixed and not a
+//     sanctioned platform value → violation.
+//
+// GREEN (must NOT be flagged):
+//   - RoleGood      = "role:operator"  — correctly namespaced business role.
+//   - RoleAdminAlias = "admin"         — sanctioned platform role alias.
+//   - RoleSuperAdmin  = "superadmin"   — sanctioned platform role alias.
+//   - RoleUnrelated   = "something"    — identifier does NOT start with "Role",
+//     so the scanner ignores it entirely (naming-pattern exemption).
+//   - constNoRolePrefix = "bare"       — unexported, does not start with "Role";
+//     ignored by the Role* naming filter.
+package roleprefixfixture
+
+// --- RED: must be caught by ROLE-PREFIX-NAMESPACED-01 ---
+
+// RoleBad is a business role constant with a bare name that lacks the
+// required "role:" prefix. It is not a sanctioned platform value either.
+const RoleBad = "operator"
+
+// --- GREEN: must NOT be caught ---
+
+// RoleGood is correctly namespaced with the "role:" prefix.
+const RoleGood = "role:operator"
+
+// RoleAdminAlias aliases the platform-reserved admin role (sanctioned bare value).
+const RoleAdminAlias = "admin"
+
+// RoleSuperAdmin aliases the platform-reserved superadmin role (sanctioned bare value).
+const RoleSuperAdmin = "superadmin"
+
+// notARole does NOT start with "Role", so the scanner's naming filter excludes it.
+// Its bare value must not be flagged.
+const notARole = "bare"

--- a/tools/archtest/internal/roleprefixfixture/fixture.go
+++ b/tools/archtest/internal/roleprefixfixture/fixture.go
@@ -15,10 +15,10 @@
 //
 // GREEN (must NOT be flagged):
 //   - RoleGood      = "role:operator"  — correctly namespaced business role.
-//   - RoleAdmin     = "admin"          — canonical alias: name "RoleAdmin" +
-//     value "admin" matches the rolePrefixPlatformAlias entry exactly.
-//   - RoleSuperAdmin = "superadmin"    — canonical alias: name "RoleSuperAdmin"
-//     + value "superadmin" matches the rolePrefixPlatformAlias entry exactly.
+//   - RoleAdmin     = "admin"          — canonical alias: identifier "RoleAdmin"
+//     with value "admin" matches a rolePrefixPlatformAlias entry exactly.
+//   - RoleSuperAdmin = "superadmin"    — canonical alias: identifier "RoleSuperAdmin"
+//     with value "superadmin" matches a rolePrefixPlatformAlias entry exactly.
 //   - notARole = "bare"               — unexported, does not start with "Role";
 //     ignored by the Role* naming filter.
 package roleprefixfixture

--- a/tools/archtest/internal/roleprefixfixture/fixture.go
+++ b/tools/archtest/internal/roleprefixfixture/fixture.go
@@ -5,14 +5,20 @@
 // business role constants and passes through correctly namespaced or
 // sanctioned platform-alias values.
 //
-// RED (must be flagged — exactly 1):
-//   - RoleBad = "operator"  — bare name, not "role:"-prefixed and not a
+// RED (must be flagged — exactly 2):
+//   - RoleBad      = "operator"  — bare name, not "role:"-prefixed and not a
 //     sanctioned platform value → violation.
+//   - RoleOperator = "admin"     — carries a sanctioned bare platform VALUE
+//     but uses a non-canonical identifier name; a business cell writing
+//     RoleOperator = "admin" would silently acquire platform-admin semantics
+//     (privilege escalation false-negative closed by F1 of PR #2214).
 //
 // GREEN (must NOT be flagged):
 //   - RoleGood      = "role:operator"  — correctly namespaced business role.
-//   - RoleAdminAlias = "admin"         — sanctioned platform role alias.
-//   - RoleSuperAdmin  = "superadmin"   — sanctioned platform role alias.
+//   - RoleAdmin     = "admin"          — canonical alias: name "RoleAdmin" +
+//     value "admin" matches the rolePrefixPlatformAlias entry exactly.
+//   - RoleSuperAdmin = "superadmin"    — canonical alias: name "RoleSuperAdmin"
+//     + value "superadmin" matches the rolePrefixPlatformAlias entry exactly.
 //   - notARole = "bare"               — unexported, does not start with "Role";
 //     ignored by the Role* naming filter.
 package roleprefixfixture
@@ -23,15 +29,27 @@ package roleprefixfixture
 // required "role:" prefix. It is not a sanctioned platform value either.
 const RoleBad = "operator"
 
+// RoleOperator carries the sanctioned platform bare value "admin" but under a
+// non-canonical identifier name. Under the old value-only allowlist this was a
+// false-negative (silently passed). Under the name↔value binding introduced by
+// F1, it is correctly flagged: only the canonical name "RoleAdmin" is permitted
+// to carry the value "admin".
+const RoleOperator = "admin"
+
 // --- GREEN: must NOT be caught ---
 
 // RoleGood is correctly namespaced with the "role:" prefix.
 const RoleGood = "role:operator"
 
-// RoleAdminAlias aliases the platform-reserved admin role (sanctioned bare value).
-const RoleAdminAlias = "admin"
+// RoleAdmin aliases the platform-reserved admin role using the canonical
+// identifier name "RoleAdmin" paired with the sanctioned bare value "admin".
+// Both name and value must match the rolePrefixPlatformAlias entry for this
+// to be accepted.
+const RoleAdmin = "admin"
 
-// RoleSuperAdmin aliases the platform-reserved superadmin role (sanctioned bare value).
+// RoleSuperAdmin aliases the platform-reserved superadmin role using the
+// canonical identifier name "RoleSuperAdmin" paired with the sanctioned bare
+// value "superadmin".
 const RoleSuperAdmin = "superadmin"
 
 // notARole does NOT start with "Role", so the scanner's naming filter excludes it.

--- a/tools/archtest/role_prefix_namespaced_test.go
+++ b/tools/archtest/role_prefix_namespaced_test.go
@@ -64,7 +64,8 @@
 //   - The allowlist {"admin", "superadmin"} is manually kept in sync with
 //     framework/runtime/auth/roles.go. ROLE-ADMIN-LITERAL-01 provides indirect
 //     coverage for "admin"; "superadmin" has no separate literal guard (residual
-//     blind spot — tracked in ADR 202606151430-639 §3).
+//     blind spot — this godoc is the authoritative blind-spot record;
+//     ADR 202606151430-639 §3.1 summarizes enforcement).
 //
 // # Anti-vacuity
 //
@@ -112,7 +113,7 @@ const (
 //
 // Blind spot: if roles.go gains a new reserved name it must also be added
 // here; there is no compile-time enforcement of that sync (residual Medium
-// ceiling documented in ADR 202606151430-639 §3).
+// ceiling documented in ADR 202606151430-639 §3.1).
 var rolePrefixPlatformAllowlist = map[string]struct{}{
 	"admin":      {},
 	"superadmin": {},
@@ -208,7 +209,9 @@ func TestRolePrefixNamespaced01(t *testing.T) {
 
 // TestRolePrefixNamespaced01_RedFixture is the negative control: the scanner
 // run against roleprefixfixture must fire on exactly the one RED case
-// (RoleBad = "operator") and leave the four GREEN cases untouched.
+// (RoleBad = "operator") and leave the three GREEN Role* cases (RoleGood /
+// RoleAdminAlias / RoleSuperAdmin) untouched; the non-Role* notARole is
+// ignored by the naming filter.
 func TestRolePrefixNamespaced01_RedFixture(t *testing.T) {
 	t.Parallel()
 

--- a/tools/archtest/role_prefix_namespaced_test.go
+++ b/tools/archtest/role_prefix_namespaced_test.go
@@ -10,12 +10,15 @@
 // domain (corecells/ + examples/) MUST satisfy exactly one of:
 //
 //   - its string value carries the "role:" prefix  (e.g. "role:operator"), OR
-//   - its value is a sanctioned platform-reserved bare name: "admin" or "superadmin"
-//     (a business cell aliasing the platform role defined in
-//     framework/runtime/auth/roles.go).
+//   - it is a canonical platform-alias: the identifier name AND value together
+//     match an entry in rolePrefixPlatformAlias (e.g. name "RoleAdmin" with
+//     value "admin", or name "RoleSuperAdmin" with value "superadmin").
 //
-// A const that fails both tests — a bare name like "operator" with no prefix and
-// not a platform alias — is a violation.
+// A const that fails both tests is a violation.  This includes the privilege-
+// escalation vector: a business cell writing `RoleOperator = "admin"` carries
+// a sanctioned platform value under a non-canonical name, which would silently
+// grant platform-admin semantics.  The name↔value binding closes that false-
+// negative (PR #2214 F1).
 //
 // # Why this rule exists
 //
@@ -61,11 +64,11 @@
 //     the scanner.
 //   - Business role constants defined outside the scan domain (corecells/ +
 //     examples/) — for instance in cellmodules/ or adapters/ — are not covered.
-//   - The allowlist {"admin", "superadmin"} is manually kept in sync with
-//     framework/runtime/auth/roles.go. ROLE-ADMIN-LITERAL-01 provides indirect
-//     coverage for "admin"; "superadmin" has no separate literal guard (residual
-//     blind spot — this godoc is the authoritative blind-spot record;
-//     ADR 202606151430-639 §3.1 summarizes enforcement).
+//   - The alias map {RoleAdmin→"admin", RoleSuperAdmin→"superadmin"} is manually
+//     kept in sync with framework/runtime/auth/roles.go. ROLE-ADMIN-LITERAL-01
+//     provides indirect coverage for "admin"; "superadmin" has no separate literal
+//     guard (residual blind spot — this godoc is the authoritative blind-spot
+//     record; ADR 202606151430-639 §3.1 summarizes enforcement).
 //
 // # Anti-vacuity
 //
@@ -76,7 +79,7 @@
 //   - role:operator  (examples/iotdevice)
 //   - role:device    (examples/iotdevice)
 //   - role:customer  (examples/todoorder)
-//   - admin          (examples/iotdevice, platform alias)
+//   - admin          (examples/iotdevice, canonical alias RoleAdmin)
 //
 // If the scan domain drifts (directory renamed, constants renamed away from the
 // "Role" prefix) and no longer reaches these definitions, the count falls below the
@@ -91,6 +94,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -99,24 +103,85 @@ const (
 	// rolePrefixMinKnownRoles is the anti-vacuity floor: the number of known
 	// business Role* string-literal constants in the scan domain as of
 	// 2026-06-15 (role:operator, role:device, role:customer, plus the
-	// admin alias in iotdevice). Adding new Role* consts to corecells/ or
-	// examples/ will keep the count above this floor; removing / renaming
-	// enough consts to drop below it is the scanner drift signal this guard
-	// is designed to detect.
+	// canonical alias RoleAdmin="admin" in iotdevice). Adding new Role* consts
+	// to corecells/ or examples/ will keep the count above this floor;
+	// removing / renaming enough consts to drop below it is the scanner drift
+	// signal this guard is designed to detect.
 	rolePrefixMinKnownRoles = 4
 )
 
-// rolePrefixPlatformAllowlist is the set of bare role values that a business
-// cell is permitted to use when aliasing a platform-reserved role. These
-// values are sourced from framework/runtime/auth/roles.go (RoleAdmin /
-// RoleSuperAdmin) and kept in sync here manually.
+// rolePrefixPlatformAlias maps the canonical constant identifier name to its
+// sanctioned bare platform value. Only when BOTH name AND value match an entry
+// here is the const accepted as a legitimate platform-role alias.
 //
-// Blind spot: if roles.go gains a new reserved name it must also be added
-// here; there is no compile-time enforcement of that sync (residual Medium
-// ceiling documented in ADR 202606151430-639 §3.1).
-var rolePrefixPlatformAllowlist = map[string]struct{}{
-	"admin":      {},
-	"superadmin": {},
+// This replaces the former value-only rolePrefixPlatformAllowlist (which
+// accepted any identifier named "Role*" carrying "admin", enabling the
+// privilege-escalation false-negative `RoleOperator = "admin"`).
+//
+// Blind spot: if roles.go gains a new reserved name, it must be added here
+// together with its canonical identifier name; there is no compile-time
+// enforcement of that sync (residual Medium ceiling documented in ADR
+// 202606151430-639 §3.1).
+var rolePrefixPlatformAlias = map[string]string{
+	"RoleAdmin":      "admin",
+	"RoleSuperAdmin": "superadmin",
+}
+
+// rolePrefixDiagnostics is the shared scanning core used by both the
+// production test and the RED fixture self-check.  Separating the scan logic
+// from the test runner ensures that the fixture exercises the same code path
+// as production — a previously independent re-implementation in the fixture
+// could pass while the production path was broken (F2, PR #2214).
+//
+// It returns every Diagnostic produced by the scan plus the count of Role*
+// string-literal constants observed (used for anti-vacuity in production).
+func rolePrefixDiagnostics(p *Pass) (diags []Diagnostic, seen int) {
+	for _, f := range p.Files {
+		EachInSubtree[ast.GenDecl](f, func(genDecl *ast.GenDecl) {
+			if genDecl.Tok != token.CONST {
+				return
+			}
+
+			var lastValues []ast.Expr
+			EachInChildren[ast.ValueSpec](genDecl, func(vs *ast.ValueSpec) {
+				values := vs.Values
+				if values == nil {
+					values = lastValues
+				} else {
+					lastValues = values
+				}
+				for i, name := range vs.Names {
+					if !isRoleIdent(name.Name) {
+						continue
+					}
+					if i >= len(values) {
+						continue
+					}
+					lit, ok := values[i].(*ast.BasicLit)
+					if !ok {
+						continue
+					}
+					v, ok := StringLitValue(lit)
+					if !ok {
+						continue
+					}
+					seen++
+					if isValidBusinessRole(name.Name, v) {
+						continue
+					}
+					diags = append(diags, Diagnostic{
+						Rel:  p.Rel(f),
+						Line: p.Fset.Position(name.Pos()).Line,
+						Message: ruleRolePrefixNamespaced01 + `: business role const must be ` +
+							`"role:"-namespaced or use a canonical platform alias ` +
+							`(RoleAdmin="admin" / RoleSuperAdmin="superadmin"); ` +
+							`got ` + name.Name + ` = ` + v,
+					})
+				}
+			})
+		})
+	}
+	return diags, seen
 }
 
 // TestRolePrefixNamespaced01 enforces ROLE-PREFIX-NAMESPACED-01.
@@ -127,7 +192,8 @@ var rolePrefixPlatformAllowlist = map[string]struct{}{
 // constant it asserts:
 //
 //   - strings.HasPrefix(value, "role:"), OR
-//   - value ∈ {"admin", "superadmin"} (sanctioned platform role aliases).
+//   - name AND value together match a rolePrefixPlatformAlias entry
+//     (e.g. name="RoleAdmin", value="admin").
 //
 // Any constant that fails both checks is reported as a violation.
 //
@@ -141,52 +207,9 @@ func TestRolePrefixNamespaced01(t *testing.T) {
 
 	var seenCount int
 	diags := Run(t, AST(scope), func(p *Pass) []Diagnostic {
-		var out []Diagnostic
-		for _, f := range p.Files {
-			EachInSubtree[ast.GenDecl](f, func(genDecl *ast.GenDecl) {
-				if genDecl.Tok != token.CONST {
-					return
-				}
-
-				var lastValues []ast.Expr
-				EachInChildren[ast.ValueSpec](genDecl, func(vs *ast.ValueSpec) {
-					values := vs.Values
-					if values == nil {
-						values = lastValues
-					} else {
-						lastValues = values
-					}
-					for i, name := range vs.Names {
-						if !isRoleIdent(name.Name) {
-							continue
-						}
-						if i >= len(values) {
-							continue
-						}
-						lit, ok := values[i].(*ast.BasicLit)
-						if !ok {
-							continue
-						}
-						v, ok := StringLitValue(lit)
-						if !ok {
-							continue
-						}
-						seenCount++
-						if isValidBusinessRole(v) {
-							continue
-						}
-						out = append(out, Diagnostic{
-							Rel:  p.Rel(f),
-							Line: p.Fset.Position(name.Pos()).Line,
-							Message: ruleRolePrefixNamespaced01 + `: business role const must be ` +
-								`"role:"-namespaced or alias a reserved platform role ` +
-								`(admin/superadmin); got ` + v,
-						})
-					}
-				})
-			})
-		}
-		return out
+		d, s := rolePrefixDiagnostics(p)
+		seenCount += s
+		return d
 	})
 
 	// Anti-vacuity: the scan must have reached enough known Role* consts.
@@ -208,61 +231,38 @@ func TestRolePrefixNamespaced01(t *testing.T) {
 }
 
 // TestRolePrefixNamespaced01_RedFixture is the negative control: the scanner
-// run against roleprefixfixture must fire on exactly the one RED case
-// (RoleBad = "operator") and leave the three GREEN Role* cases (RoleGood /
-// RoleAdminAlias / RoleSuperAdmin) untouched; the non-Role* notARole is
-// ignored by the naming filter.
+// run against roleprefixfixture must fire on exactly the two RED cases
+// (RoleBad = "operator" and RoleOperator = "admin") and leave the three GREEN
+// Role* cases (RoleGood / RoleAdmin / RoleSuperAdmin) untouched; the non-Role*
+// notARole is ignored by the naming filter.
+//
+// The fixture is scanned via the shared rolePrefixDiagnostics function (same
+// code path as production) — not via an independent re-implementation — so a
+// regression in the production path is also caught here (F2, PR #2214).
 func TestRolePrefixNamespaced01_RedFixture(t *testing.T) {
 	t.Parallel()
 
 	fixturePkg := "./tools/archtest/internal/roleprefixfixture"
 
-	var found int
+	var allDiags []Diagnostic
 	_ = Run(t, Fixture(FixtureOpts{Tests: false}, []string{fixturePkg}),
 		func(p *Pass) []Diagnostic {
-			for _, f := range p.Files {
-				EachInSubtree[ast.GenDecl](f, func(genDecl *ast.GenDecl) {
-					if genDecl.Tok != token.CONST {
-						return
-					}
-					var lastValues []ast.Expr
-					EachInChildren[ast.ValueSpec](genDecl, func(vs *ast.ValueSpec) {
-						values := vs.Values
-						if values == nil {
-							values = lastValues
-						} else {
-							lastValues = values
-						}
-						for i, name := range vs.Names {
-							if !isRoleIdent(name.Name) {
-								continue
-							}
-							if i >= len(values) {
-								continue
-							}
-							lit, ok := values[i].(*ast.BasicLit)
-							if !ok {
-								continue
-							}
-							v, ok := StringLitValue(lit)
-							if !ok {
-								continue
-							}
-							if !isValidBusinessRole(v) {
-								found++
-							}
-						}
-					})
-				})
-			}
+			d, _ := rolePrefixDiagnostics(p)
+			allDiags = append(allDiags, d...)
 			return nil
 		})
 
-	assert.Equal(t, 1, found,
-		"ROLE-PREFIX-NAMESPACED-01 RED fixture self-check FAILED: expected exactly 1 "+
-			"violation (RoleBad = \"operator\"). Got %d — "+
-			"found<1 means the scanner missed the bare-name RED case; "+
-			"found>1 means it over-matched a GREEN case (role:-prefixed or platform alias).", found)
+	require.Len(t, allDiags, 2,
+		"ROLE-PREFIX-NAMESPACED-01 RED fixture self-check FAILED: expected exactly 2 "+
+			"violations (RoleBad=\"operator\" and RoleOperator=\"admin\"). Got %d — "+
+			"<2 means the scanner missed a RED case; >2 means it over-matched a GREEN case.",
+		len(allDiags))
+
+	// Verify each diagnostic targets the expected constant.
+	assert.Contains(t, allDiags[0].Message+allDiags[1].Message, "RoleBad",
+		"expected one diagnostic to mention RoleBad")
+	assert.Contains(t, allDiags[0].Message+allDiags[1].Message, "RoleOperator",
+		"expected one diagnostic to mention RoleOperator")
 }
 
 // isRoleIdent reports whether name is an exported identifier that starts
@@ -272,12 +272,20 @@ func isRoleIdent(name string) bool {
 	return strings.HasPrefix(name, "Role")
 }
 
-// isValidBusinessRole reports whether v satisfies the naming convention:
-// either a "role:"-prefixed business role, or a sanctioned platform bare name.
-func isValidBusinessRole(v string) bool {
-	if strings.HasPrefix(v, "role:") {
+// isValidBusinessRole reports whether the constant with the given identifier
+// name and string value satisfies the naming convention:
+//
+//   - the value carries a "role:" prefix (business role), OR
+//   - name AND value together match a canonical platform-alias entry in
+//     rolePrefixPlatformAlias (e.g. name="RoleAdmin", value="admin").
+//
+// The second condition binds both name and value, preventing the privilege-
+// escalation false-negative where any arbitrary name (e.g. "RoleOperator")
+// could carry a sanctioned platform value ("admin") and be silently accepted.
+func isValidBusinessRole(name, value string) bool {
+	if strings.HasPrefix(value, "role:") {
 		return true
 	}
-	_, ok := rolePrefixPlatformAllowlist[v]
-	return ok
+	want, ok := rolePrefixPlatformAlias[name]
+	return ok && want == value
 }

--- a/tools/archtest/role_prefix_namespaced_test.go
+++ b/tools/archtest/role_prefix_namespaced_test.go
@@ -1,0 +1,280 @@
+//go:build archtest
+
+// INVARIANT: ROLE-PREFIX-NAMESPACED-01
+//
+// archtest: ROLE-PREFIX-NAMESPACED-01
+//
+// # ROLE-PREFIX-NAMESPACED-01 (Medium)
+//
+// Every exported const whose name starts with "Role" in the business / application
+// domain (corecells/ + examples/) MUST satisfy exactly one of:
+//
+//   - its string value carries the "role:" prefix  (e.g. "role:operator"), OR
+//   - its value is a sanctioned platform-reserved bare name: "admin" or "superadmin"
+//     (a business cell aliasing the platform role defined in
+//     framework/runtime/auth/roles.go).
+//
+// A const that fails both tests — a bare name like "operator" with no prefix and
+// not a platform alias — is a violation.
+//
+// # Why this rule exists
+//
+// GoCell has two disjoint role namespaces:
+//
+//   - Platform-reserved roles — "admin" / "superadmin" — defined once in
+//     framework/runtime/auth/roles.go and kept intentionally bare (no prefix).
+//     The ROLE-ADMIN-LITERAL-01 rule governs them separately; they are authoritative
+//     and immutable from the perspective of business cells.
+//
+//   - Business / application roles — defined inside individual cells and examples —
+//     must carry the "role:" prefix to avoid silent collision with the platform
+//     reserved names and to make role semantics self-documenting at the wire layer.
+//
+// Before this rule, the only guard was a comment in
+// examples/iotdevice/cells/devicecell/internal/dto/authz.go (a Soft guard per
+// ADR 202606151430-639). This rule upgrades the enforcement to Medium (AST-level
+// scan with anti-vacuity + RED fixture), aligned with AI-robust governance charter
+// (.claude/rules/gocell/ai-robust.md).
+//
+// # Scan domain
+//
+// The scan covers corecells/ (platform cell implementations) and examples/ (example
+// cells). The framework/runtime/auth/roles.go authoritative definition file is
+// intentionally excluded from the scan domain: it is the definition site for the
+// bare platform roles, not a location where convention drift can occur.
+//
+// # AI-robust rating — Medium (AST literal-scan ceiling)
+//
+// A Hard guard would require a type-system-enforced funnel (e.g. a sealed Role
+// type preventing bare construction). As of ADR 202606151430-639 that Hard path is
+// not pursued: the cost of wrapping every role constant in a typed constructor
+// exceeds the benefit at pre-GA scale, and the AST scanner catches the realistic
+// drift vector (a developer writing a new bare-name const). This is a sanctioned
+// Medium standing on its own merits, not a proxy for a reachable Hard guard.
+//
+// # Blind spots (charter §"强制盲区自检")
+//
+//   - Runtime-assembled role strings (fmt.Sprintf, concatenation) are not Go
+//     compile-time constants and escape the literal scanner.
+//   - Role constants whose name does NOT start with "Role" (e.g. "adminRole" or
+//     an unexported "roleAdmin") are not matched by the naming pattern and escape
+//     the scanner.
+//   - Business role constants defined outside the scan domain (corecells/ +
+//     examples/) — for instance in cellmodules/ or adapters/ — are not covered.
+//   - The allowlist {"admin", "superadmin"} is manually kept in sync with
+//     framework/runtime/auth/roles.go. ROLE-ADMIN-LITERAL-01 provides indirect
+//     coverage for "admin"; "superadmin" has no separate literal guard (residual
+//     blind spot — tracked in ADR 202606151430-639 §3).
+//
+// # Anti-vacuity
+//
+// The production scan MUST observe at least [rolePrefixMinKnownRoles] Role*
+// string-literal constants to pass. This threshold equals the count of known
+// business Role* consts at rule-creation time (2026-06-15):
+//
+//   - role:operator  (examples/iotdevice)
+//   - role:device    (examples/iotdevice)
+//   - role:customer  (examples/todoorder)
+//   - admin          (examples/iotdevice, platform alias)
+//
+// If the scan domain drifts (directory renamed, constants renamed away from the
+// "Role" prefix) and no longer reaches these definitions, the count falls below the
+// threshold and the test fails loud instead of passing vacuously green.
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	ruleRolePrefixNamespaced01 = "ROLE-PREFIX-NAMESPACED-01"
+
+	// rolePrefixMinKnownRoles is the anti-vacuity floor: the number of known
+	// business Role* string-literal constants in the scan domain as of
+	// 2026-06-15 (role:operator, role:device, role:customer, plus the
+	// admin alias in iotdevice). Adding new Role* consts to corecells/ or
+	// examples/ will keep the count above this floor; removing / renaming
+	// enough consts to drop below it is the scanner drift signal this guard
+	// is designed to detect.
+	rolePrefixMinKnownRoles = 4
+)
+
+// rolePrefixPlatformAllowlist is the set of bare role values that a business
+// cell is permitted to use when aliasing a platform-reserved role. These
+// values are sourced from framework/runtime/auth/roles.go (RoleAdmin /
+// RoleSuperAdmin) and kept in sync here manually.
+//
+// Blind spot: if roles.go gains a new reserved name it must also be added
+// here; there is no compile-time enforcement of that sync (residual Medium
+// ceiling documented in ADR 202606151430-639 §3).
+var rolePrefixPlatformAllowlist = map[string]struct{}{
+	"admin":      {},
+	"superadmin": {},
+}
+
+// TestRolePrefixNamespaced01 enforces ROLE-PREFIX-NAMESPACED-01.
+//
+// It walks production .go files under corecells/ and examples/, scanning
+// top-level const declarations for any exported identifier whose name
+// starts with "Role" and whose value is a string literal. For each such
+// constant it asserts:
+//
+//   - strings.HasPrefix(value, "role:"), OR
+//   - value ∈ {"admin", "superadmin"} (sanctioned platform role aliases).
+//
+// Any constant that fails both checks is reported as a violation.
+//
+// The anti-vacuity guard below asserts that ≥ [rolePrefixMinKnownRoles]
+// Role* string-literal constants were seen during the scan.
+func TestRolePrefixNamespaced01(t *testing.T) {
+	t.Parallel()
+
+	root := findModuleRoot(t)
+	scope := DirsScope(root, platformAndExampleCellScanDirs())
+
+	var seenCount int
+	diags := Run(t, AST(scope), func(p *Pass) []Diagnostic {
+		var out []Diagnostic
+		for _, f := range p.Files {
+			EachInSubtree[ast.GenDecl](f, func(genDecl *ast.GenDecl) {
+				if genDecl.Tok != token.CONST {
+					return
+				}
+
+				var lastValues []ast.Expr
+				EachInChildren[ast.ValueSpec](genDecl, func(vs *ast.ValueSpec) {
+					values := vs.Values
+					if values == nil {
+						values = lastValues
+					} else {
+						lastValues = values
+					}
+					for i, name := range vs.Names {
+						if !isRoleIdent(name.Name) {
+							continue
+						}
+						if i >= len(values) {
+							continue
+						}
+						lit, ok := values[i].(*ast.BasicLit)
+						if !ok {
+							continue
+						}
+						v, ok := StringLitValue(lit)
+						if !ok {
+							continue
+						}
+						seenCount++
+						if isValidBusinessRole(v) {
+							continue
+						}
+						out = append(out, Diagnostic{
+							Rel:  p.Rel(f),
+							Line: p.Fset.Position(name.Pos()).Line,
+							Message: ruleRolePrefixNamespaced01 + `: business role const must be ` +
+								`"role:"-namespaced or alias a reserved platform role ` +
+								`(admin/superadmin); got ` + v,
+						})
+					}
+				})
+			})
+		}
+		return out
+	})
+
+	// Anti-vacuity: the scan must have reached enough known Role* consts.
+	// A count of 0 (or below floor) means the scan domain or naming pattern
+	// drifted and the rule is silently vacuous.
+	if seenCount < rolePrefixMinKnownRoles {
+		diags = append(diags, Diagnostic{
+			Message: fmt.Sprintf(
+				"%s anti-vacuity: only %d Role* string-literal const(s) observed in "+
+					"corecells/ + examples/ — expected at least %d. "+
+					"The scan domain or Role* naming pattern may have drifted "+
+					"(directories renamed, consts renamed away from the 'Role' prefix).",
+				ruleRolePrefixNamespaced01, seenCount, rolePrefixMinKnownRoles,
+			),
+		})
+	}
+
+	Report(t, ruleRolePrefixNamespaced01, diags)
+}
+
+// TestRolePrefixNamespaced01_RedFixture is the negative control: the scanner
+// run against roleprefixfixture must fire on exactly the one RED case
+// (RoleBad = "operator") and leave the four GREEN cases untouched.
+func TestRolePrefixNamespaced01_RedFixture(t *testing.T) {
+	t.Parallel()
+
+	fixturePkg := "./tools/archtest/internal/roleprefixfixture"
+
+	var found int
+	_ = Run(t, Fixture(FixtureOpts{Tests: false}, []string{fixturePkg}),
+		func(p *Pass) []Diagnostic {
+			for _, f := range p.Files {
+				EachInSubtree[ast.GenDecl](f, func(genDecl *ast.GenDecl) {
+					if genDecl.Tok != token.CONST {
+						return
+					}
+					var lastValues []ast.Expr
+					EachInChildren[ast.ValueSpec](genDecl, func(vs *ast.ValueSpec) {
+						values := vs.Values
+						if values == nil {
+							values = lastValues
+						} else {
+							lastValues = values
+						}
+						for i, name := range vs.Names {
+							if !isRoleIdent(name.Name) {
+								continue
+							}
+							if i >= len(values) {
+								continue
+							}
+							lit, ok := values[i].(*ast.BasicLit)
+							if !ok {
+								continue
+							}
+							v, ok := StringLitValue(lit)
+							if !ok {
+								continue
+							}
+							if !isValidBusinessRole(v) {
+								found++
+							}
+						}
+					})
+				})
+			}
+			return nil
+		})
+
+	assert.Equal(t, 1, found,
+		"ROLE-PREFIX-NAMESPACED-01 RED fixture self-check FAILED: expected exactly 1 "+
+			"violation (RoleBad = \"operator\"). Got %d — "+
+			"found<1 means the scanner missed the bare-name RED case; "+
+			"found>1 means it over-matched a GREEN case (role:-prefixed or platform alias).", found)
+}
+
+// isRoleIdent reports whether name is an exported identifier that starts
+// with "Role". The scan only flags identifiers that match this pattern;
+// role constants with non-"Role" names are a documented blind spot.
+func isRoleIdent(name string) bool {
+	return strings.HasPrefix(name, "Role")
+}
+
+// isValidBusinessRole reports whether v satisfies the naming convention:
+// either a "role:"-prefixed business role, or a sanctioned platform bare name.
+func isValidBusinessRole(v string) bool {
+	if strings.HasPrefix(v, "role:") {
+		return true
+	}
+	_, ok := rolePrefixPlatformAllowlist[v]
+	return ok
+}


### PR DESCRIPTION
## Summary

EPIC #1831 PR-8（docs / ADR / governance 文档批）：修正本地部署 quickstart、补 admin-invariant ADR 的 migration 024 注记、新增 role 命名约定 ADR 并以 Medium archtest 闭环强制业务 role 的 `role:` 前缀。

## Why / 背景

PR-8 是 epic #1831「Cx1 backlog 聚合清理」第 8 批，聚焦 docs/ADR/governance 文档尾项。原列 5 个 Cx1 issue，经探索 + 原则自审（彻底 / 不向后兼容 / 优雅简洁 / AI-HARD）收敛为 **3 个实施 + 2 个 issue 管理**：

| # | 动作 | 内容 |
|---|------|------|
| #987 | 实施 | `docs/ops/local-docker-deploy.md`：Step 5 登录响应示例对齐 contract（`expiresIn`→6 字段完整 shape）；新增 Step 6 验证 audit chain（按**现行** handler 行为写——空 `actorId`=permissioned ledger-wide read，admin 默认能看到 `user.created`，纠正 issue 已漂移的 self-access 旧叙述） |
| #1404 | 实施 | admin-invariant ADR 新增 §3.6 + §3.2 cross-ref：记录 migration 024 把 §3.2 弱不变量收紧为 S4.0 强不变量（effective admin = active AND admin role），及其 Down 段回滚弱化语义 + sealed `DestructiveDownPermit` 门控（#1248） |
| #639 | 实施（ADR+archtest 闭环） | 新增 role 命名约定 ADR；新增 Medium archtest `ROLE-PREFIX-NAMESPACED-01` 强制业务 role 带 `role:` 前缀（allowlist 平台裸值 `admin`/`superadmin`）；修 iotdevice authz.go 一处 stale 注释 |
| #774 | **关闭 not-planned** | ADR 索引：手维护即漂移、116 条 pre-GA 价值低 → 关闭（带外） |
| #767 | **挂起/defer** | fixtures 决策：依赖 #967 run-journey CLI，暂不实现 → 挂起（带外） |

> **#639 纠偏**：初次探索误读 iotdevice 注释为「全局无前缀」。实测相反——业务 role（`role:operator`/`role:device`/`role:customer`）带 `role:` 前缀、平台 role（`admin`/`superadmin`）裸名，今仅靠一条注释（Soft）守。已与维护者重新对齐：enforcement 方向是**强制**业务前缀，非禁止前缀。

## Refs

- Closes #987
- Closes #639
- Closes #1404
- Part of #1831（EPIC PR-8）
- 带外：#774 关闭 not-planned、#767 挂起 defer（见各 issue 评论）
- ADR 风格 ref: `docs/architecture/202605101400-adr-admin-invariant.md`

## Risk / 兼容性

- **低风险**：3 处文档 + 1 个新 archtest + 1 行注释；无 wire/contract/migration 改动（#987 是把文档对齐既有 contract，非改 contract）。
- 新增 archtest `ROLE-PREFIX-NAMESPACED-01`（Medium，AST 扫描 + anti-vacuity + RED fixture）：生产扫描现状全绿（operator/device/customer 带前缀、admin alias allowlisted）。盲区见该 archtest godoc。
- **维护者注意**：#1404 改动**未动 ADR Status**（仍 `Proposed`）——§4 的 S4 项标 TBD，Status 可能为有意保留；是否转 Accepted 留维护者裁定。

## Test plan

- [x] `go -C examples/iotdevice build ./...` + `go -C tools build -tags=archtest ./...` 通过（workspace 无 root module，按模块构建）
- [x] `go -C tools test -tags=archtest -run RolePrefixNamespaced ./tools/archtest/` 通过（生产绿 + RED fixture 命中 + anti-vacuity）
- [x] `golangci-lint run`（CI-faithful：tools 带 `--build-tags=archtest,releasesmoke`、`--new-from-merge-base=origin/develop`）→ tools + examples/iotdevice 均 **0 issues**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
