### PR TITLE
feat(topology): phase0 broker 闸 sealed EventTransportKind 替换 storage/nil 代理 [#2211]

### DIFF
--- a/cellmodules/eventtransport/doc.go
+++ b/cellmodules/eventtransport/doc.go
@@ -25,6 +25,25 @@
 // configured: a missing GOCELL_AMQP_URL is a startup error, never a silent
 // degrade back to in-memory.
 //
+// # INVARIANT: EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01
+//
+// Resolve stamps each [Transport] with a sealed [runtime/bootstrap.EventTransportKind]
+// (Transport.Kind): RealBrokerEventTransport() on the postgres → RabbitMQ branch,
+// InMemoryEventTransport() on the demo branch. This package is the SINGLE
+// sanctioned minter of the real-broker variant — the composition root threads
+// Transport.Kind into bootstrap.WithEventTransportKind so the phase0
+// broker-mandatory gate (validateSplitTopologyBroker) trusts a type-system fact
+// instead of the older StorageBackend()=="postgres" proxy ("non-nil ≠ real
+// broker" closed, #2211). bootstrap (framework module) must export the
+// constructor for this package (root module) to call it, and a
+// framework/.../internal/ package cannot bridge that cross-module import, so the
+// caller restriction is a structural Medium ceiling enforced by archtest
+// EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01 (a call-level AST scan, same family as the
+// RowScopeAll minter and COMMAND-ASYNC-EMIT-CALLER-01). The production end-to-end
+// guarantee remains Hard via COREBUNDLE-EVENTBUS-FUNNEL-01 above: an in-memory bus
+// is import-unexpressible in the production roots, so a forged real-broker kind
+// cannot be paired with one there.
+//
 // # Broker connection is intentionally assembly-level (not per-cell)
 //
 // The broker (RabbitMQ, GOCELL_AMQP_URL) is the cross-cell event bus: its

--- a/cellmodules/eventtransport/doc.go
+++ b/cellmodules/eventtransport/doc.go
@@ -25,6 +25,24 @@
 // configured: a missing GOCELL_AMQP_URL is a startup error, never a silent
 // degrade back to in-memory.
 //
+// # Composition-root usage
+//
+// A composition root resolves the transport once and threads its three outputs
+// into bootstrap:
+//
+//	transport, err := eventtransport.Resolve(clk, topo, eventtransport.Config{AMQPURL: os.Getenv("GOCELL_AMQP_URL")})
+//	// ... handle err ...
+//	opts := []bootstrap.Option{
+//	    bootstrap.WithPublisher(transport.Publisher),
+//	    bootstrap.WithSubscriber(transport.Subscriber),
+//	    bootstrap.WithEventTransportKind(transport.Kind), // sealed broker-kind for the phase0 split gate (#2211)
+//	}
+//	for _, mr := range transport.Resources { // broker connection (postgres mode) for LIFO teardown
+//	    opts = append(opts, bootstrap.WithManagedResource(mr))
+//	}
+//
+// See cmd/corebundle and examples/ssobff for the two production wirings.
+//
 // # INVARIANT: EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01
 //
 // Resolve stamps each [Transport] with a sealed [runtime/bootstrap.EventTransportKind]

--- a/cellmodules/eventtransport/transport.go
+++ b/cellmodules/eventtransport/transport.go
@@ -37,7 +37,11 @@ const dlxExchange = "gocell.events.dlx"
 // real-broker variant (EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01); the composition
 // root threads Kind into bootstrap.WithEventTransportKind so the phase0
 // broker-mandatory gate trusts a type-system fact instead of a StorageBackend
-// proxy (#2211).
+// proxy (#2211). Kind is intentionally NOT promoted to composition.SharedDeps
+// (unlike Publisher/Subscriber): it is a wiring-time fact consumed only by the
+// bootstrap startup gate — cell modules and the shared-dep layer never inspect
+// it — so it stays a composition-root-local value (cmdLocals / the ssobff infra
+// struct), threaded directly into the bootstrap option.
 type Transport struct {
 	Publisher  outbox.Publisher
 	Subscriber outbox.Subscriber

--- a/cellmodules/eventtransport/transport.go
+++ b/cellmodules/eventtransport/transport.go
@@ -30,10 +30,19 @@ const dlxExchange = "gocell.events.dlx"
 // real broker's publisher/subscriber backed by one shared connection, and
 // Resources holds that connection (a lifecycle.ManagedResource) so bootstrap can
 // close it during shutdown.
+//
+// Kind is the sealed bootstrap.EventTransportKind fact stating whether the
+// resolved transport is a real cross-process broker (postgres → RabbitMQ) or an
+// in-process bus (demo). This package is the SINGLE sanctioned minter of the
+// real-broker variant (EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01); the composition
+// root threads Kind into bootstrap.WithEventTransportKind so the phase0
+// broker-mandatory gate trusts a type-system fact instead of a StorageBackend
+// proxy (#2211).
 type Transport struct {
 	Publisher  outbox.Publisher
 	Subscriber outbox.Subscriber
 	Resources  []lifecycle.ManagedResource
+	Kind       bootstrap.EventTransportKind
 }
 
 // Config carries the composition-root-read configuration for the transport. The
@@ -116,7 +125,7 @@ func dispatchTransport(clk clock.Clock, spec brokerSpec, cfg Config) (Transport,
 	switch spec.kind {
 	case brokerInMemory:
 		eb := eventbus.New(clk)
-		return Transport{Publisher: eb, Subscriber: eb}, nil
+		return Transport{Publisher: eb, Subscriber: eb, Kind: bootstrap.InMemoryEventTransport()}, nil
 	case brokerRabbitMQ:
 		return resolveRabbitMQ(clk, spec, cfg)
 	default:
@@ -148,5 +157,8 @@ func resolveRabbitMQ(clk clock.Clock, spec brokerSpec, cfg Config) (Transport, e
 		// timeouts) keep their adapter defaults.
 		Subscriber: rabbitmq.NewSubscriber(clk, conn, rabbitmq.SubscriberConfig{DLXExchange: dlxExchange}),
 		Resources:  []lifecycle.ManagedResource{conn},
+		// Sole sanctioned mint of the real-broker kind (EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01):
+		// only reached on the postgres → RabbitMQ branch.
+		Kind: bootstrap.RealBrokerEventTransport(),
 	}, nil
 }

--- a/cellmodules/eventtransport/transport_test.go
+++ b/cellmodules/eventtransport/transport_test.go
@@ -141,6 +141,31 @@ func TestResolve_Postgres_RabbitMQ_BundlesConnAsResource(t *testing.T) {
 	require.NoError(t, tr.Resources[0].Close(context.Background()))
 }
 
+// TestResolve_TransportKind verifies Resolve stamps the sealed
+// bootstrap.EventTransportKind that the phase0 broker-mandatory gate trusts
+// (#2211): demo/memory → not a real broker; postgres rabbitmq → real broker.
+// This sealed fact is what replaces the gate's StorageBackend()=="postgres"
+// proxy — the eventtransport resolver is the single sanctioned minter of the
+// real-broker variant (EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01).
+func TestResolve_TransportKind(t *testing.T) {
+	t.Parallel()
+
+	demo, err := Resolve(clock.Real(), mkTopo(t, "memory"), Config{})
+	require.NoError(t, err)
+	assert.False(t, demo.Kind.IsRealBroker(),
+		"demo/memory transport must not report a real broker (in-process bus)")
+
+	pg, err := Resolve(
+		clock.Real(),
+		mkTopo(t, "postgres"),
+		Config{AMQPURL: "amqp://localhost:5672/", connOpts: []rabbitmq.ConnectionOption{rabbitmq.WithDialFunc(okDial)}},
+	)
+	require.NoError(t, err)
+	assert.True(t, pg.Kind.IsRealBroker(),
+		"postgres rabbitmq transport must report a real broker")
+	require.NoError(t, pg.Resources[0].Close(context.Background()))
+}
+
 func TestDLXExchange_StableName(t *testing.T) {
 	t.Parallel()
 	// The DLX exchange name is an operations contract (broker topology); pin it so

--- a/cmd/corebundle/bundle_options.go
+++ b/cmd/corebundle/bundle_options.go
@@ -51,6 +51,9 @@ func runtimeBaseOptions(
 		bootstrap.WithAssembly(asm),
 		bootstrap.WithPublisher(shared.Publisher),
 		bootstrap.WithSubscriber(shared.Subscriber),
+		// Sealed broker-kind fact (from eventtransport.Resolve via cmdLocals): the
+		// phase0 split-topology gate requires a real broker, not an in-process bus (#2211).
+		bootstrap.WithEventTransportKind(locals.eventTransportKind),
 		// ConsumerBase is field-injected into SubscriberWithMiddleware (not a
 		// middleware list entry). It is the explicit EntryHandler→SubscriberHandler
 		// conversion boundary: idempotency Claim/Commit/Release + retry live here,

--- a/cmd/corebundle/cmd_locals.go
+++ b/cmd/corebundle/cmd_locals.go
@@ -8,6 +8,7 @@ import (
 	promadapter "github.com/ghbvf/gocell/adapters/prometheus"
 	adapterredis "github.com/ghbvf/gocell/adapters/redis"
 	kernellifecycle "github.com/ghbvf/gocell/framework/kernel/lifecycle"
+	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
 )
 
 // cmdLocals holds cmd-private wiring that is NOT on composition.SharedDeps —
@@ -44,6 +45,14 @@ type cmdLocals struct {
 	// consumer that publishes/subscribes through the broker drain (registered later
 	// via cell opts → close first), and before the PG pool closes (#1940).
 	brokerResources []kernellifecycle.ManagedResource
+
+	// eventTransportKind is the sealed broker-kind fact resolved by
+	// eventtransport.Resolve (real broker in postgres mode, in-memory in demo).
+	// runtimeBaseOptions threads it into bootstrap.WithEventTransportKind so the
+	// phase0 split-topology broker gate trusts a type-system fact rather than a
+	// StorageBackend proxy (#2211). It is transport-derived like brokerResources,
+	// so it lives here beside it rather than on composition.SharedDeps.
+	eventTransportKind bootstrap.EventTransportKind
 
 	// metricsHandler is the Prometheus HTTP handler.
 	metricsHandler http.Handler

--- a/cmd/corebundle/shared_deps.go
+++ b/cmd/corebundle/shared_deps.go
@@ -120,6 +120,9 @@ func LoadSharedDepsFromEnv(ctx context.Context) (*composition.SharedDeps, *cmdLo
 	// mode; empty in demo mode) to cmd wiring so runtimeBaseOptions registers them
 	// as ManagedResources for LIFO shutdown.
 	locals.brokerResources = transport.Resources
+	// Hand the sealed broker-kind fact to cmd wiring so runtimeBaseOptions threads
+	// it into bootstrap.WithEventTransportKind for the phase0 split-topology gate (#2211).
+	locals.eventTransportKind = transport.Kind
 
 	// Build composition.SharedDeps (public, interface-only fields consumed by
 	// platform cell modules). The control-plane production checks (verbose /

--- a/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
+++ b/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
@@ -217,6 +217,20 @@ Medium 为天花板」，本 ADR **设下游档位目标**（实现属对应 iss
   cell 在本进程、消费 cell 在 remote，或反之）即为 split。双闸 = 静态（`gocell validate` 遍历
   contractUsages 判跨进程 pub/sub）+ 启动期（bootstrap phase0，同形于 `runtime/bootstrap/topology.go`
   既有「postgres requires real adapter」耦合规则）拒绝。→ US3 #1965（blocked-by #1940）。
+
+  > **Amendment 2026-06-15（#2211，US3 加固）**：phase0 启动期闸 `validateSplitTopologyBroker` 的
+  > 「是否真实 broker」判定，由 #1965 的 `StorageBackend()=="postgres" ∧ non-nil pub/sub` 代理升级为
+  > **sealed `bootstrap.EventTransportKind` 事实**：`cellmodules/eventtransport.Resolve` 在构造 RabbitMQ
+  > transport 的同一分支 mint `RealBrokerEventTransport()`，composition root 经 `WithEventTransportKind`
+  > 透传 `Transport.Kind`，闸改查 `IsRealBroker()`。威胁矩阵重评：#1965 闸 godoc 记录的残留洞
+  > 「`StorageBackend==postgres` + 手注入 non-nil in-memory 实例（non-nil ≠ real broker）」对 honest
+  > wiring（经 Resolve）**已关闭**——Resolve 只在真实 broker 分支 mint real-broker kind；dishonest
+  > forge（直调 `RealBrokerEventTransport()` 配 in-mem 总线）由 caller-funnel archtest
+  > `EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01` 守，生产侧另由既有 `COREBUNDLE-EVENTBUS-FUNNEL-01` depguard
+  > 使 in-mem 总线在生产 root **import 层不可表达**（Hard 端到端）。分层评级随之细化：sealed 构造 Hard、
+  > minter-单调用方结构性 Medium（跨模块 `framework`↔`cellmodules`，`internal/` 不可桥接 → 无低成本 Hard
+  > 路径，不立升级 issue）、闸运行时比较仍 Medium。「拓扑 × bus 类型 type system 不可表达」在 bus-realness
+  > 维度被 sealed-kind 收紧；「split 是否真有跨进程 *event*」（vs sync-only-remote 粗代理）仍属 US7 #1967。
 - **进程内跨 cell Go 直传 = 0 + gRPC 盲区收口 → Medium archtest。** 金丝雀
   `ModuleExports.BootstrapLedgerStore` 已删（PR #1467），archtest 收口直传=0 + 覆盖 #1752 引入的
   gRPC cross-cell 盲区。typed AST scan 即足，无低成本 Hard 化路径。→ US8 #1961。

--- a/docs/architecture/202606131500-1940-adr-topology-gated-event-transport.md
+++ b/docs/architecture/202606131500-1940-adr-topology-gated-event-transport.md
@@ -107,6 +107,22 @@ PR 范围。
 - **权威语义**：`cellmodules/replaydeps/doc.go`（§INVARIANT REPLAYDEPS-INMEM-FUNNEL-01）+
   `tools/archtest/replaydeps_inmem_funnel.go`。
 
+## Amendment 2026-06-15（#2211）：`Transport.Kind` sealed broker-kind 事实
+
+`Resolve` 现给每个 `Transport` 盖一个 sealed `bootstrap.EventTransportKind`（`Transport.Kind`）：
+postgres → RabbitMQ 分支 mint `RealBrokerEventTransport()`，demo 分支 mint `InMemoryEventTransport()`。
+这是 #1423 US3 phase0 broker-mandatory 闸的输入升级——闸由 `StorageBackend()=="postgres"` 代理改查
+sealed `IsRealBroker()`（«non-nil ≠ real broker» 收口，见 ADR 1423 的 2026-06-15 amendment）。
+
+- **本包是 real-broker 变体的唯一 sanctioned minter**：composition root 透传 `Transport.Kind` 到
+  `bootstrap.WithEventTransportKind`，自身不调构造器。由新 archtest
+  `EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01`（call-level scan，allowlist 本包）守。
+- **评级**：sealed 构造 Hard；minter-单调用方结构性 Medium（跨模块 `framework`↔`cellmodules`，
+  `internal/` 不可桥接 → 无低成本 Hard 路径，不立 issue，与 REPLAYDEPS-INMEM-FUNNEL-01 同族 Go 天花板）；
+  生产端到端「split ⇏ in-mem」仍由本 ADR 的 `COREBUNDLE-EVENTBUS-FUNNEL-01` depguard 保 Hard。
+- **权威语义**：`cellmodules/eventtransport/doc.go`（§INVARIANT EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01）+
+  `framework/runtime/bootstrap/event_transport_kind.go`。
+
 ## 参考
 
 - 对称 funnel：`kernel/outbox/mode_resolver.go`（`ResolveEmitter`）、`cellmodules/replaydeps`（#825/#2017）

--- a/docs/guides/deployment-topology.md
+++ b/docs/guides/deployment-topology.md
@@ -106,10 +106,15 @@ When cells are split across processes, the following infrastructure is required:
   topology combined with an in-memory EventBus is rejected by a **double gate**:
   the static `gocell validate` rule TOPO-13 and a bootstrap **phase0 runtime
   gate** (`validateSplitTopologyBroker`) that fail-fasts when the deployment has
-  remote cells while `StorageBackend() != postgres` (the in-memory bus is
-  reachable only in non-postgres topology — #1940 funnel). The runtime gate is a
-  coarse proxy: it fires on any remote cell, even one with only sync (no
-  cross-process events); a precise codegen-derived signal is a follow-up.
+  remote cells while the resolved event transport is not a real broker. Since
+  #2211 that decision is the sealed `EventTransportKind` (minted only by
+  `eventtransport.Resolve`, threaded via `bootstrap.WithEventTransportKind`): the
+  gate checks `IsRealBroker()`, and an **unset** kind — e.g. a composition root
+  that declared remote cells but forgot the option — is fail-closed. This
+  replaced the earlier `StorageBackend() != postgres` proxy ("non-nil ≠ real
+  broker" closed). The runtime gate is a coarse proxy: it fires on any remote
+  cell, even one with only sync (no cross-process events); a precise
+  codegen-derived signal is a follow-up (US7 #1967).
 - **Remote sync transport** (US4 #1963 / US5 #1966): a remote dispatch
   transport layer for synchronous cross-cell calls (planned, not yet
   implemented). US4 also removes the TOPO-12 fail-close gate.

--- a/examples/ssobff/app.go
+++ b/examples/ssobff/app.go
@@ -259,6 +259,9 @@ func buildSSOBFFBootstrapOptions(
 		bootstrap.WithAssembly(asm),
 		bootstrap.WithPublisher(infra.transport.Publisher),
 		bootstrap.WithSubscriber(infra.transport.Subscriber),
+		// Sealed broker-kind fact from eventtransport.Resolve: the phase0
+		// split-topology gate requires a real broker, not an in-process bus (#2211).
+		bootstrap.WithEventTransportKind(infra.transport.Kind),
 		bootstrap.WithConsumerBase(cb),
 		bootstrap.WithManagedResource(pool),
 		// Defense-in-depth: validate NonceStore/ConsumerClaimer kind against topology

--- a/framework/runtime/bootstrap/bootstrap.go
+++ b/framework/runtime/bootstrap/bootstrap.go
@@ -148,6 +148,7 @@ type Bootstrap struct {
 	workers                []worker.Worker
 	publisher              outbox.Publisher
 	subscriber             outbox.Subscriber
+	eventTransportKind     EventTransportKind   // sealed broker-kind fact for the phase0 split gate (#2211); unset = fail-closed
 	consumerBase           *outbox.ConsumerBase // field-injected into SubscriberWithMiddleware for idempotency
 	consumerMiddleware     []outbox.SubscriptionMiddleware
 	routerReadyTimeout     time.Duration

--- a/framework/runtime/bootstrap/deployment_topology_test.go
+++ b/framework/runtime/bootstrap/deployment_topology_test.go
@@ -620,10 +620,13 @@ func TestValidateSplitTopologyBroker(t *testing.T) {
 	// nonNilBus is used for the GREEN cases that require non-nil publisher/subscriber.
 	nonNilBus := eventbus.New(clock.Real())
 
-	// typedNilPub is a typed-nil interface value (non-nil interface header, nil
-	// concrete pointer). A bare == nil check would MISS it; the gate uses
-	// validation.IsNilInterface so it is correctly rejected (#2188 review F3).
+	// typedNilPub / typedNilSub are typed-nil interface values (non-nil interface
+	// header, nil concrete pointer). A bare == nil check would MISS them; the gate
+	// uses validation.IsNilInterface so both publisher and subscriber are correctly
+	// rejected (#2188 review F3). Both directions are covered to lock the symmetric
+	// IsNilInterface check on each sink.
 	var typedNilPub outbox.Publisher = (*eventbus.InMemoryEventBus)(nil)
+	var typedNilSub outbox.Subscriber = (*eventbus.InMemoryEventBus)(nil)
 
 	cases := []struct {
 		name               string
@@ -688,6 +691,17 @@ func TestValidateSplitTopologyBroker(t *testing.T) {
 			wantErrCode:        errcode.ErrValidationFailed,
 		},
 		{
+			// Symmetric to the publisher case: a typed-nil subscriber must also be
+			// rejected (the gate's IsNilInterface check is applied to both sinks).
+			name:               "RED: split topology + real-broker kind + typed-nil subscriber → rejected (F3 typed-nil)",
+			deploymentTopology: splitDT,
+			kind:               RealBrokerEventTransport(),
+			publisher:          nonNilBus,
+			subscriber:         typedNilSub,
+			wantErr:            true,
+			wantErrCode:        errcode.ErrValidationFailed,
+		},
+		{
 			name:               "GREEN: split topology + real-broker kind + non-nil pub/sub → accepted",
 			deploymentTopology: splitDT,
 			kind:               RealBrokerEventTransport(),
@@ -736,9 +750,13 @@ func TestValidateSplitTopologyBroker(t *testing.T) {
 	}
 }
 
-// TestPhase0_RejectsSplitTopologyWithInMemoryBus verifies that phase0 end-to-end
-// rejects a split topology combined with in-memory bus (no postgres storage).
-func TestPhase0_RejectsSplitTopologyWithInMemoryBus(t *testing.T) {
+// TestPhase0_RejectsSplitTopologyWithoutBrokerKind verifies that phase0 end-to-end
+// rejects a split topology when no real-broker EventTransportKind is declared.
+// The composition root here omits WithEventTransportKind, so the kind is the zero
+// value (unset) → IsRealBroker()==false → fail-closed. Since #2211 the rejection
+// is driven by the sealed kind, NOT by the (now gate-irrelevant) controlPlaneTopology
+// storage backend — the in-memory bus can no longer be reached in a split topology.
+func TestPhase0_RejectsSplitTopologyWithoutBrokerKind(t *testing.T) {
 	splitSpec := DeploymentTopologySpec{
 		Colocated: []string{"cellA"},
 		Remote: []RemoteCellEndpoint{
@@ -760,7 +778,7 @@ func TestPhase0_RejectsSplitTopologyWithInMemoryBus(t *testing.T) {
 
 	err = b.phase0ValidateOptions()
 	if err == nil {
-		t.Fatal("phase0ValidateOptions: expected error for split topology + in-memory bus, got nil")
+		t.Fatal("phase0ValidateOptions: expected error for split topology without a real-broker kind, got nil")
 	}
 	var ec *errcode.Error
 	if !errors.As(err, &ec) {
@@ -775,8 +793,12 @@ func TestPhase0_RejectsSplitTopologyWithInMemoryBus(t *testing.T) {
 }
 
 // TestPhase0_AcceptsSplitTopologyWithPostgres verifies that phase0 accepts a
-// split topology when postgres storage is declared and non-nil publisher/subscriber
-// are injected (broker-mandatory gate, F1).
+// split topology when a real-broker EventTransportKind + non-nil publisher/subscriber
+// are injected (broker-mandatory gate). Note: brokerBus is an in-memory eventbus
+// used only to satisfy the non-nil sink check — the gate validates the sealed Kind
+// fact, NOT the bus implementation. The honest pairing (a real kind ⇒ a real bus)
+// is the composition root's job; in production COREBUNDLE-EVENTBUS-FUNNEL-01 makes
+// the dishonest pairing import-unexpressible, so this unit-test shortcut cannot leak.
 func TestPhase0_AcceptsSplitTopologyWithPostgres(t *testing.T) {
 	splitSpec := DeploymentTopologySpec{
 		Colocated: []string{"cellA"},

--- a/framework/runtime/bootstrap/deployment_topology_test.go
+++ b/framework/runtime/bootstrap/deployment_topology_test.go
@@ -423,6 +423,7 @@ func TestPhase0_AcceptsValidDeploymentTopology(t *testing.T) {
 		WithControlPlaneTopology(postgresTopo),
 		WithPublisher(brokerBus),
 		WithSubscriber(brokerBus),
+		WithEventTransportKind(RealBrokerEventTransport()),
 		WithListener(cell.PrimaryListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
 		WithListener(cell.HealthListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
 	)
@@ -465,6 +466,7 @@ func TestBootstrap_DeploymentTopologyGetter_BeforePhase0(t *testing.T) {
 		WithControlPlaneTopology(postgresTopo),
 		WithPublisher(brokerBus),
 		WithSubscriber(brokerBus),
+		WithEventTransportKind(RealBrokerEventTransport()),
 		WithListener(cell.PrimaryListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
 		WithListener(cell.HealthListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
 	)
@@ -585,12 +587,16 @@ func TestDeploymentTopologyHasRemoteCells(t *testing.T) {
 
 // TestValidateSplitTopologyBroker exercises the phase0 broker-mandatory gate
 // (validateSplitTopologyBroker) directly, without starting a full Bootstrap.
+// Since #2211 the gate keys off the sealed EventTransportKind fact (minted only
+// by eventtransport.Resolve) rather than the StorageBackend()=="postgres" proxy.
 // The gate must:
-//   - reject split topology (≥1 remote) + in-memory bus (storage != postgres)
-//   - reject split topology + postgres storage but nil publisher or subscriber
-//     (F1: phase2 would degrade to in-memory bus — same security gap)
-//   - accept split topology + postgres storage + non-nil publisher + non-nil subscriber
-//   - accept colocated topology + in-memory bus (no remote cells, no broker needed)
+//   - reject split topology (≥1 remote) + in-memory kind
+//   - reject split topology + UNSET kind (composition root forgot the option →
+//     fail-closed, same posture as a forgotten publisher/subscriber)
+//   - reject split topology + real-broker kind but nil/typed-nil publisher or
+//     subscriber (phase2 would degrade to in-memory bus — same security gap)
+//   - accept split topology + real-broker kind + non-nil publisher + subscriber
+//   - accept colocated / zero topology regardless of kind (gate does not fire)
 func TestValidateSplitTopologyBroker(t *testing.T) {
 	splitSpec := DeploymentTopologySpec{
 		Colocated: []string{"cellA"},
@@ -610,14 +616,6 @@ func TestValidateSplitTopologyBroker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newDeploymentTopology(colocated): %v", err)
 	}
-	memoryTopo, err := NewTopology("", "memory", false)
-	if err != nil {
-		t.Fatalf("NewTopology(memory): %v", err)
-	}
-	postgresTopo, err := NewTopology("real", "postgres", false)
-	if err != nil {
-		t.Fatalf("NewTopology(postgres): %v", err)
-	}
 
 	// nonNilBus is used for the GREEN cases that require non-nil publisher/subscriber.
 	nonNilBus := eventbus.New(clock.Real())
@@ -630,93 +628,94 @@ func TestValidateSplitTopologyBroker(t *testing.T) {
 	cases := []struct {
 		name               string
 		deploymentTopology DeploymentTopology
-		controlPlaneTopo   Topology
+		kind               EventTransportKind
 		publisher          outbox.Publisher
 		subscriber         outbox.Subscriber
 		wantErr            bool
 		wantErrCode        errcode.Code
 	}{
 		{
-			name:               "RED: split topology + in-memory bus → rejected",
+			name:               "RED: split topology + in-memory kind → rejected",
 			deploymentTopology: splitDT,
-			controlPlaneTopo:   memoryTopo,
+			kind:               InMemoryEventTransport(),
+			publisher:          nonNilBus,
+			subscriber:         nonNilBus,
 			wantErr:            true,
 			wantErrCode:        errcode.ErrValidationFailed,
 		},
 		{
-			// F1: split topology + postgres storage but nil publisher → rejected.
-			// phase2InitPubSub falls back to in-memory bus when publisher==nil,
-			// so this combination must be fail-closed even though StorageBackend==postgres.
-			name:               "RED: split topology + postgres + nil publisher → rejected (F1 nil guard)",
+			// Composition root forgot WithEventTransportKind → zero value (unset).
+			// IsRealBroker()==false → fail-closed, exactly like a forgotten broker.
+			name:               "RED: split topology + UNSET kind → rejected (fail-closed)",
 			deploymentTopology: splitDT,
-			controlPlaneTopo:   postgresTopo,
+			kind:               EventTransportKind{}, // unset
+			publisher:          nonNilBus,
+			subscriber:         nonNilBus,
+			wantErr:            true,
+			wantErrCode:        errcode.ErrValidationFailed,
+		},
+		{
+			// real-broker kind but nil publisher → rejected. phase2InitPubSub falls
+			// back to in-memory bus when publisher==nil, so this stays fail-closed
+			// (independent invariant: a real-broker kind with a nil sink is broken wiring).
+			name:               "RED: split topology + real-broker kind + nil publisher → rejected (nil guard)",
+			deploymentTopology: splitDT,
+			kind:               RealBrokerEventTransport(),
 			publisher:          nil,
 			subscriber:         nonNilBus,
 			wantErr:            true,
 			wantErrCode:        errcode.ErrValidationFailed,
 		},
 		{
-			// F1: split topology + postgres storage but nil subscriber → rejected.
-			name:               "RED: split topology + postgres + nil subscriber → rejected (F1 nil guard)",
+			name:               "RED: split topology + real-broker kind + nil subscriber → rejected (nil guard)",
 			deploymentTopology: splitDT,
-			controlPlaneTopo:   postgresTopo,
+			kind:               RealBrokerEventTransport(),
 			publisher:          nonNilBus,
 			subscriber:         nil,
 			wantErr:            true,
 			wantErrCode:        errcode.ErrValidationFailed,
 		},
 		{
-			name:               "GREEN: split topology + postgres storage + non-nil pub/sub → accepted",
+			// F3: typed-nil publisher (non-nil interface, nil concrete pointer) must
+			// be rejected — a bare == nil check would let it pass and phase2 would
+			// degrade to the in-memory bus. validation.IsNilInterface closes it.
+			name:               "RED: split topology + real-broker kind + typed-nil publisher → rejected (F3 typed-nil)",
 			deploymentTopology: splitDT,
-			controlPlaneTopo:   postgresTopo,
+			kind:               RealBrokerEventTransport(),
+			publisher:          typedNilPub,
+			subscriber:         nonNilBus,
+			wantErr:            true,
+			wantErrCode:        errcode.ErrValidationFailed,
+		},
+		{
+			name:               "GREEN: split topology + real-broker kind + non-nil pub/sub → accepted",
+			deploymentTopology: splitDT,
+			kind:               RealBrokerEventTransport(),
 			publisher:          nonNilBus,
 			subscriber:         nonNilBus,
 			wantErr:            false,
 		},
 		{
-			name:               "GREEN: colocated topology + in-memory bus → accepted (no remote cells)",
+			name:               "GREEN: colocated topology + in-memory kind → accepted (no remote cells)",
 			deploymentTopology: colocatedDT,
-			controlPlaneTopo:   memoryTopo,
+			kind:               InMemoryEventTransport(),
 			wantErr:            false,
 		},
 		{
-			name:               "GREEN: zero deployment topology + in-memory bus → accepted (all-colocated default)",
+			name:               "GREEN: zero deployment topology + unset kind → accepted (all-colocated default)",
 			deploymentTopology: DeploymentTopology{},
-			controlPlaneTopo:   memoryTopo,
+			kind:               EventTransportKind{},
 			wantErr:            false,
-		},
-		{
-			// F6: zero-value Topology{} (StorageBackend()=="") combined with a split
-			// deployment topology must be fail-closed rejected. This locks the
-			// invariant that a zero Topology does not accidentally read as postgres
-			// and let an un-configured split deployment pass the broker gate.
-			name:               "RED: split topology + zero Topology{} (StorageBackend==\"\") → rejected (fail-closed)",
-			deploymentTopology: splitDT,
-			controlPlaneTopo:   Topology{}, // true zero value — StorageBackend()==""
-			wantErr:            true,
-			wantErrCode:        errcode.ErrValidationFailed,
-		},
-		{
-			// F3: typed-nil publisher (non-nil interface, nil concrete pointer)
-			// must be rejected — a bare == nil check would let it pass and phase2
-			// would degrade to the in-memory bus. validation.IsNilInterface closes it.
-			name:               "RED: split topology + postgres + typed-nil publisher → rejected (F3 typed-nil)",
-			deploymentTopology: splitDT,
-			controlPlaneTopo:   postgresTopo,
-			publisher:          typedNilPub,
-			subscriber:         nonNilBus,
-			wantErr:            true,
-			wantErrCode:        errcode.ErrValidationFailed,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			b := &Bootstrap{
-				deploymentTopology:   tc.deploymentTopology,
-				controlPlaneTopology: tc.controlPlaneTopo,
-				publisher:            tc.publisher,
-				subscriber:           tc.subscriber,
+				deploymentTopology: tc.deploymentTopology,
+				eventTransportKind: tc.kind,
+				publisher:          tc.publisher,
+				subscriber:         tc.subscriber,
 			}
 			err := b.validateSplitTopologyBroker()
 			if tc.wantErr {
@@ -797,6 +796,7 @@ func TestPhase0_AcceptsSplitTopologyWithPostgres(t *testing.T) {
 		WithControlPlaneTopology(postgresTopo),
 		WithPublisher(brokerBus),
 		WithSubscriber(brokerBus),
+		WithEventTransportKind(RealBrokerEventTransport()),
 		WithListener(cell.PrimaryListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
 		WithListener(cell.HealthListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
 	)

--- a/framework/runtime/bootstrap/event_transport_kind.go
+++ b/framework/runtime/bootstrap/event_transport_kind.go
@@ -30,9 +30,9 @@ package bootstrap
 // by archtest EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01 (same family as the
 // RowScopeAll minter and COMMAND-ASYNC-EMIT-CALLER-01). The production
 // end-to-end guarantee is nonetheless Hard: the COREBUNDLE-EVENTBUS-FUNNEL-01
-// depguard makes an in-memory bus import-unexpressible in the production
-// composition roots, so a forged real-broker kind cannot be paired with an
-// in-memory bus there.
+// depguard (corebundle-no-direct-eventbus + ssobff-no-direct-eventbus) makes an
+// in-memory bus import-unexpressible in BOTH production composition roots, so a
+// forged real-broker kind cannot be paired with an in-memory bus there.
 //
 // Field set frozen by TestEventTransportKindZeroExportedFields
 // (EVENT-TRANSPORT-KIND-SEALED-FIELD-FROZEN-01).
@@ -51,7 +51,13 @@ func InMemoryEventTransport() EventTransportKind {
 
 // RealBrokerEventTransport mints the kind for a real cross-process broker
 // (postgres topology → RabbitMQ). IsRealBroker()==true. Sanctioned caller:
-// cellmodules/eventtransport.Resolve only (EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01).
+// cellmodules/eventtransport.Resolve only.
+//
+// Enforcement rating: Hard (sealed construction — see type godoc) + Medium
+// (caller funnel EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01, a cross-module Go ceiling
+// with no low-cost Hard path) + Hard end-to-end (the COREBUNDLE-EVENTBUS-FUNNEL-01
+// depguard makes an in-memory bus import-unexpressible in the production roots).
+// ADR: docs/architecture/202606131500-1940 (amendment 2026-06-15).
 func RealBrokerEventTransport() EventTransportKind {
 	return EventTransportKind{set: true, realBroker: true}
 }
@@ -62,7 +68,11 @@ func (k EventTransportKind) IsRealBroker() bool {
 	return k.set && k.realBroker
 }
 
-// String renders the kind for diagnostics (errcode internal attrs / logs).
+// String renders the kind for diagnostics (errcode internal attrs / logs). The
+// "unset" value is the operationally significant one: it means the composition
+// root never called WithEventTransportKind, which the split-topology gate treats
+// as fail-closed — so a server log showing eventTransportKind=unset on a startup
+// rejection points the operator at the missing WithEventTransportKind wiring.
 func (k EventTransportKind) String() string {
 	switch {
 	case !k.set:

--- a/framework/runtime/bootstrap/event_transport_kind.go
+++ b/framework/runtime/bootstrap/event_transport_kind.go
@@ -1,0 +1,75 @@
+package bootstrap
+
+// event_transport_kind.go — sealed broker-kind fact for the phase0
+// broker-mandatory gate (#2211).
+//
+// ref: uber-go/fx app.go — sealed value constructed at wiring time, safe zero
+// value (here: unset → fail-closed at the gate).
+
+// EventTransportKind is the sealed fact "is the resolved event transport a real
+// cross-process broker, or an in-process bus?" It upgrades the phase0
+// broker-mandatory gate (validateSplitTopologyBroker) from the weaker
+// StorageBackend()=="postgres" ∧ non-nil proxy to a type-system fact: a split
+// deployment topology requires IsRealBroker()==true.
+//
+// Sealed construction (Hard): all fields are unexported, so a package-external
+// struct literal cannot mint (let alone forge, e.g. EventTransportKind{realBroker:true})
+// a value — the only entry points are the two constructors below. The zero
+// value is "unset" → IsRealBroker() reports false, so a split topology whose
+// composition root forgot to declare the kind is rejected (fail-closed), the
+// same posture as a forgotten publisher/subscriber.
+//
+// Single sanctioned minter of the real-broker variant (Medium, Go/module
+// ceiling): RealBrokerEventTransport is intended to be called ONLY by
+// cellmodules/eventtransport.Resolve (the topology-gated transport funnel),
+// which mints it in the same branch that constructs the RabbitMQ
+// publisher/subscriber. bootstrap (framework module) must export the
+// constructor for eventtransport (root module, cellmodules/) to call it, and a
+// framework/.../internal/ package cannot bridge that cross-module import, so a
+// struct-level Hard funnel is unreachable; the caller restriction is enforced
+// by archtest EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01 (same family as the
+// RowScopeAll minter and COMMAND-ASYNC-EMIT-CALLER-01). The production
+// end-to-end guarantee is nonetheless Hard: the COREBUNDLE-EVENTBUS-FUNNEL-01
+// depguard makes an in-memory bus import-unexpressible in the production
+// composition roots, so a forged real-broker kind cannot be paired with an
+// in-memory bus there.
+//
+// Field set frozen by TestEventTransportKindZeroExportedFields
+// (EVENT-TRANSPORT-KIND-SEALED-FIELD-FROZEN-01).
+type EventTransportKind struct {
+	set        bool // false = unset (fail-closed): no kind declared
+	realBroker bool // true = real cross-process broker; false = in-process bus
+}
+
+// InMemoryEventTransport mints the kind for an in-process eventbus (demo /
+// memory topology). IsRealBroker()==false. This is the safe direction (a split
+// topology carrying this kind is rejected by the broker gate), so it has no
+// caller funnel.
+func InMemoryEventTransport() EventTransportKind {
+	return EventTransportKind{set: true, realBroker: false}
+}
+
+// RealBrokerEventTransport mints the kind for a real cross-process broker
+// (postgres topology → RabbitMQ). IsRealBroker()==true. Sanctioned caller:
+// cellmodules/eventtransport.Resolve only (EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01).
+func RealBrokerEventTransport() EventTransportKind {
+	return EventTransportKind{set: true, realBroker: true}
+}
+
+// IsRealBroker reports whether the resolved transport is a real cross-process
+// broker. The zero value (unset) reports false so the broker gate fails closed.
+func (k EventTransportKind) IsRealBroker() bool {
+	return k.set && k.realBroker
+}
+
+// String renders the kind for diagnostics (errcode internal attrs / logs).
+func (k EventTransportKind) String() string {
+	switch {
+	case !k.set:
+		return "unset"
+	case k.realBroker:
+		return "real-broker"
+	default:
+		return "in-memory"
+	}
+}

--- a/framework/runtime/bootstrap/event_transport_kind_test.go
+++ b/framework/runtime/bootstrap/event_transport_kind_test.go
@@ -1,0 +1,99 @@
+package bootstrap
+
+// event_transport_kind_test.go — tests for the sealed EventTransportKind fact.
+//
+// INVARIANT: EVENT-TRANSPORT-KIND-SEALED-FIELD-FROZEN-01
+
+import (
+	"reflect"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// EVENT-TRANSPORT-KIND-SEALED-FIELD-FROZEN-01
+// ---------------------------------------------------------------------------
+
+// TestEventTransportKindZeroExportedFields enforces the sealed-construction
+// invariant: an EventTransportKind must have zero exported fields so the only
+// way to mint one is via InMemoryEventTransport / RealBrokerEventTransport. If
+// any field were exported, package-external code could forge a real-broker kind
+// via a struct literal (e.g. EventTransportKind{RealBroker: true}), defeating
+// the seal that the phase0 broker gate trusts (INVARIANT:
+// EVENT-TRANSPORT-KIND-SEALED-FIELD-FROZEN-01).
+func TestEventTransportKindZeroExportedFields(t *testing.T) {
+	rt := reflect.TypeOf(EventTransportKind{})
+	for i := 0; i < rt.NumField(); i++ {
+		if f := rt.Field(i); f.IsExported() {
+			t.Errorf("EventTransportKind.%s is exported; all fields must be unexported so the only "+
+				"mint path is InMemoryEventTransport / RealBrokerEventTransport (sealed)", f.Name)
+		}
+	}
+}
+
+// TestEventTransportKindExpectedUnexportedFields freezes the exact unexported
+// field set (anti-drift companion to the exported-zero test above).
+func TestEventTransportKindExpectedUnexportedFields(t *testing.T) {
+	wantFields := map[string]bool{
+		"set":        false,
+		"realBroker": false,
+	}
+	rt := reflect.TypeOf(EventTransportKind{})
+	for i := 0; i < rt.NumField(); i++ {
+		name := rt.Field(i).Name
+		if _, ok := wantFields[name]; !ok {
+			t.Errorf("unexpected field %q in EventTransportKind; update EVENT-TRANSPORT-KIND-SEALED-FIELD-FROZEN-01 test", name)
+		}
+		wantFields[name] = true
+	}
+	for name, seen := range wantFields {
+		if !seen {
+			t.Errorf("expected field %q not found in EventTransportKind", name)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsRealBroker semantics (unset = fail-closed)
+// ---------------------------------------------------------------------------
+
+// TestEventTransportKind_IsRealBroker covers all three states: the zero value
+// (unset) must report false so the broker gate fails closed when a composition
+// root forgot to declare the kind; in-memory reports false; real-broker true.
+func TestEventTransportKind_IsRealBroker(t *testing.T) {
+	cases := []struct {
+		name string
+		kind EventTransportKind
+		want bool
+	}{
+		{name: "zero value (unset) → false (fail-closed)", kind: EventTransportKind{}, want: false},
+		{name: "in-memory → false", kind: InMemoryEventTransport(), want: false},
+		{name: "real broker → true", kind: RealBrokerEventTransport(), want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.kind.IsRealBroker(); got != tc.want {
+				t.Errorf("IsRealBroker() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEventTransportKind_String covers the diagnostic rendering used by the
+// gate's errcode internal attribute.
+func TestEventTransportKind_String(t *testing.T) {
+	cases := []struct {
+		kind EventTransportKind
+		want string
+	}{
+		{kind: EventTransportKind{}, want: "unset"},
+		{kind: InMemoryEventTransport(), want: "in-memory"},
+		{kind: RealBrokerEventTransport(), want: "real-broker"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			if got := tc.kind.String(); got != tc.want {
+				t.Errorf("String() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/framework/runtime/bootstrap/options_assembly.go
+++ b/framework/runtime/bootstrap/options_assembly.go
@@ -71,10 +71,12 @@ func WithDeploymentTopology(spec DeploymentTopologySpec) Option {
 // Note: this option no longer feeds the broker-mandatory split gate
 // (validateSplitTopologyBroker). Since #2211 that gate checks the sealed
 // EventTransportKind (WithEventTransportKind, minted by eventtransport.Resolve),
-// not StorageBackend — to pass it with a split deployment topology supply
-// RealBrokerEventTransport() via WithEventTransportKind plus non-nil
+// not StorageBackend — to pass it with a split deployment topology, thread
+// eventtransport.Resolve(...).Kind via WithEventTransportKind plus non-nil
 // publisher/subscriber via WithPublisher/WithSubscriber; an unset kind is
-// fail-closed.
+// fail-closed. (Do NOT call RealBrokerEventTransport() directly — that
+// constructor is reserved for eventtransport.Resolve and tests,
+// EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01.)
 func WithControlPlaneTopology(topo Topology) Option {
 	return func(b *Bootstrap) {
 		b.controlPlaneTopology = topo

--- a/framework/runtime/bootstrap/options_assembly.go
+++ b/framework/runtime/bootstrap/options_assembly.go
@@ -68,11 +68,13 @@ func WithDeploymentTopology(spec DeploymentTopologySpec) Option {
 // hand-written bootstraps. The always-on nil/noop/ring service-token checks
 // (validateAuthServiceTokenPlan) run regardless.
 //
-// Note: the broker-mandatory split gate (validateSplitTopologyBroker) still
-// applies — a zero Topology reads as non-postgres (StorageBackend()==""), so a
-// split deployment topology is fail-closed rejected (not skipped). To pass the
-// gate with a split topology, supply a postgres Topology AND inject non-nil
-// publisher/subscriber via WithPublisher/WithSubscriber.
+// Note: this option no longer feeds the broker-mandatory split gate
+// (validateSplitTopologyBroker). Since #2211 that gate checks the sealed
+// EventTransportKind (WithEventTransportKind, minted by eventtransport.Resolve),
+// not StorageBackend — to pass it with a split deployment topology supply
+// RealBrokerEventTransport() via WithEventTransportKind plus non-nil
+// publisher/subscriber via WithPublisher/WithSubscriber; an unset kind is
+// fail-closed.
 func WithControlPlaneTopology(topo Topology) Option {
 	return func(b *Bootstrap) {
 		b.controlPlaneTopology = topo

--- a/framework/runtime/bootstrap/options_events.go
+++ b/framework/runtime/bootstrap/options_events.go
@@ -47,6 +47,23 @@ func WithSubscriber(s outbox.Subscriber) Option {
 	}
 }
 
+// WithEventTransportKind declares whether the injected event transport is a real
+// cross-process broker or an in-process bus, as resolved by
+// cellmodules/eventtransport.Resolve (which mints the sealed EventTransportKind).
+// The phase0 broker-mandatory gate (validateSplitTopologyBroker) requires
+// IsRealBroker()==true for a split deployment topology; an unset kind (option
+// omitted) is fail-closed. Colocated deployments may omit it — the gate does not
+// fire without remote cells. The composition root threads the resolver's
+// Transport.Kind here, so the gate trusts a type-system fact instead of the
+// older StorageBackend proxy (#2211).
+//
+// ref: uber-go/fx app.go — Option pattern; each Option targets a single concern.
+func WithEventTransportKind(k EventTransportKind) Option {
+	return func(b *Bootstrap) {
+		b.eventTransportKind = k
+	}
+}
+
 // WithConsumerMiddleware registers business subscriber-side middleware applied to
 // every topic's EntryHandler before ConsumerBase idempotency is applied.
 // Middleware is applied in registration order; each entry wraps the next, so the

--- a/framework/runtime/bootstrap/options_events.go
+++ b/framework/runtime/bootstrap/options_events.go
@@ -50,12 +50,16 @@ func WithSubscriber(s outbox.Subscriber) Option {
 // WithEventTransportKind declares whether the injected event transport is a real
 // cross-process broker or an in-process bus, as resolved by
 // cellmodules/eventtransport.Resolve (which mints the sealed EventTransportKind).
-// The phase0 broker-mandatory gate (validateSplitTopologyBroker) requires
-// IsRealBroker()==true for a split deployment topology; an unset kind (option
-// omitted) is fail-closed. Colocated deployments may omit it — the gate does not
-// fire without remote cells. The composition root threads the resolver's
-// Transport.Kind here, so the gate trusts a type-system fact instead of the
-// older StorageBackend proxy (#2211).
+// The composition root threads the resolver's Transport.Kind here, so the phase0
+// broker-mandatory gate (validateSplitTopologyBroker) trusts a type-system fact
+// instead of the older StorageBackend proxy (#2211).
+//
+// When WithDeploymentTopology declares any remote cell, this option becomes
+// effectively MANDATORY: the gate requires IsRealBroker()==true for a split
+// topology, so omitting it (or passing the zero value EventTransportKind{} —
+// identical to omitting it, both read as "unset") causes phase0 to reject the
+// bootstrap fail-closed. Colocated deployments may omit it — the gate does not
+// fire without remote cells.
 //
 // ref: uber-go/fx app.go — Option pattern; each Option targets a single concern.
 func WithEventTransportKind(k EventTransportKind) Option {

--- a/framework/runtime/bootstrap/phases_assembly.go
+++ b/framework/runtime/bootstrap/phases_assembly.go
@@ -161,9 +161,18 @@ func (b *Bootstrap) validateSplitTopologyBroker() error {
 	if b.deploymentTopology.HasRemoteCells() &&
 		(!b.eventTransportKind.IsRealBroker() ||
 			validation.IsNilInterface(b.publisher) || validation.IsNilInterface(b.subscriber)) {
+		// Distinct internal attrs so the server log pinpoints WHICH sub-cause
+		// tripped the gate — an unset/in-memory kind (composition root forgot
+		// WithEventTransportKind), a nil publisher, and a nil subscriber are
+		// different wiring mistakes that the single const message cannot
+		// distinguish on the wire (MESSAGE-CONST-LITERAL-01).
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			errMsgSplitTopologyRequiresBroker,
-			errcode.WithInternal(errcode.InternalAttr("eventTransportKind", b.eventTransportKind.String())))
+			errcode.WithInternal(
+				errcode.InternalAttr("eventTransportKind", b.eventTransportKind.String()),
+				errcode.InternalAttr("publisherNil", validation.IsNilInterface(b.publisher)),
+				errcode.InternalAttr("subscriberNil", validation.IsNilInterface(b.subscriber)),
+			))
 	}
 	return nil
 }
@@ -245,7 +254,8 @@ const errMsgSplitTopologyRequiresBroker = "split deployment topology (remote cel
 	"set GOCELL_CELL_ADAPTER_MODE=postgres (+ GOCELL_ADAPTER_MODE=real) and GOCELL_AMQP_URL so " +
 	"eventtransport.Resolve selects a real broker, and thread its Transport.Kind via " +
 	"WithEventTransportKind plus a non-nil publisher/subscriber via WithPublisher/WithSubscriber" +
-	" — or remove topology.remote to keep all cells co-located (no broker needed)"
+	" — or drop the remote cells from the deployment topology (assembly topology.remote / " +
+	"DeploymentTopologySpec.Remote) to keep all cells co-located (no broker needed)"
 
 // phase10ShutdownBudgetBuckets is the number of independent timeout buckets
 // allocated by phase10OrchestrateShutdown — drainCtx (stage 1+2) and tearCtx

--- a/framework/runtime/bootstrap/phases_assembly.go
+++ b/framework/runtime/bootstrap/phases_assembly.go
@@ -126,42 +126,44 @@ func (b *Bootstrap) validateDeploymentTopology() error {
 }
 
 // validateSplitTopologyBroker rejects the illegal combination of a split
-// deployment topology (≥1 remote cell) with an in-memory EventBus. The bus is
-// in-memory iff the storage backend is not postgres (#1940 eventtransport
-// funnel: in-memory is reachable only in demo/non-postgres topology), so this
-// gate is expressed via controlPlaneTopology.StorageBackend() — the same shape
-// as topology.go's "postgres requires real adapter" coupling check. Called at
-// phase0 after validateDeploymentTopology seals b.deploymentTopology.
+// deployment topology (≥1 remote cell) with an in-process EventBus — the bus
+// cannot deliver events across process boundaries. Called at phase0 after
+// validateDeploymentTopology seals b.deploymentTopology.
 //
-// Split topology additionally requires explicit broker publisher/subscriber
-// injection; a nil publisher or subscriber causes phase2InitPubSub to fall back
-// to the in-memory EventBus regardless of StorageBackend, so this gate also
-// rejects that combination. The nil check uses validation.IsNilInterface so a
-// typed-nil interface value (e.g. WithPublisher((*T)(nil))) cannot slip past a
-// bare == nil comparison — the same defense SharedDeps applies to its
-// Publisher/Subscriber. Residual blind-spot: StorageBackend==postgres with a
-// hand-injected non-nil in-memory publisher/subscriber instance is not caught
-// here (non-nil ≠ real broker); that hole is closed by the
-// COREBUNDLE-EVENTBUS-FUNNEL-01 depguard (in-memory bus is import-banned in the
-// production composition roots, reachable only via eventtransport.Resolve's
-// non-postgres branch). Promoting this gate to a sealed broker-kind check is
-// tracked as a follow-up (#1965 review F2).
+// The "is it a real cross-process broker?" decision is the sealed
+// EventTransportKind fact (#2211): cellmodules/eventtransport.Resolve mints
+// RealBrokerEventTransport() exactly when it constructs the RabbitMQ transport,
+// InMemoryEventTransport() for the demo/in-process bus, and the composition root
+// threads it here via WithEventTransportKind. The gate therefore checks a
+// type-system fact (IsRealBroker) rather than the older
+// StorageBackend()=="postgres" proxy ("non-nil ≠ real broker" closed). An unset
+// kind (composition root omitted the option) reports IsRealBroker()==false, so a
+// split topology is fail-closed.
 //
-// Medium gate (Hard unreachable: compares two runtime values). Coarse proxy:
-// fires on ANY remote cell — even one with only sync (HTTP/CellTransport)
-// contracts and no cross-process events — because HasRemoteCells is a
-// per-assembly signal, not a per-contract signal (US7 #1967 refines this).
-// Fail-closed: an un-injected controlPlaneTopology reads as memory, so a split
-// topology that forgot to declare postgres storage is correctly rejected; a nil
-// (or typed-nil) publisher or subscriber is also rejected (phase2 would degrade
-// to in-memory bus). See also DeploymentTopology.HasRemoteCells for the blind-spot.
+// Split topology additionally requires non-nil publisher/subscriber; a nil (or
+// typed-nil) sink causes phase2InitPubSub to fall back to the in-process bus, so
+// the gate keeps that as an independent fail-closed invariant (a real-broker
+// kind paired with a nil sink is still broken wiring). The nil check uses
+// validation.IsNilInterface so a typed-nil interface value (e.g.
+// WithPublisher((*T)(nil))) cannot slip past a bare == nil comparison.
+//
+// Grading: sealed-kind construction is Hard (unexported fields → no
+// struct-literal forgery); "only eventtransport.Resolve mints the real-broker
+// variant" is a structural Medium (cross-module Go ceiling, archtest
+// EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01); the production end-to-end guarantee is
+// Hard via the COREBUNDLE-EVENTBUS-FUNNEL-01 depguard (an in-memory bus is
+// import-unexpressible in the production composition roots, so a forged
+// real-broker kind cannot be paired with one there). This gate itself stays
+// Medium (compares two runtime values). Coarse proxy (separate blind-spot, US7
+// #1967): HasRemoteCells fires on ANY remote cell, even a sync-only one with no
+// cross-process events — see DeploymentTopology.HasRemoteCells.
 func (b *Bootstrap) validateSplitTopologyBroker() error {
 	if b.deploymentTopology.HasRemoteCells() &&
-		(b.controlPlaneTopology.StorageBackend() != StorageBackendPostgres ||
+		(!b.eventTransportKind.IsRealBroker() ||
 			validation.IsNilInterface(b.publisher) || validation.IsNilInterface(b.subscriber)) {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			errMsgSplitTopologyRequiresBroker,
-			errcode.WithInternal(errcode.InternalAttr("storageBackend", b.controlPlaneTopology.StorageBackend())))
+			errcode.WithInternal(errcode.InternalAttr("eventTransportKind", b.eventTransportKind.String())))
 	}
 	return nil
 }
@@ -240,8 +242,9 @@ const terminationGraceSafetyMargin = 10 * time.Second
 // errMsgSplitTopologyRequiresBroker — MESSAGE-CONST-LITERAL-01.
 const errMsgSplitTopologyRequiresBroker = "split deployment topology (remote cells) requires a real event broker; " +
 	"the in-memory EventBus cannot deliver events across process boundaries — " +
-	"set GOCELL_CELL_ADAPTER_MODE=postgres (+ GOCELL_ADAPTER_MODE=real) and GOCELL_AMQP_URL, " +
-	"and inject a real broker publisher/subscriber via WithPublisher/WithSubscriber" +
+	"set GOCELL_CELL_ADAPTER_MODE=postgres (+ GOCELL_ADAPTER_MODE=real) and GOCELL_AMQP_URL so " +
+	"eventtransport.Resolve selects a real broker, and thread its Transport.Kind via " +
+	"WithEventTransportKind plus a non-nil publisher/subscriber via WithPublisher/WithSubscriber" +
 	" — or remove topology.remote to keep all cells co-located (no broker needed)"
 
 // phase10ShutdownBudgetBuckets is the number of independent timeout buckets

--- a/tools/archtest/event_transport_kind_mint_caller_test.go
+++ b/tools/archtest/event_transport_kind_mint_caller_test.go
@@ -103,7 +103,7 @@ func TestEventTransportKindMinterFunnel01(t *testing.T) {
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
 
-	var observed bool
+	var observed, observedInFunnel bool
 	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
 		if !p.Typed() {
 			return nil
@@ -118,6 +118,7 @@ func TestEventTransportKindMinterFunnel01(t *testing.T) {
 				}
 				observed = true
 				if inFunnel {
+					observedInFunnel = true
 					return // eventtransport.Resolve is the sanctioned minter
 				}
 				pos := p.Fset.Position(call.Pos())
@@ -149,6 +150,19 @@ func TestEventTransportKindMinterFunnel01(t *testing.T) {
 				"bootstrap.RealBrokerEventTransport() was observed anywhere. eventtransport.Resolve " +
 				"(resolveRabbitMQ) must mint it on the RabbitMQ branch — either the minter was " +
 				"removed/renamed or the scanner regressed; the funnel guards nothing without it.",
+		})
+	}
+	// Second anti-vacuity: the observed mint must occur INSIDE the sanctioned
+	// minter package, exercising the allowlist GREEN path. If observed==true but
+	// observedInFunnel==false, the only mint is somewhere else and the funnel's
+	// suppression branch was never taken (the eventtransport pkgPath drifted or
+	// the minter moved out) — that is a silent regression of the funnel's anchor.
+	if observed && !observedInFunnel {
+		diags = append(diags, Diagnostic{
+			Message: "EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01 anti-vacuity: RealBrokerEventTransport() " +
+				"is minted in production but NOT inside " + eventTransportKindMinterPkgPath +
+				"; the sanctioned-minter (GREEN) path was never exercised. Either the minter moved out " +
+				"of eventtransport.Resolve or eventTransportKindMinterPkgPath drifted.",
 		})
 	}
 

--- a/tools/archtest/event_transport_kind_mint_caller_test.go
+++ b/tools/archtest/event_transport_kind_mint_caller_test.go
@@ -1,0 +1,191 @@
+//go:build archtest
+
+// event_transport_kind_mint_caller_test.go — locks the SOLE sanctioned minter of
+// the real-broker bootstrap.EventTransportKind (#2211, epic #1423).
+//
+// INVARIANT: EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01
+//
+// # What this guards
+//
+// bootstrap.RealBrokerEventTransport() mints the sealed EventTransportKind whose
+// IsRealBroker()==true is the fact the phase0 broker-mandatory gate
+// (validateSplitTopologyBroker) trusts to allow a split deployment topology. The
+// gate replaced the older StorageBackend()=="postgres" ∧ non-nil proxy with this
+// sealed fact ("non-nil ≠ real broker" closed). The PRIMARY seal is the type
+// system: EventTransportKind has only unexported fields, so a package-external
+// struct literal cannot forge a real-broker value (Hard, EVENT-TRANSPORT-KIND-
+// SEALED-FIELD-FROZEN-01). The remaining escape is the exported constructor
+// itself — any package importing bootstrap could call RealBrokerEventTransport()
+// and hand the gate a "real broker" claim while wiring an in-process bus.
+//
+// This archtest pins every production call of RealBrokerEventTransport() to the
+// sole sanctioned minter, cellmodules/eventtransport.Resolve, which mints it ONLY
+// in the branch that constructs the RabbitMQ transport (resolveRabbitMQ). The
+// composition roots thread the resolver's Transport.Kind into
+// bootstrap.WithEventTransportKind — they never call the constructor themselves.
+//
+// # AI-robust rating (charter §"Funnel 双向锁评级")
+//
+//   - Downstream (sealed construction): HARD — EventTransportKind's fields are
+//     unexported, so a real-broker value cannot be struct-literal-forged
+//     out-of-package (EVENT-TRANSPORT-KIND-SEALED-FIELD-FROZEN-01).
+//   - Production end-to-end ("split ⇏ in-memory"): HARD via the sibling depguard
+//     COREBUNDLE-EVENTBUS-FUNNEL-01 — an in-memory bus is import-unexpressible in
+//     the production composition roots, so a forged real-broker kind cannot be
+//     paired with one there.
+//   - Upstream (only eventtransport.Resolve mints): MEDIUM — this caller-allowlist
+//     archtest, a deliberately accepted permanent ceiling, not a deferred TODO.
+//     EventTransportKind lives in bootstrap (framework module) so its gate can
+//     consume it without an import cycle, but the sole minter is
+//     cellmodules/eventtransport (root module); bootstrap must export the
+//     constructor for it to call it, and a framework/.../internal/ package cannot
+//     bridge a cross-module import, so Go visibility cannot express "only
+//     eventtransport may mint a real-broker kind". Same Go/module ceiling
+//     documented for the RowScopeAll minter, COMMAND-ASYNC-EMIT-CALLER-01,
+//     OUTBOX-RECONSTRUCTION-CALLER-01 (#851/#893/#1282). No fake Hard-upgrade
+//     issue is opened.
+//
+// # Detection is type-aware (not string scanning)
+//
+// ResolvePackageRef resolves call.Fun to runtime/bootstrap.RealBrokerEventTransport,
+// alias- and dot-import-proof. No const-evaluation is needed (the callee identity
+// alone is the trip).
+//
+// # Tool blind spots (charter §"强制盲区自检")
+//
+//  1. A real-broker kind laundered through a function value
+//     (f := bootstrap.RealBrokerEventTransport; f()) is still a SelectorExpr the
+//     ResolvePackageRef walk resolves, so it is caught. A kind returned by a
+//     wrapper that itself calls the minter is caught at the wrapper's call.
+//  2. _test.go files are out of scope (Production scope, Tests:false): test
+//     helpers may mint a real-broker kind to exercise the gate. That is the same
+//     posture as DEVICE-PRINCIPAL-MINT-CALLER-01's test exemption — a sealed value
+//     minted in a test never reaches production wiring.
+//  3. The RED fixture is build-tagged (archtest_fixture), excluded from the
+//     default-tags Production scan, so it cannot pollute the production result.
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// eventTransportKindMinterName is the sealed real-broker minter on the bootstrap
+// package (declared in event_transport_kind.go). bootstrapPkgPath is reused from
+// probename_sealed_funnel.go (same archtest package).
+const eventTransportKindMinterName = "RealBrokerEventTransport"
+
+// eventTransportKindMinterPkgPath is the SOLE sanctioned caller package:
+// cellmodules/eventtransport (root module), whose Resolve mints the real-broker
+// kind only when it constructs the RabbitMQ transport.
+const eventTransportKindMinterPkgPath = PlatformModulePath + "/cellmodules/eventtransport"
+
+// eventTransportKindMintFixturePkg is the build-tagged RED fixture exercised by
+// the reverse self-check.
+const eventTransportKindMintFixturePkg = "./tools/archtest/internal/eventtransportkindmintfixture"
+
+// isRealBrokerEventTransportCall reports whether call invokes
+// bootstrap.RealBrokerEventTransport (alias/dot-import-proof via ResolvePackageRef).
+func isRealBrokerEventTransportCall(p *Pass, call *ast.CallExpr) bool {
+	pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, call.Fun)
+	return ok && pkgPath == bootstrapPkgPath && name == eventTransportKindMinterName
+}
+
+// TestEventTransportKindMinterFunnel01 asserts every production call of
+// bootstrap.RealBrokerEventTransport() sits in cellmodules/eventtransport, and
+// that eventtransport actually mints it (anti-vacuity).
+func TestEventTransportKindMinterFunnel01(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var observed bool
+	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		inFunnel := p.Pkg.Path() == eventTransportKindMinterPkgPath
+		var d []Diagnostic
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+				if !isRealBrokerEventTransportCall(p, call) {
+					return
+				}
+				observed = true
+				if inFunnel {
+					return // eventtransport.Resolve is the sanctioned minter
+				}
+				pos := p.Fset.Position(call.Pos())
+				d = append(d, Diagnostic{
+					Rel:  rel,
+					Line: pos.Line,
+					Message: fmt.Sprintf(
+						"EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01: %s calls bootstrap.RealBrokerEventTransport() "+
+							"outside the sole sanctioned minter cellmodules/eventtransport.Resolve. A real-broker "+
+							"EventTransportKind must be minted only where the RabbitMQ transport is actually "+
+							"constructed (resolveRabbitMQ); minting it elsewhere hands the phase0 split-topology gate "+
+							"(validateSplitTopologyBroker) a \"real broker\" claim that may not be backed by one. "+
+							"Thread eventtransport.Resolve's Transport.Kind via bootstrap.WithEventTransportKind "+
+							"instead; or, if this is a genuinely new sanctioned minter, widen the funnel allowlist "+
+							"with a rationale.",
+						rel),
+				})
+			})
+		}
+		return d
+	})
+
+	// Anti-vacuity: cellmodules/eventtransport must actually mint the real-broker
+	// kind, else the funnel guards nothing (the minter was removed/renamed or the
+	// scanner regressed).
+	if !observed {
+		diags = append(diags, Diagnostic{
+			Message: "EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01 anti-vacuity: no production call to " +
+				"bootstrap.RealBrokerEventTransport() was observed anywhere. eventtransport.Resolve " +
+				"(resolveRabbitMQ) must mint it on the RabbitMQ branch — either the minter was " +
+				"removed/renamed or the scanner regressed; the funnel guards nothing without it.",
+		})
+	}
+
+	Report(t, "EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01", diags)
+}
+
+// TestEventTransportKindMinterFunnel01_RedFixture verifies the scanner fires
+// against a package that mints the real-broker kind outside eventtransport, and
+// does NOT flag the in-memory GREEN control. found==0 means the scanner is
+// fail-open (anti-vacuity for the detector itself).
+func TestEventTransportKindMinterFunnel01_RedFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var found int
+	_ = Run(t, Fixture(FixtureOpts{Tests: false}, []string{eventTransportKindMintFixturePkg}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		// The fixture package path is not cellmodules/eventtransport, so any
+		// RealBrokerEventTransport call there is a violation; InMemoryEventTransport
+		// (the GREEN control) must not be counted.
+		for _, file := range p.Files {
+			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+				if isRealBrokerEventTransportCall(p, call) {
+					found++
+				}
+			})
+		}
+		return nil
+	})
+
+	assert.Equal(t, 1, found,
+		"EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01 RED fixture self-check FAILED: expected exactly 1 "+
+			"violation from eventtransportkindmintfixture (the ForgeRealBroker call; the SafeInMemory "+
+			"InMemoryEventTransport control must NOT be flagged); got %d. found==0 means the scanner is "+
+			"fail-open — check ResolvePackageRef resolves under the archtest_fixture tag.", found)
+}

--- a/tools/archtest/event_transport_kind_mint_caller_test.go
+++ b/tools/archtest/event_transport_kind_mint_caller_test.go
@@ -47,16 +47,22 @@
 //
 // # Detection is type-aware (not string scanning)
 //
-// ResolvePackageRef resolves call.Fun to runtime/bootstrap.RealBrokerEventTransport,
-// alias- and dot-import-proof. No const-evaluation is needed (the callee identity
-// alone is the trip).
+// The scan visits every ast.SelectorExpr and resolves it via ResolvePackageRef to
+// runtime/bootstrap.RealBrokerEventTransport (alias- and dot-import-proof). It is a
+// SelectorExpr-level (reference) scan, NOT a CallExpr.Fun-only scan, so it catches
+// both a direct call (bootstrap.RealBrokerEventTransport()) AND a function-value
+// reference (f := bootstrap.RealBrokerEventTransport) — the latter would evade a
+// CallExpr.Fun scan because the resulting call's Fun is a local ident (#2215 F1).
+// No const-evaluation is needed (the referenced symbol's identity alone is the trip).
 //
 // # Tool blind spots (charter §"强制盲区自检")
 //
 //  1. A real-broker kind laundered through a function value
-//     (f := bootstrap.RealBrokerEventTransport; f()) is still a SelectorExpr the
-//     ResolvePackageRef walk resolves, so it is caught. A kind returned by a
-//     wrapper that itself calls the minter is caught at the wrapper's call.
+//     (f := bootstrap.RealBrokerEventTransport; f()) IS caught: the assignment's
+//     RHS is the SelectorExpr bootstrap.RealBrokerEventTransport, which the
+//     SelectorExpr-level scan resolves directly (regression-tested by the fixture's
+//     ForgeViaFuncValue RED case). A kind returned by a wrapper that itself
+//     references the minter is caught at the wrapper's reference.
 //  2. _test.go files are out of scope (Production scope, Tests:false): test
 //     helpers may mint a real-broker kind to exercise the gate. That is the same
 //     posture as DEVICE-PRINCIPAL-MINT-CALLER-01's test exemption — a sealed value
@@ -87,10 +93,15 @@ const eventTransportKindMinterPkgPath = PlatformModulePath + "/cellmodules/event
 // the reverse self-check.
 const eventTransportKindMintFixturePkg = "./tools/archtest/internal/eventtransportkindmintfixture"
 
-// isRealBrokerEventTransportCall reports whether call invokes
+// isRealBrokerEventTransportRef reports whether sel references
 // bootstrap.RealBrokerEventTransport (alias/dot-import-proof via ResolvePackageRef).
-func isRealBrokerEventTransportCall(p *Pass, call *ast.CallExpr) bool {
-	pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, call.Fun)
+// Resolving the SelectorExpr (not a CallExpr.Fun) catches BOTH a direct call
+// (bootstrap.RealBrokerEventTransport()) and a function-value reference
+// (f := bootstrap.RealBrokerEventTransport; f()) — the latter would evade a
+// CallExpr.Fun-only scan because the call's Fun is then a local ident, not the
+// package selector (#2215 F1).
+func isRealBrokerEventTransportRef(p *Pass, sel *ast.SelectorExpr) bool {
+	pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, sel)
 	return ok && pkgPath == bootstrapPkgPath && name == eventTransportKindMinterName
 }
 
@@ -112,8 +123,8 @@ func TestEventTransportKindMinterFunnel01(t *testing.T) {
 		var d []Diagnostic
 		for _, file := range p.Files {
 			rel := p.Rel(file)
-			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-				if !isRealBrokerEventTransportCall(p, call) {
+			EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+				if !isRealBrokerEventTransportRef(p, sel) {
 					return
 				}
 				observed = true
@@ -121,19 +132,19 @@ func TestEventTransportKindMinterFunnel01(t *testing.T) {
 					observedInFunnel = true
 					return // eventtransport.Resolve is the sanctioned minter
 				}
-				pos := p.Fset.Position(call.Pos())
+				pos := p.Fset.Position(sel.Pos())
 				d = append(d, Diagnostic{
 					Rel:  rel,
 					Line: pos.Line,
 					Message: fmt.Sprintf(
-						"EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01: %s calls bootstrap.RealBrokerEventTransport() "+
-							"outside the sole sanctioned minter cellmodules/eventtransport.Resolve. A real-broker "+
-							"EventTransportKind must be minted only where the RabbitMQ transport is actually "+
-							"constructed (resolveRabbitMQ); minting it elsewhere hands the phase0 split-topology gate "+
-							"(validateSplitTopologyBroker) a \"real broker\" claim that may not be backed by one. "+
-							"Thread eventtransport.Resolve's Transport.Kind via bootstrap.WithEventTransportKind "+
-							"instead; or, if this is a genuinely new sanctioned minter, widen the funnel allowlist "+
-							"with a rationale.",
+						"EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01: %s references bootstrap.RealBrokerEventTransport "+
+							"(direct call OR function-value reference) outside the sole sanctioned minter "+
+							"cellmodules/eventtransport.Resolve. A real-broker EventTransportKind must be minted only "+
+							"where the RabbitMQ transport is actually constructed (resolveRabbitMQ); minting it "+
+							"elsewhere hands the phase0 split-topology gate (validateSplitTopologyBroker) a \"real "+
+							"broker\" claim that may not be backed by one. Thread eventtransport.Resolve's Transport.Kind "+
+							"via bootstrap.WithEventTransportKind instead; or, if this is a genuinely new sanctioned "+
+							"minter, widen the funnel allowlist with a rationale.",
 						rel),
 				})
 			})
@@ -170,9 +181,12 @@ func TestEventTransportKindMinterFunnel01(t *testing.T) {
 }
 
 // TestEventTransportKindMinterFunnel01_RedFixture verifies the scanner fires
-// against a package that mints the real-broker kind outside eventtransport, and
-// does NOT flag the in-memory GREEN control. found==0 means the scanner is
-// fail-open (anti-vacuity for the detector itself).
+// against a package that references the real-broker minter outside eventtransport
+// — BOTH as a direct call (ForgeRealBroker) AND as a function-value reference
+// (ForgeViaFuncValue, the #2215 F1 regression case) — and does NOT flag the
+// in-memory GREEN control. found==0 means the scanner is fail-open (anti-vacuity
+// for the detector itself); found==1 would mean the function-value reference
+// still evades (the F1 regression).
 func TestEventTransportKindMinterFunnel01_RedFixture(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
@@ -185,11 +199,11 @@ func TestEventTransportKindMinterFunnel01_RedFixture(t *testing.T) {
 			return nil
 		}
 		// The fixture package path is not cellmodules/eventtransport, so any
-		// RealBrokerEventTransport call there is a violation; InMemoryEventTransport
+		// RealBrokerEventTransport reference there is a violation; InMemoryEventTransport
 		// (the GREEN control) must not be counted.
 		for _, file := range p.Files {
-			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-				if isRealBrokerEventTransportCall(p, call) {
+			EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+				if isRealBrokerEventTransportRef(p, sel) {
 					found++
 				}
 			})
@@ -197,9 +211,11 @@ func TestEventTransportKindMinterFunnel01_RedFixture(t *testing.T) {
 		return nil
 	})
 
-	assert.Equal(t, 1, found,
-		"EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01 RED fixture self-check FAILED: expected exactly 1 "+
-			"violation from eventtransportkindmintfixture (the ForgeRealBroker call; the SafeInMemory "+
-			"InMemoryEventTransport control must NOT be flagged); got %d. found==0 means the scanner is "+
-			"fail-open — check ResolvePackageRef resolves under the archtest_fixture tag.", found)
+	assert.Equal(t, 2, found,
+		"EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01 RED fixture self-check FAILED: expected exactly 2 "+
+			"violations from eventtransportkindmintfixture (ForgeRealBroker's direct call + "+
+			"ForgeViaFuncValue's function-value reference; the SafeInMemory InMemoryEventTransport "+
+			"control must NOT be flagged); got %d. found==1 means a function-value reference still "+
+			"evades the scan (F1 regression); found==0 means the scanner is fail-open — check "+
+			"ResolvePackageRef resolves SelectorExpr under the archtest_fixture tag.", found)
 }

--- a/tools/archtest/internal/eventtransportkindmintfixture/fixture.go
+++ b/tools/archtest/internal/eventtransportkindmintfixture/fixture.go
@@ -3,12 +3,14 @@
 // Package eventtransportkindmintfixture is the RED fixture for
 // EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01.
 //
-// It mints the real-broker EventTransportKind via bootstrap.RealBrokerEventTransport()
-// from OUTSIDE cellmodules/eventtransport — the sole sanctioned minter. That is
-// the forge the funnel must flag: a composition root (or any package) that hands
-// the phase0 split-topology gate a "real broker" claim without going through
-// eventtransport.Resolve, which mints it only when it actually constructs the
-// RabbitMQ transport (#2211).
+// It references the real-broker minter bootstrap.RealBrokerEventTransport from
+// OUTSIDE cellmodules/eventtransport — the sole sanctioned minter — two ways:
+// a direct call (ForgeRealBroker) and a function-value reference
+// (ForgeViaFuncValue, the #2215 F1 regression case that a CallExpr.Fun-only scan
+// would miss). Both are the forge the funnel must flag: a composition root (or any
+// package) that hands the phase0 split-topology gate a "real broker" claim without
+// going through eventtransport.Resolve, which mints it only when it actually
+// constructs the RabbitMQ transport (#2211).
 //
 // InMemoryEventTransport() is the GREEN control: it is the safe direction (a
 // split topology carrying it is rejected by the gate), so the scanner must NOT
@@ -19,10 +21,21 @@ package eventtransportkindmintfixture
 
 import "github.com/ghbvf/gocell/framework/runtime/bootstrap"
 
-// ForgeRealBroker mints the real-broker kind outside eventtransport — the
-// violation the funnel must catch.
+// ForgeRealBroker mints the real-broker kind outside eventtransport via a direct
+// call — the violation the funnel must catch.
 func ForgeRealBroker() bootstrap.EventTransportKind {
 	return bootstrap.RealBrokerEventTransport()
+}
+
+// ForgeViaFuncValue launders the minter through a function value before calling
+// it (#2215 F1): the call expression's Fun is the local `mint`, so a
+// CallExpr.Fun-only scan would MISS this. The funnel's SelectorExpr-level scan
+// resolves the `bootstrap.RealBrokerEventTransport` reference on the assignment
+// RHS, so it is still flagged. This is the regression guard for the func-value
+// blind spot.
+func ForgeViaFuncValue() bootstrap.EventTransportKind {
+	mint := bootstrap.RealBrokerEventTransport
+	return mint()
 }
 
 // SafeInMemory mints the in-memory kind — the GREEN control the scanner must

--- a/tools/archtest/internal/eventtransportkindmintfixture/fixture.go
+++ b/tools/archtest/internal/eventtransportkindmintfixture/fixture.go
@@ -1,0 +1,32 @@
+//go:build archtest_fixture
+
+// Package eventtransportkindmintfixture is the RED fixture for
+// EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01.
+//
+// It mints the real-broker EventTransportKind via bootstrap.RealBrokerEventTransport()
+// from OUTSIDE cellmodules/eventtransport — the sole sanctioned minter. That is
+// the forge the funnel must flag: a composition root (or any package) that hands
+// the phase0 split-topology gate a "real broker" claim without going through
+// eventtransport.Resolve, which mints it only when it actually constructs the
+// RabbitMQ transport (#2211).
+//
+// InMemoryEventTransport() is the GREEN control: it is the safe direction (a
+// split topology carrying it is rejected by the gate), so the scanner must NOT
+// flag it.
+//
+// DO NOT use this package in production code.
+package eventtransportkindmintfixture
+
+import "github.com/ghbvf/gocell/framework/runtime/bootstrap"
+
+// ForgeRealBroker mints the real-broker kind outside eventtransport — the
+// violation the funnel must catch.
+func ForgeRealBroker() bootstrap.EventTransportKind {
+	return bootstrap.RealBrokerEventTransport()
+}
+
+// SafeInMemory mints the in-memory kind — the GREEN control the scanner must
+// leave unflagged.
+func SafeInMemory() bootstrap.EventTransportKind {
+	return bootstrap.InMemoryEventTransport()
+}


### PR DESCRIPTION
## Summary

bootstrap phase0 split-topology broker 闸 `validateSplitTopologyBroker` 的「是否真实 broker」判定，由 `StorageBackend()=="postgres" ∧ non-nil pub/sub` 代理升级为 **sealed `EventTransportKind` 事实**（`eventtransport.Resolve` 唯一产出 real-broker 变体 → composition root 经 `WithEventTransportKind` 透传 → 闸查 `IsRealBroker()`）。

## Why / 背景

#1965（PR #2188）落地的 phase0 broker 闸用 `StorageBackend==postgres ∧ non-nil pub/sub` 判定总线非真实 broker，证明载体偏弱：**「pub/sub 非 nil」≠「真实 broker 已接线」**——`postgres` + 手注入 non-nil in-memory 实例即可绕过（split 拓扑下跑进程内总线、跨进程丢事件）。该闸 godoc 已把本项登记为 follow-up「#1965 review F2」，即 **#2211**。本 PR 把运行时 nil/storage 代理升级为类型系统证明的 sealed 事实（纵深加固；生产可达路径本已被 depguard 关闭）。

## Refs

- Closes #2211
- 共同载体后续复用：#2196（运行时闸 `HasRemoteCells` 粗代理精化 + TOPO-13 broker-backed split 放行）**不在本 PR 范围**——TOPO-12 仍 active（blanket 禁 `topology.remote`），其 trigger 未达（依赖 US4 #1963 / US7 #1967）；本 PR 的 sealed-kind 是 #2196 后续复用的共同载体。
- ADR amendment：`202606131142-1423`（broker 双闸 §214-219 + 威胁矩阵重评）、`202606131500-1940`（`Transport.Kind`）。
- Epic #1423 US3 加固。

## Risk / 兼容性

- **无 wire/contract 影响**：未触 contract schema / event topic / command key / HTTP path / codegen golden（eventtransport 与 bootstrap option 均非 codegen 产物），无 contract-fanout。
- **新增导出符号**（pre-GA，无外部消费方）：`bootstrap.EventTransportKind` / `InMemoryEventTransport()` / `RealBrokerEventTransport()` / `WithEventTransportKind()` / `eventtransport.Transport.Kind`。
- **行为变更仅对 split 拓扑**：colocated 部署（生产现状，TOPO-12 下唯一合法形态）闸不 fire，~15 个 colocated 集成测试不受影响。删除 `StorageBackend()` 近似分支（replace 非 augment，不留双路径）。

## AI-robust 评级（同 PR 自闭环三件套）

| 载体 | 档位 | 证明 |
|------|------|------|
| `EventTransportKind` 值构造 | **Hard** | 全 unexported 字段 → struct-literal 伪造编译错；`EVENT-TRANSPORT-KIND-SEALED-FIELD-FROZEN-01` 字段冻结 |
| 生产端到端「split ⇏ in-mem」 | **Hard** | 既有 `COREBUNDLE-EVENTBUS-FUNNEL-01` depguard（in-mem 总线生产 root import 不可表达） |
| real-broker 仅由 resolver mint | **Medium** | `EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01` caller-funnel（跨模块 `framework`↔`cellmodules` Go 天花板，含 RED fixture + anti-vacuity；无低成本 Hard 路径，不立 issue） |
| 闸运行时比较 | **Medium** | compares two runtime values（Hard 不可达，原 gate godoc 已载） |

## Test plan

- [x] `go build ./...`（framework / cellmodules / cmd/corebundle / examples/ssobff 各模块）本地通过
- [x] `go test`（bootstrap gate/freeze、eventtransport `Transport.Kind`、corebundle/ssobff 单测）本地通过
- [x] `go vet -tags=integration`（corebundle / ssobff / cellmodules）通过（改了导出签名）
- [x] archtest `EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01`（funnel + anti-vacuity + RED fixture）+ sealed-freeze 本地绿
- [x] `golangci-lint run` 0 issues（framework / cellmodules / cmd/corebundle / examples/ssobff / tools[archtest,releasesmoke]）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
