### PR TITLE
fix(auditquery): 空 Payload 5xx + id 过滤器校验夹点 + cursorInvalid 泄漏收敛 [#2199][#1742][#1103]

### DIFF
--- a/adapters/postgres/audit_cross_tenant_store.go
+++ b/adapters/postgres/audit_cross_tenant_store.go
@@ -102,6 +102,9 @@ func (s *AuditCrossTenantStore) QueryCrossTenant(
 		return nil, errcode.New(errcode.KindInternal, errcode.ErrInternal,
 			errMsgCrossTenantObligation)
 	}
+	if err := ledger.ValidateQueryFilters(filters); err != nil {
+		return nil, err
+	}
 	if len(params.Sort) == 0 {
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"audit ledger: cross-tenant query requires a non-empty sort")

--- a/adapters/postgres/audit_ledger_store.go
+++ b/adapters/postgres/audit_ledger_store.go
@@ -477,6 +477,9 @@ func (s *LedgerStore) Query(
 	if err := ledger.ValidateQueryTenant(t); err != nil {
 		return nil, err
 	}
+	if err := ledger.ValidateQueryFilters(filters); err != nil {
+		return nil, err
+	}
 	if err := vis.Validate(); err != nil {
 		return nil, err
 	}

--- a/contracts/http/audit/list/v1/contract.yaml
+++ b/contracts/http/audit/list/v1/contract.yaml
@@ -54,7 +54,7 @@ endpoints:
     responseProjection: true
     responses:
       400:
-        description: "Bad request — invalid query parameter format (e.g. from/to not RFC3339, invalid cursor or limit)"
+        description: "Bad request — invalid query parameter format (e.g. from/to not RFC3339, invalid cursor or limit; actorId/subjectId/traceId contains unsafe characters or exceeds MaxMetadataIDLen; eventType exceeds MaxMetadataIDLen)"
         schemaRef: "../../../../shared/errors/error-response-v1.schema.json"
       401:
         description: "Unauthorized — missing or invalid bearer token"

--- a/corecells/auditcore/slices/auditquery/handler.go
+++ b/corecells/auditcore/slices/auditquery/handler.go
@@ -479,7 +479,7 @@ func toListResponseDataItem(e *ledger.Entry) *auditlist.ResponseDataItem {
 	if !e.OccurredAt.IsZero() {
 		occurredAt = e.OccurredAt.Format(time.RFC3339Nano)
 	}
-	return &auditlist.ResponseDataItem{
+	item := &auditlist.ResponseDataItem{
 		ID:            e.ID,
 		EventID:       e.EventID,
 		EventType:     e.EventType,
@@ -491,8 +491,16 @@ func toListResponseDataItem(e *ledger.Entry) *auditlist.ResponseDataItem {
 		OccurredAt:    occurredAt,
 		Timestamp:     e.Timestamp.Format(time.RFC3339Nano),
 		Scope:         rowScope(e.TenantID),
-		Payload:       json.RawMessage(redaction.RedactPayload(e.Payload)),
 	}
+	// Only set Payload when redacted bytes are non-empty. An empty []byte stored
+	// as json.RawMessage in the any-typed Payload field is non-nil, so ToMap
+	// includes it and json.Marshal fails with "unexpected end of JSON input"
+	// (#2199). Leaving Payload nil means ToMap omits the key entirely via the
+	// `if i.Payload != nil` guard in generated/contracts/http/audit/list/v1/types_gen.go.
+	if raw := redaction.RedactPayload(e.Payload); len(raw) > 0 {
+		item.Payload = json.RawMessage(raw)
+	}
+	return item
 }
 
 // rowScope classifies an audit row relative to the calling tenant for the wire

--- a/corecells/auditcore/slices/auditquery/handler.go
+++ b/corecells/auditcore/slices/auditquery/handler.go
@@ -74,11 +74,18 @@ func auditQueryPolicy(r *http.Request) error {
 // ledger (all actors, or a specific other user). Non-admins and admin-self
 // queries are silent. Factored out of List for cognitive-complexity budget.
 //
+// The logger parameter is the Service's injected *slog.Logger (not the global
+// slog default). Using the injected logger ensures that tests capturing the
+// injected logger can observe — and therefore guard — the CWE-117 ordering
+// invariant (validate before log). Using the global slog default would make
+// the TestHandleQuery_FilterValidation_ValidationBeforeLogging test vacuous:
+// breadcrumbs would go to global slog while the test watches the injected handler.
+//
 // Super-admin access is excluded from this breadcrumb: the mandatory FR-007
 // slog.Error cross-tenant audit is emitted inside p.CrossTenantVisibility on the
 // super-admin path. Emitting a second admin-breadcrumb would be redundant and
 // confusing (a lower-severity Info record for a higher-privilege event).
-func logAdminAuditQuery(ctx context.Context, p *auth.Principal, subject, actorIDFilter string) {
+func logAdminAuditQuery(ctx context.Context, logger *slog.Logger, p *auth.Principal, subject, actorIDFilter string) {
 	if p.HasRole(auth.RoleSuperAdmin) {
 		return // FR-007 audit already emitted inside p.CrossTenantVisibility
 	}
@@ -87,9 +94,9 @@ func logAdminAuditQuery(ctx context.Context, p *auth.Principal, subject, actorID
 	}
 	switch {
 	case actorIDFilter == "":
-		slog.InfoContext(ctx, "audit: admin querying all actors", slog.String("admin", subject))
+		logger.InfoContext(ctx, "audit: admin querying all actors", slog.String("admin", subject))
 	case actorIDFilter != subject:
-		slog.InfoContext(ctx, "audit: admin querying other user",
+		logger.InfoContext(ctx, "audit: admin querying other user",
 			slog.String("admin", subject), slog.String("target_actor", actorIDFilter))
 	}
 }
@@ -197,7 +204,7 @@ func (a ListAdapter) List(ctx context.Context, req *auditlist.Request) (auditlis
 		return nil, err
 	}
 
-	logAdminAuditQuery(ctx, p, subject, req.ActorID)
+	logAdminAuditQuery(ctx, a.S.logger, p, subject, req.ActorID)
 
 	// Column masking (epic #1337 PR-12, FR-016/FR-017): derive the mask obligation
 	// from the row-visibility scope ONCE here — it gates both the query predicates
@@ -380,22 +387,36 @@ func buildAuditFilters(req *auditlist.Request) (ledger.AuditFilters, error) {
 //
 // Empty values are allowed ("no filter"). Violations yield KindInvalid /
 // ErrValidationFailed → HTTP 400 (already declared in contract.yaml).
+//
+// INTENTIONAL TWO-LAYER DESIGN: this function is the wire-boundary gate (layer 1).
+// It runs at the handler before any logging (CWE-117: never log unvalidated input)
+// and returns a client-facing 400. ledger.ValidateQueryFilters is the store-layer
+// defense-in-depth chokepoint (layer 2) shared by all backends including
+// CrossTenantQueryStore, guarding non-handler callers such as internal tooling,
+// direct store access, and cross-tenant read paths. Both layers call the same
+// idutil.SafeID validation and MaxMetadataIDLen cap — they must NOT be merged
+// (the handler layer must stay at the wire boundary; the ledger layer must stay
+// at the store entry). The apparent duplication is load-bearing security layering.
 func validateIDFilters(req *auditlist.Request) error {
 	if err := idutil.SafeID(req.ActorID).Validate(); err != nil {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-			"invalid query parameter: actorId format")
+			"invalid query parameter: actorId format",
+			errcode.WithInternal(errcode.InternalAttr("field", "actorId")))
 	}
 	if err := idutil.SafeID(req.SubjectID).Validate(); err != nil {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-			"invalid query parameter: subjectId format")
+			"invalid query parameter: subjectId format",
+			errcode.WithInternal(errcode.InternalAttr("field", "subjectId")))
 	}
 	if err := idutil.SafeID(req.TraceID).Validate(); err != nil {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-			"invalid query parameter: traceId format")
+			"invalid query parameter: traceId format",
+			errcode.WithInternal(errcode.InternalAttr("field", "traceId")))
 	}
 	if len(req.EventType) > idutil.MaxMetadataIDLen {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-			"invalid query parameter: eventType too long")
+			"invalid query parameter: eventType too long",
+			errcode.WithInternal(errcode.InternalAttr("field", "eventType")))
 	}
 	return nil
 }

--- a/corecells/auditcore/slices/auditquery/handler.go
+++ b/corecells/auditcore/slices/auditquery/handler.go
@@ -10,6 +10,7 @@ import (
 	cell "github.com/ghbvf/gocell/framework/kernel/cell"
 	"github.com/ghbvf/gocell/framework/pkg/authz"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/idutil"
 	"github.com/ghbvf/gocell/framework/pkg/projection"
 	"github.com/ghbvf/gocell/framework/pkg/query"
 	"github.com/ghbvf/gocell/framework/pkg/redaction"
@@ -187,6 +188,15 @@ func (a ListAdapter) List(ctx context.Context, req *auditlist.Request) (auditlis
 	}
 	vis := vr.vis
 
+	// CWE-117 ordering: validate filter inputs BEFORE any logging of request
+	// fields (buildAuditFilters is the wire-boundary gate; logAdminAuditQuery
+	// must not receive unvalidated input — a malformed actorId would otherwise
+	// appear in log records before the 400 is returned).
+	filters, err := buildAuditFilters(req)
+	if err != nil {
+		return nil, err
+	}
+
 	logAdminAuditQuery(ctx, p, subject, req.ActorID)
 
 	// Column masking (epic #1337 PR-12, FR-016/FR-017): derive the mask obligation
@@ -198,11 +208,6 @@ func (a ListAdapter) List(ctx context.Context, req *auditlist.Request) (auditlis
 	// mask (full column view) — same as RowScopeTenant.
 	mask := auditFieldMask(vis.Scope())
 	if err := rejectMaskedFilters(mask, req); err != nil {
-		return nil, err
-	}
-
-	filters, err := buildAuditFilters(req)
-	if err != nil {
 		return nil, err
 	}
 
@@ -323,13 +328,27 @@ func rejectMaskedFilters(mask authz.FieldMask, req *auditlist.Request) error {
 	return nil
 }
 
-// buildAuditFilters parses the request time-range fields and constructs an
+// buildAuditFilters validates and parses the request filter fields into an
 // AuditFilters. Extracted from List to keep cognitive complexity ≤ 15.
+//
+// This is the wire-boundary validation gate (CWE-117 / #1742): it must run
+// BEFORE any logging of req fields. The handler's List function calls this
+// before logAdminAuditQuery so an invalid actorId is never logged.
+//
+// ID fields (actorId, subjectId, traceId): validated via idutil.SafeID.Validate
+// (SafeID charset + MaxMetadataIDLen length cap). Empty is allowed.
+//
+// eventType: length cap only (len > MaxMetadataIDLen). EventType is a dotted
+// label and uses characters outside the SafeID charset (e.g. dots), so only
+// a length cap is enforced here.
 //
 // Inbound from/to use RFC3339Nano (optional sub-second precision) so a caller
 // can round-trip a returned occurredAt/timestamp verbatim as a filter bound
 // without truncation.
 func buildAuditFilters(req *auditlist.Request) (ledger.AuditFilters, error) {
+	if err := validateIDFilters(req); err != nil {
+		return ledger.AuditFilters{}, err
+	}
 	filters := ledger.AuditFilters{
 		EventType: req.EventType,
 		ActorID:   req.ActorID,
@@ -353,6 +372,32 @@ func buildAuditFilters(req *auditlist.Request) (ledger.AuditFilters, error) {
 		filters.To = t
 	}
 	return filters, nil
+}
+
+// validateIDFilters validates the ID-typed query filter parameters from the
+// wire request before any logging or store access. Extracted from buildAuditFilters
+// to keep cognitive complexity ≤ 15.
+//
+// Empty values are allowed ("no filter"). Violations yield KindInvalid /
+// ErrValidationFailed → HTTP 400 (already declared in contract.yaml).
+func validateIDFilters(req *auditlist.Request) error {
+	if err := idutil.SafeID(req.ActorID).Validate(); err != nil {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"invalid query parameter: actorId format")
+	}
+	if err := idutil.SafeID(req.SubjectID).Validate(); err != nil {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"invalid query parameter: subjectId format")
+	}
+	if err := idutil.SafeID(req.TraceID).Validate(); err != nil {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"invalid query parameter: traceId format")
+	}
+	if len(req.EventType) > idutil.MaxMetadataIDLen {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"invalid query parameter: eventType too long")
+	}
+	return nil
 }
 
 // requireAuditReadForCrossTenant enforces the audit:read PDP check unconditionally

--- a/corecells/auditcore/slices/auditquery/handler_test.go
+++ b/corecells/auditcore/slices/auditquery/handler_test.go
@@ -2159,3 +2159,32 @@ func TestHandleQuery_FilterValidation_ValidationBeforeLogging(t *testing.T) {
 		})
 	}
 }
+
+// TestList_NilLogger_AdminQuery_NoPanic is the regression guard for the codex F1
+// finding: the admin audit-query breadcrumb (logAdminAuditQuery) switched from the
+// nil-safe package-level slog.InfoContext to an injected logger.InfoContext, so a
+// Service constructed with a nil logger would nil-panic on the admin path. NewService
+// now normalizes a nil logger to slog.Default(), so the dereference is safe.
+//
+// The admin-with-empty-actorId case is the exact branch that panicked: it hits
+// `case actorIDFilter == "":` → logger.InfoContext("audit: admin querying all actors").
+func TestList_NilLogger_AdminQuery_NoPanic(t *testing.T) {
+	store := newHandlerStore(t)
+
+	// nil logger: pre-fix this nil-panics inside logAdminAuditQuery.InfoContext.
+	svc, err := NewService(store, testCodec(), nil, outbox.DemoCellTxManager(), query.RunModeProd)
+	require.NoError(t, err)
+	mux := newHandlerMux(svc)
+
+	// Admin with NO actorId filter → logAdminAuditQuery fires the "querying all
+	// actors" breadcrumb, dereferencing the (formerly nil) injected logger.
+	ctx := auditTestCtx("admin-user", []string{"admin"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries", nil)
+	req = req.WithContext(ctx)
+
+	require.NotPanics(t, func() { mux.ServeHTTP(w, req) },
+		"admin audit query must not panic when the Service was built with a nil logger")
+	assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+}

--- a/corecells/auditcore/slices/auditquery/handler_test.go
+++ b/corecells/auditcore/slices/auditquery/handler_test.go
@@ -1967,3 +1967,195 @@ func TestHandleQuery_EmptyPayload_Returns200(t *testing.T) {
 		}
 	}
 }
+
+// --- Issue #1742: actorId/subjectId/traceId/eventType input validation ---
+
+// maxIDLen matches idutil.MaxMetadataIDLen (256). Redeclared here as a
+// test-local const rather than importing idutil so tests stay in the auditquery
+// package and match the "mock in same-package test file" convention. The actual
+// enforcement uses idutil.SafeID(x).Validate() whose cap is MaxMetadataIDLen.
+const testMaxIDLen = 256
+
+// TestHandleQuery_FilterValidation_IDFormats is a table-driven test that verifies
+// the wire-boundary validation introduced for #1742 (CWE-117 log injection + SQL
+// predicate hygiene). Invalid actorId/subjectId/traceId (too long or unsafe chars)
+// must return 400 BEFORE any logging of the untrusted input occurs. Valid inputs
+// must pass through and produce 200.
+//
+// Critically: the validation MUST run BEFORE logAdminAuditQuery logs req.ActorID
+// (CWE-117 — never log unvalidated input). The ordering is: validate → log →
+// query. A 400 for an invalid filter means the log never fires.
+func TestHandleQuery_FilterValidation_IDFormats(t *testing.T) {
+	store := newHandlerStore(t)
+	svc, err := NewService(store, testCodec(), slog.Default(), outbox.DemoCellTxManager(), query.RunModeProd)
+	require.NoError(t, err)
+	mux := newHandlerMux(svc)
+
+	// Seed one entry so a valid query returns 200 with data.
+	base := time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, store.Append(context.Background(), &ledger.Entry{
+		ID: "fv-1", EventID: "evt-fv-1", EventType: "event.test.v1",
+		ActorID: "admin-user", Timestamp: base, Payload: []byte("{}"),
+	}))
+
+	tooLong := func(n int) string {
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = 'a'
+		}
+		return string(b)
+	}
+
+	tests := []struct {
+		name       string
+		param      string // query param to set
+		value      string
+		wantStatus int
+		wantCode   string // error code in JSON when wantStatus != 200
+	}{
+		// --- actorId ---
+		{
+			name:  "actorId too long",
+			param: "actorId", value: tooLong(testMaxIDLen + 1),
+			wantStatus: http.StatusBadRequest, wantCode: "ERR_VALIDATION_FAILED",
+		},
+		// Space is outside the SafeID charset (ASCII letters, digits, ._:/-).
+		{
+			name:  "actorId unsafe chars (space)",
+			param: "actorId", value: "usr injection",
+			wantStatus: http.StatusBadRequest, wantCode: "ERR_VALIDATION_FAILED",
+		},
+		// '@' is outside the SafeID charset.
+		{
+			name:  "actorId unsafe chars (at-sign)",
+			param: "actorId", value: "usr@injection",
+			wantStatus: http.StatusBadRequest, wantCode: "ERR_VALIDATION_FAILED",
+		},
+		{
+			name:  "actorId valid (self)",
+			param: "actorId", value: "admin-user",
+			wantStatus: http.StatusOK,
+		},
+		{
+			// Exactly at MaxMetadataIDLen (256) is allowed; one over is rejected.
+			name:  "actorId exactly at max len is valid",
+			param: "actorId", value: tooLong(testMaxIDLen),
+			wantStatus: http.StatusOK,
+		},
+		// --- subjectId ---
+		{
+			name:  "subjectId too long",
+			param: "subjectId", value: tooLong(testMaxIDLen + 1),
+			wantStatus: http.StatusBadRequest, wantCode: "ERR_VALIDATION_FAILED",
+		},
+		{
+			name:  "subjectId unsafe chars (bracket)",
+			param: "subjectId", value: "subject[injection]",
+			wantStatus: http.StatusBadRequest, wantCode: "ERR_VALIDATION_FAILED",
+		},
+		{
+			name:  "subjectId valid",
+			param: "subjectId", value: "victim-user",
+			wantStatus: http.StatusOK,
+		},
+		// --- traceId ---
+		{
+			name:  "traceId too long",
+			param: "traceId", value: tooLong(testMaxIDLen + 1),
+			wantStatus: http.StatusBadRequest, wantCode: "ERR_VALIDATION_FAILED",
+		},
+		{
+			name:  "traceId unsafe chars (semicolon)",
+			param: "traceId", value: "trace;injection",
+			wantStatus: http.StatusBadRequest, wantCode: "ERR_VALIDATION_FAILED",
+		},
+		{
+			name:  "traceId valid",
+			param: "traceId", value: "trace-abc-123",
+			wantStatus: http.StatusOK,
+		},
+		// --- eventType: length cap only (dotted label, not SafeID charset) ---
+		{
+			name:  "eventType too long (length cap)",
+			param: "eventType", value: tooLong(testMaxIDLen + 1),
+			wantStatus: http.StatusBadRequest, wantCode: "ERR_VALIDATION_FAILED",
+		},
+		{
+			name:  "eventType valid dotted label",
+			param: "eventType", value: "some.event.v1",
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Build the request using net/url.Values to correctly percent-encode
+			// special characters (spaces, brackets, etc.) in query param values,
+			// avoiding httptest.NewRequest panicking on raw control characters.
+			// For non-self actorId we need an admin with allow-all authorizer.
+			ctx := auditTestCtx("admin-user", []string{"admin"})
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries", nil)
+			// Set RawQuery after construction so the value is properly encoded.
+			qv := req.URL.Query()
+			qv.Set(tc.param, tc.value)
+			req.URL.RawQuery = qv.Encode()
+			req = req.WithContext(ctx)
+			mux.ServeHTTP(w, req)
+
+			assert.Equal(t, tc.wantStatus, w.Code, "case %q body=%s", tc.name, w.Body.String())
+			if tc.wantCode != "" {
+				var resp struct {
+					Error struct {
+						Code string `json:"code"`
+					} `json:"error"`
+				}
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+				assert.Equal(t, tc.wantCode, resp.Error.Code, "case %q", tc.name)
+			}
+		})
+	}
+}
+
+// TestHandleQuery_FilterValidation_ValidationBeforeLogging asserts the CWE-117
+// ordering: when actorId is invalid, the handler must return 400 WITHOUT logging
+// the untrusted actorId value. This is a smoke test for the correct call order
+// (validate → log, never log → validate).
+func TestHandleQuery_FilterValidation_ValidationBeforeLogging(t *testing.T) {
+	store := newHandlerStore(t)
+
+	capture := &testCaptureHandler{}
+	log := slog.New(capture)
+
+	svc, err := NewService(store, testCodec(), log, outbox.DemoCellTxManager(), query.RunModeProd)
+	require.NoError(t, err)
+	mux := newHandlerMux(svc)
+
+	// Use a malformed actorId (unsafe chars — '@' is outside SafeID charset)
+	// so validation returns 400 before logging.
+	malformedActor := "actor@injection"
+
+	// Admin context so logAdminAuditQuery would fire IF we got past validation.
+	ctx := auditTestCtx("admin-user", []string{"admin"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries", nil)
+	qv := req.URL.Query()
+	qv.Set("actorId", malformedActor)
+	req.URL.RawQuery = qv.Encode()
+	req = req.WithContext(ctx)
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "invalid actorId must return 400; body=%s", w.Body.String())
+
+	// No log record should contain the malformed actor value — if validation fired
+	// before logging, logAdminAuditQuery was never called with the bad input.
+	for _, rec := range capture.records {
+		rec.Attrs(func(a slog.Attr) bool {
+			assert.NotContains(t, a.Value.String(), malformedActor,
+				"malformed actorId must not appear in any log record (CWE-117)")
+			return true
+		})
+	}
+}

--- a/corecells/auditcore/slices/auditquery/handler_test.go
+++ b/corecells/auditcore/slices/auditquery/handler_test.go
@@ -1901,3 +1901,69 @@ func TestHandleQuery_SuperAdmin_CrossTenant_FiltersPassthrough(t *testing.T) {
 	wantTo := "2026-06-30T23:59:59Z"
 	assert.Equal(t, wantTo, filters.To.UTC().Format(time.RFC3339), "to must reach the cross-tenant store")
 }
+
+// --- Issue #2199: empty Payload must not cause 5xx ---
+
+// TestHandleQuery_EmptyPayload_Returns200 is the regression guard for #2199:
+// an audit entry with nil/empty Payload must not cause 5xx when ToMap tries to
+// marshal an empty json.RawMessage. The fix ensures toListResponseDataItem leaves
+// the Payload field nil when the redacted bytes are empty, so ToMap omits the key
+// and json.Marshal never sees an empty RawMessage.
+//
+// Additionally, items WITH a non-empty payload must still render correctly in the
+// same response.
+func TestHandleQuery_EmptyPayload_Returns200(t *testing.T) {
+	store := newHandlerStore(t)
+	svc, err := NewService(store, testCodec(), slog.Default(), outbox.DemoCellTxManager(), query.RunModeProd)
+	require.NoError(t, err)
+	mux := newHandlerMux(svc)
+
+	base := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	// Entry with nil payload (pre-populated rows or framework events may have none).
+	require.NoError(t, store.Append(context.Background(), &ledger.Entry{
+		ID: "ep-nil-1", EventID: "evt-ep-nil-1", EventType: "event.test.v1",
+		ActorID:   "usr-ep",
+		Timestamp: base,
+		Payload:   nil, // empty / absent payload
+	}))
+	// Entry with empty-slice payload.
+	require.NoError(t, store.Append(context.Background(), &ledger.Entry{
+		ID: "ep-nil-2", EventID: "evt-ep-nil-2", EventType: "event.test.v1",
+		ActorID:   "usr-ep",
+		Timestamp: base.Add(time.Minute),
+		Payload:   []byte{}, // zero-length payload
+	}))
+	// Entry with a non-empty payload — must still render the payload key.
+	require.NoError(t, store.Append(context.Background(), &ledger.Entry{
+		ID: "ep-data-3", EventID: "evt-ep-data-3", EventType: "event.test.v1",
+		ActorID:   "usr-ep",
+		Timestamp: base.Add(seedThirdEntryOffset),
+		Payload:   []byte(`{"k":"v"}`),
+	}))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/entries?actorId=usr-ep", nil)
+	req = req.WithContext(auditTestCtx("usr-ep", nil))
+	mux.ServeHTTP(w, req)
+
+	require.Equalf(t, http.StatusOK, w.Code, "#2199: empty-payload entry must not cause 5xx; body=%s", w.Body.String())
+
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Data, 3, "all three entries must be present")
+
+	for _, item := range resp.Data {
+		eventID, _ := item["eventId"].(string)
+		if eventID == "evt-ep-data-3" {
+			// Non-empty payload must appear as a valid JSON value.
+			_, hasPayload := item["payload"]
+			assert.True(t, hasPayload, "item with non-empty payload must include 'payload' key")
+		} else {
+			// Empty-payload items must NOT include the 'payload' key (omit nil).
+			_, hasPayload := item["payload"]
+			assert.False(t, hasPayload, "item %s with empty payload must NOT include 'payload' key", eventID)
+		}
+	}
+}

--- a/corecells/auditcore/slices/auditquery/service.go
+++ b/corecells/auditcore/slices/auditquery/service.go
@@ -74,11 +74,22 @@ func WithCrossTenantStore(s ledger.CrossTenantQueryStore) ServiceOption {
 // txRunner for the tenant-scoped RunInTx that activates FORCE RLS on reads.
 // opts are optional ServiceOption values; currently WithCrossTenantStore is the
 // only supported option.
+//
+// logger is an OPTIONAL dependency normalized to slog.Default() when nil — the
+// "optional dependency gets a default in the constructor" pattern (go-standards.md).
+// This is the single chokepoint every s.logger consumer (LogCursorError and the
+// admin-breadcrumb logAdminAuditQuery) flows through, so a nil logger can never be
+// dereferenced downstream (e.g. logAdminAuditQuery's logger.InfoContext). Mirrors
+// log/slog's top-level Info/InfoContext, which fall back to the default logger
+// rather than requiring callers to hold a non-nil *Logger.
 func NewService(
 	store ledger.QueryStore, codec *query.CursorCodec, logger *slog.Logger,
 	txRunner persistence.CellTxManager, runMode query.RunMode,
 	opts ...ServiceOption,
 ) (*Service, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	s := &Service{store: store, codec: codec, txRunner: txRunner, logger: logger, runMode: runMode}
 	for _, o := range opts {
 		o(s)

--- a/corecells/auditcore/slices/auditquery/service_test.go
+++ b/corecells/auditcore/slices/auditquery/service_test.go
@@ -402,9 +402,11 @@ func TestService_Query_CursorContextMismatch(t *testing.T) {
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
-	reasonAttr, ok := ecErr.FindAttr("reason")
-	require.True(t, ok)
-	assert.Equal(t, "query context mismatch", reasonAttr.Value().(string))
+	// Regression guard (#1103): reason must not be in public Details.
+	_, ok := ecErr.FindAttr("reason")
+	assert.False(t, ok, "reason must not appear in public Details (wire-leaking regression #1103)")
+	assert.Contains(t, ecErr.Error(), "query context mismatch",
+		"reason must still surface in Error() for server-side diagnostics")
 }
 
 // TestService_Query_CursorContextMismatch_SubjectID is the subjectId sibling of
@@ -441,9 +443,11 @@ func TestService_Query_CursorContextMismatch_SubjectID(t *testing.T) {
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
-	reasonAttr, ok := ecErr.FindAttr("reason")
-	require.True(t, ok)
-	assert.Equal(t, "query context mismatch", reasonAttr.Value().(string))
+	// Regression guard (#1103): reason must not be in public Details.
+	_, ok := ecErr.FindAttr("reason")
+	assert.False(t, ok, "reason must not appear in public Details (wire-leaking regression #1103)")
+	assert.Contains(t, ecErr.Error(), "query context mismatch",
+		"reason must still surface in Error() for server-side diagnostics")
 }
 
 // TestService_Query_CursorContextMismatch_TraceID is the traceId sibling of
@@ -481,9 +485,11 @@ func TestService_Query_CursorContextMismatch_TraceID(t *testing.T) {
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
-	reasonAttr, ok := ecErr.FindAttr("reason")
-	require.True(t, ok)
-	assert.Equal(t, "query context mismatch", reasonAttr.Value().(string))
+	// Regression guard (#1103): reason must not be in public Details.
+	_, ok := ecErr.FindAttr("reason")
+	assert.False(t, ok, "reason must not appear in public Details (wire-leaking regression #1103)")
+	assert.Contains(t, ecErr.Error(), "query context mismatch",
+		"reason must still surface in Error() for server-side diagnostics")
 }
 
 func newTestServiceWithLogBuf() (*Service, *ledger.MemStore, *bytes.Buffer) {
@@ -618,9 +624,11 @@ func TestService_Query_CursorContextMismatch_TenantID(t *testing.T) {
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
-	reasonAttr, ok := ecErr.FindAttr("reason")
-	require.True(t, ok)
-	assert.Equal(t, "query context mismatch", reasonAttr.Value().(string))
+	// Regression guard (#1103): reason must not be in public Details.
+	_, ok := ecErr.FindAttr("reason")
+	assert.False(t, ok, "reason must not appear in public Details (wire-leaking regression #1103)")
+	assert.Contains(t, ecErr.Error(), "query context mismatch",
+		"reason must still surface in Error() for server-side diagnostics")
 }
 
 // TestService_Query_CursorContextMismatch_RowScope is the row-visibility sibling
@@ -655,9 +663,11 @@ func TestService_Query_CursorContextMismatch_RowScope(t *testing.T) {
 		var ecErr *errcode.Error
 		require.ErrorAs(t, err, &ecErr)
 		assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
-		reasonAttr, ok := ecErr.FindAttr("reason")
-		require.True(t, ok)
-		assert.Equal(t, "query context mismatch", reasonAttr.Value().(string))
+		// Regression guard (#1103): reason must not be in public Details.
+		_, ok := ecErr.FindAttr("reason")
+		assert.False(t, ok, "reason must not appear in public Details (wire-leaking regression #1103)")
+		assert.Contains(t, ecErr.Error(), "query context mismatch",
+			"reason must still surface in Error() for server-side diagnostics")
 	}
 
 	t.Run("scope change self→tenant", func(t *testing.T) {

--- a/corecells/configcore/internal/configreader/service_test.go
+++ b/corecells/configcore/internal/configreader/service_test.go
@@ -193,9 +193,12 @@ func TestService_List_ScopeMismatch(t *testing.T) {
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
-	reasonAttr, ok := ecErr.FindAttr("reason")
-	require.True(t, ok)
-	assert.Equal(t, "sort scope mismatch", reasonAttr.Value().(string))
+	// Regression guard (#1103): reason must not be in public Details.
+	_, ok := ecErr.FindAttr("reason")
+	assert.False(t, ok, "reason must not appear in public Details (wire-leaking regression #1103)")
+	// Reason must still surface in internal Error() string.
+	assert.Contains(t, ecErr.Error(), "sort scope mismatch",
+		"reason must still surface in Error() for server-side diagnostics")
 }
 
 func TestService_List_ContextMismatch(t *testing.T) {
@@ -214,9 +217,12 @@ func TestService_List_ContextMismatch(t *testing.T) {
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
-	reasonAttr, ok := ecErr.FindAttr("reason")
-	require.True(t, ok)
-	assert.Equal(t, "query context mismatch", reasonAttr.Value().(string))
+	// Regression guard (#1103): reason must not be in public Details.
+	_, ok := ecErr.FindAttr("reason")
+	assert.False(t, ok, "reason must not appear in public Details (wire-leaking regression #1103)")
+	// Reason must still surface in internal Error() string.
+	assert.Contains(t, ecErr.Error(), "query context mismatch",
+		"reason must still surface in Error() for server-side diagnostics")
 }
 
 func TestService_List_LastPage(t *testing.T) {

--- a/corecells/configcore/slices/featureflag/service_test.go
+++ b/corecells/configcore/slices/featureflag/service_test.go
@@ -166,9 +166,12 @@ func TestService_List_ScopeMismatch(t *testing.T) {
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
-	reasonAttr, ok := ecErr.FindAttr("reason")
-	require.True(t, ok)
-	assert.Equal(t, "sort scope mismatch", reasonAttr.Value().(string))
+	// Regression guard (#1103): reason must not be in public Details.
+	_, ok := ecErr.FindAttr("reason")
+	assert.False(t, ok, "reason must not appear in public Details (wire-leaking regression #1103)")
+	// Reason must still surface in internal Error() string.
+	assert.Contains(t, ecErr.Error(), "sort scope mismatch",
+		"reason must still surface in Error() for server-side diagnostics")
 }
 
 func TestService_List_ContextMismatch(t *testing.T) {
@@ -190,9 +193,12 @@ func TestService_List_ContextMismatch(t *testing.T) {
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
-	reasonAttr, ok := ecErr.FindAttr("reason")
-	require.True(t, ok)
-	assert.Equal(t, "query context mismatch", reasonAttr.Value().(string))
+	// Regression guard (#1103): reason must not be in public Details.
+	_, ok := ecErr.FindAttr("reason")
+	assert.False(t, ok, "reason must not appear in public Details (wire-leaking regression #1103)")
+	// Reason must still surface in internal Error() string.
+	assert.Contains(t, ecErr.Error(), "query context mismatch",
+		"reason must still surface in Error() for server-side diagnostics")
 }
 
 func TestService_List_LastPage(t *testing.T) {

--- a/examples/iotdevice/cells/devicecell/internal/devicecmd/service_test.go
+++ b/examples/iotdevice/cells/devicecell/internal/devicecmd/service_test.go
@@ -532,10 +532,10 @@ func TestService_ScanActive_CursorDeviceMismatch(t *testing.T) {
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
-	reasonAttr, ok := ecErr.FindAttr("reason")
-	require.True(t, ok)
-	got, _ := reasonAttr.Value().(string)
-	assert.Equal(t, "query context mismatch", got)
+	_, ok := ecErr.FindAttr("reason")
+	assert.False(t, ok, "reason must not leak via public details (#1103)")
+	assert.Contains(t, ecErr.Error(), "query context mismatch",
+		"reason should remain on the internal/server-log surface (#1103)")
 }
 
 func TestService_Enqueue_ThenDequeue_Report_ThenAck(t *testing.T) {

--- a/examples/todoorder/cells/ordercell/slices/orderquery/service_test.go
+++ b/examples/todoorder/cells/ordercell/slices/orderquery/service_test.go
@@ -251,10 +251,10 @@ func TestService_List_ScopeMismatch(t *testing.T) {
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
-	reasonAttr, ok := ecErr.FindAttr("reason")
-	require.True(t, ok)
-	got, _ := reasonAttr.Value().(string)
-	assert.Equal(t, "sort scope mismatch", got)
+	_, ok := ecErr.FindAttr("reason")
+	assert.False(t, ok, "reason must not leak via public details (#1103)")
+	assert.Contains(t, ecErr.Error(), "sort scope mismatch",
+		"reason should remain on the internal/server-log surface (#1103)")
 }
 
 func TestService_List_ContextMismatch(t *testing.T) {
@@ -278,8 +278,8 @@ func TestService_List_ContextMismatch(t *testing.T) {
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
-	reasonAttr, ok := ecErr.FindAttr("reason")
-	require.True(t, ok)
-	got, _ := reasonAttr.Value().(string)
-	assert.Equal(t, "query context mismatch", got)
+	_, ok := ecErr.FindAttr("reason")
+	assert.False(t, ok, "reason must not leak via public details (#1103)")
+	assert.Contains(t, ecErr.Error(), "query context mismatch",
+		"reason should remain on the internal/server-log surface (#1103)")
 }

--- a/framework/pkg/pgquery/keyset.go
+++ b/framework/pkg/pgquery/keyset.go
@@ -156,6 +156,5 @@ func cursorInvalid(reason string) error {
 	return errcode.New(errcode.KindInvalid, errcode.ErrCursorInvalid,
 		"invalid cursor; restart from first page (client should discard stored cursor)",
 		errcode.WithInternal(errcode.InternalAttr("_", reason)),
-		errcode.WithDetails(errcode.PublicString("reason", reason)),
 	)
 }

--- a/framework/pkg/pgquery/keyset_test.go
+++ b/framework/pkg/pgquery/keyset_test.go
@@ -269,9 +269,14 @@ func requireCursorInvalid(t *testing.T, err error, reason string) {
 	var got *errcode.Error
 	require.ErrorAs(t, err, &got)
 	assert.Equal(t, errcode.ErrCursorInvalid, got.Code)
-	reasonAttr, ok := got.FindAttr("reason")
-	require.True(t, ok)
-	s, ok := reasonAttr.Value().(string)
-	require.True(t, ok, "reason must be a string value")
-	assert.Equal(t, reason, s)
+
+	// Regression guard for #1103: reason must NOT appear in the public/wire
+	// details surface. FindAttr searches only e.Details (public), so
+	// ok==false proves the reason is not leaking via the 4xx response.
+	_, ok := got.FindAttr("reason")
+	assert.False(t, ok, "reason must not be in public Details (wire-leaking regression)")
+
+	// The reason text must still be present on the internal surface (Error()
+	// includes InternalDetails under the "_" sentinel key).
+	assert.Contains(t, got.Error(), reason, "reason must still surface in Error() for server-side diagnostics")
 }

--- a/framework/pkg/query/cursor.go
+++ b/framework/pkg/query/cursor.go
@@ -181,9 +181,9 @@ const cursorInvalidMsg = "invalid cursor; restart from first page (client should
 // message. The reason is set as an InternalDetail under the "_" sentinel key so
 // it appears in server-side logs via Error() but is never emitted on the wire.
 //
-// Note: cursorInvalidExtra has been deleted (#1103). There is intentionally no
-// API to attach public details to a cursor-invalid error — this makes the
-// keyset-structure leak non-expressible.
+// By design there is no API to attach public wire details to a cursor-invalid
+// error — all diagnostic detail goes to WithInternal only, making keyset-structure
+// leaks non-expressible (#1103).
 func cursorInvalid(reason string) error {
 	return errcode.New(
 		errcode.KindInvalid,

--- a/framework/pkg/query/cursor.go
+++ b/framework/pkg/query/cursor.go
@@ -173,37 +173,23 @@ func QueryContext(pairs ...string) string {
 }
 
 // cursorInvalidMsg is the stable, client-facing message for all cursor
-// validation failures. Specific diagnostics go into errcode.Error.Details
-// so they appear in the response "details" field without polluting "message".
+// validation failures. Runtime diagnostic details (reason, got, want) are
+// server-only and must never reach the wire — they go to WithInternal only.
 const cursorInvalidMsg = "invalid cursor; restart from first page (client should discard stored cursor)"
 
 // cursorInvalid returns a standardized cursor error with a stable client-facing
-// message and diagnostic reason in the details field. The reason is also set as
-// an InternalDetail under the "_" sentinel key so it appears in server-side
-// logs via Error().
+// message. The reason is set as an InternalDetail under the "_" sentinel key so
+// it appears in server-side logs via Error() but is never emitted on the wire.
+//
+// Note: cursorInvalidExtra has been deleted (#1103). There is intentionally no
+// API to attach public details to a cursor-invalid error — this makes the
+// keyset-structure leak non-expressible.
 func cursorInvalid(reason string) error {
 	return errcode.New(
 		errcode.KindInvalid,
 		errcode.ErrCursorInvalid,
 		cursorInvalidMsg,
 		errcode.WithInternal(errcode.InternalAttr("_", reason)),
-		errcode.WithDetails(errcode.PublicString("reason", reason)),
-	)
-}
-
-// cursorInvalidExtra returns a standardized cursor error with extra diagnostic
-// attributes appended after the reason key. The reason attribute is appended
-// last so dashboards can rely on it appearing in a stable position.
-func cursorInvalidExtra(reason string, extra ...errcode.PublicDetail) error {
-	attrs := make([]errcode.PublicDetail, 0, len(extra)+1)
-	attrs = append(attrs, extra...)
-	attrs = append(attrs, errcode.PublicString("reason", reason))
-	return errcode.New(
-		errcode.KindInvalid,
-		errcode.ErrCursorInvalid,
-		cursorInvalidMsg,
-		errcode.WithInternal(errcode.InternalAttr("_", reason)),
-		errcode.WithDetails(attrs...),
 	)
 }
 
@@ -216,15 +202,15 @@ func ValidateCursorScope(cur Cursor, sort []SortColumn, queryCtx string) error {
 		return cursorInvalid("sort scope is required")
 	}
 	if expected := SortScope(sort); cur.Scope != expected {
-		return cursorInvalidExtra("sort scope mismatch",
-			errcode.PublicString("got", cur.Scope), errcode.PublicString("want", expected))
+		// got/want folded into internal reason — never exposed on wire (#1103).
+		return cursorInvalid(fmt.Sprintf("sort scope mismatch: got %q want %q", cur.Scope, expected))
 	}
 	if cur.Context == "" {
 		return cursorInvalid("query context is required")
 	}
 	if cur.Context != queryCtx {
-		return cursorInvalidExtra("query context mismatch",
-			errcode.PublicString("got", cur.Context), errcode.PublicString("want", queryCtx))
+		// got/want folded into internal reason — never exposed on wire (#1103).
+		return cursorInvalid(fmt.Sprintf("query context mismatch: got %q want %q", cur.Context, queryCtx))
 	}
 	if len(cur.Values) != len(sort) {
 		return cursorInvalid(fmt.Sprintf("has %d values but expected %d sort columns", len(cur.Values), len(sort)))

--- a/framework/pkg/query/cursor_logger_test.go
+++ b/framework/pkg/query/cursor_logger_test.go
@@ -73,3 +73,41 @@ func TestLogCursorError_NilLogger_ReturnsNil(t *testing.T) {
 	fn := LogCursorError(nil, "test")
 	assert.Nil(t, fn)
 }
+
+// TestLogCursorError_RealCursorInvalidError locks the Error()↔logger contract
+// (#1103): after #1103, the diagnostic reason moves to WithInternal (key "_"),
+// so the ONLY observability surface is the server-log "error" attr (the result
+// of err.Error()). This test passes a real cursorInvalid error (the exact type
+// LogCursorError receives in production) and asserts that the logged "error"
+// attr contains the reason substring. A bare fmt.Errorf (as previously used)
+// would never exercise the [ERR_CURSOR_INVALID] ... server-log format.
+func TestLogCursorError_RealCursorInvalidError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	fn := LogCursorError(logger, "auditquery")
+	require.NotNil(t, fn)
+
+	// Build a real cursorInvalid error — same package, unexported but accessible
+	// because this file is package query.
+	const reason = `sort scope mismatch: got "x" want "y"`
+	realErr := cursorInvalid(reason)
+
+	fn(context.Background(), "scope", realErr)
+
+	logs := parseJSONLogLines(t, &buf)
+	require.Len(t, logs, 1)
+	rec := logs[0]
+
+	// The logged "error" attr must contain the reason substring so server-side
+	// operators can diagnose which cursor dimension mismatched (#1103: this is
+	// the ONLY observability surface after the public-detail leak was removed).
+	errStr, ok := rec["error"].(string)
+	require.True(t, ok, "error attr must be a string")
+	assert.Contains(t, errStr, reason,
+		"logged error must contain the reason so server-side diagnostics work after #1103")
+
+	// Sanity: the standard slice/reason attrs are still present.
+	assert.Equal(t, "auditquery", rec["slice"])
+	assert.Equal(t, "scope", rec["reason"])
+}

--- a/framework/pkg/query/cursor_test.go
+++ b/framework/pkg/query/cursor_test.go
@@ -262,19 +262,26 @@ func TestSortScope_DifferentColumnsProduceDifferentScope(t *testing.T) {
 // --- ValidateCursorScope tests ---
 
 // requireCursorInvalid asserts err is *errcode.Error with ErrCursorInvalid code
-// and the expected reason in Details. This catches regressions where the error
-// type or code drifts while the message text still matches.
+// and the stable client-facing message. It also acts as a regression guard for
+// #1103: reason must NOT appear in the public/wire Details surface.
+//
+// FindAttr searches only e.Details (public), so ok==false proves reason is not
+// leaking via the 4xx wire response. The reason text is still expected on the
+// internal surface (Error() surfaces InternalDetails under the "_" sentinel).
 func requireCursorInvalid(t *testing.T, err error, wantReason string) {
 	t.Helper()
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
 	assert.Equal(t, cursorInvalidMsg, ecErr.Message)
-	reasonAttr, ok := ecErr.FindAttr("reason")
-	require.True(t, ok)
-	s, ok := reasonAttr.Value().(string)
-	require.True(t, ok, "reason must be a string value")
-	assert.Equal(t, wantReason, s)
+
+	// Regression guard (#1103): reason must NOT be on public wire surface.
+	_, ok := ecErr.FindAttr("reason")
+	assert.False(t, ok, "reason must not appear in public Details (wire-leaking regression #1103)")
+
+	// Reason must still be on the internal surface (server-log only).
+	assert.Contains(t, ecErr.Error(), wantReason,
+		"reason must still surface in Error() for server-side diagnostics")
 }
 
 func TestValidateCursorScope_Mismatch(t *testing.T) {
@@ -285,19 +292,17 @@ func TestValidateCursorScope_Mismatch(t *testing.T) {
 	err := ValidateCursorScope(cur, sortB, qctx)
 	requireCursorInvalid(t, err, "sort scope mismatch")
 
-	// Assert got/want diagnostics from cursorInvalidExtra.
+	// Regression guard (#1103): got/want must NOT be in public Details either.
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
-	gotAttr, ok := ecErr.FindAttr("got")
-	require.True(t, ok)
-	gotStr, ok := gotAttr.Value().(string)
-	require.True(t, ok, "got must be a string value")
-	assert.Equal(t, SortScope(sortA), gotStr)
-	wantAttr, ok := ecErr.FindAttr("want")
-	require.True(t, ok)
-	wantStr, ok := wantAttr.Value().(string)
-	require.True(t, ok, "want must be a string value")
-	assert.Equal(t, SortScope(sortB), wantStr)
+	_, gotOK := ecErr.FindAttr("got")
+	assert.False(t, gotOK, "got must not appear in public Details (wire-leaking regression #1103)")
+	_, wantOK := ecErr.FindAttr("want")
+	assert.False(t, wantOK, "want must not appear in public Details (wire-leaking regression #1103)")
+
+	// got/want values must appear in internal Error() string (folded into reason).
+	assert.Contains(t, ecErr.Error(), SortScope(sortA), "got value must be in Error() for diagnostics")
+	assert.Contains(t, ecErr.Error(), SortScope(sortB), "want value must be in Error() for diagnostics")
 }
 
 func TestValidateCursorScope_ValueCountMismatch(t *testing.T) {
@@ -347,19 +352,17 @@ func TestValidateCursorScope_ContextMismatch(t *testing.T) {
 	err := ValidateCursorScope(cur, sort, ctxB)
 	requireCursorInvalid(t, err, "query context mismatch")
 
-	// Assert got/want diagnostics from cursorInvalidExtra.
+	// Regression guard (#1103): got/want must NOT be in public Details either.
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
-	gotAttr, ok := ecErr.FindAttr("got")
-	require.True(t, ok)
-	gotStr, ok := gotAttr.Value().(string)
-	require.True(t, ok, "got must be a string value")
-	assert.Equal(t, ctxA, gotStr)
-	wantAttr, ok := ecErr.FindAttr("want")
-	require.True(t, ok)
-	wantStr, ok := wantAttr.Value().(string)
-	require.True(t, ok, "want must be a string value")
-	assert.Equal(t, ctxB, wantStr)
+	_, gotOK := ecErr.FindAttr("got")
+	assert.False(t, gotOK, "got must not appear in public Details (wire-leaking regression #1103)")
+	_, wantOK := ecErr.FindAttr("want")
+	assert.False(t, wantOK, "want must not appear in public Details (wire-leaking regression #1103)")
+
+	// got/want values must appear in internal Error() string (folded into reason).
+	assert.Contains(t, ecErr.Error(), ctxA, "got value must be in Error() for diagnostics")
+	assert.Contains(t, ecErr.Error(), ctxB, "want value must be in Error() for diagnostics")
 }
 
 func TestValidateCursorScope_ContextMatch(t *testing.T) {
@@ -563,11 +566,12 @@ func TestCursorCodec_Decode_TooLong(t *testing.T) {
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
-	reasonAttr, ok := ecErr.FindAttr("reason")
-	require.True(t, ok)
-	s, ok := reasonAttr.Value().(string)
-	require.True(t, ok, "reason must be a string value")
-	assert.Equal(t, "cursor token exceeds maximum length", s)
+	// Regression guard (#1103): reason must not be in public Details.
+	_, ok := ecErr.FindAttr("reason")
+	assert.False(t, ok, "reason must not appear in public Details (wire-leaking regression #1103)")
+	// Reason must still surface in internal Error() string.
+	assert.Contains(t, ecErr.Error(), "cursor token exceeds maximum length",
+		"reason must still surface in Error() for server-side diagnostics")
 }
 
 // TestCursorCodec_Decode_MaxLengthBoundary confirms the exact-limit cursor

--- a/framework/pkg/query/cursor_test.go
+++ b/framework/pkg/query/cursor_test.go
@@ -589,10 +589,14 @@ func TestCursorCodec_Decode_MaxLengthBoundary(t *testing.T) {
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
-	// Must not be rejected by the length guard.
-	if reasonAttr, ok := ecErr.FindAttr("reason"); ok {
-		if s, ok := reasonAttr.Value().(string); ok {
-			assert.NotEqual(t, "cursor token exceeds maximum length", s)
-		}
-	}
+	// Regression guard (#1103): reason must not be in public Details (wire-leaking).
+	// After #1103 reason lives in WithInternal (key "_"), so FindAttr on public
+	// Details must always return ok==false.
+	_, ok := ecErr.FindAttr("reason")
+	assert.False(t, ok, "reason must not appear in public Details (wire-leaking regression #1103)")
+	// The boundary semantic: an at-limit token is NOT rejected by the length guard,
+	// so its error reason must not be "cursor token exceeds maximum length".
+	// After #1103 the reason is in Error() (server-log surface), not in public details.
+	assert.NotContains(t, ecErr.Error(), "cursor token exceeds maximum length",
+		"at-limit cursor must not be rejected by the length guard; only the signature check fails")
 }

--- a/framework/pkg/query/mempage_test.go
+++ b/framework/pkg/query/mempage_test.go
@@ -78,7 +78,9 @@ func cmpFloat(a, b float64) int {
 }
 
 // requireCursorInvalidMsg asserts the error is a standardized cursor error
-// with unified message and the expected reason in details.
+// with the stable client-facing message and the expected reason text on the
+// internal surface. Regression guard for #1103: reason must NOT appear in
+// the public wire Details (FindAttr searches only e.Details, public surface).
 func requireCursorInvalidMsg(t *testing.T, err error, wantReason string) {
 	t.Helper()
 	var ecErr *errcode.Error
@@ -86,11 +88,14 @@ func requireCursorInvalidMsg(t *testing.T, err error, wantReason string) {
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
 	assert.Equal(t, query.TestCursorInvalidMsg, ecErr.Message,
 		"client-facing message must be stable across all cursor errors")
-	reasonAttr, ok := ecErr.FindAttr("reason")
-	require.True(t, ok)
-	s, ok := reasonAttr.Value().(string)
-	require.True(t, ok, "reason must be a string value")
-	assert.Equal(t, wantReason, s)
+
+	// Regression guard (#1103): reason must NOT be in public Details.
+	_, ok := ecErr.FindAttr("reason")
+	assert.False(t, ok, "reason must not appear in public Details (wire-leaking regression #1103)")
+
+	// Reason must still surface in internal Error() string.
+	assert.Contains(t, ecErr.Error(), wantReason,
+		"reason must still surface in Error() for server-side diagnostics")
 }
 
 // --- Sort tests ---

--- a/framework/pkg/query/paged_query_test.go
+++ b/framework/pkg/query/paged_query_test.go
@@ -180,11 +180,12 @@ func TestExecutePagedQuery_ScopeMismatch(t *testing.T) {
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
-	reasonAttr, ok := ecErr.FindAttr("reason")
-	require.True(t, ok)
-	s, ok := reasonAttr.Value().(string)
-	require.True(t, ok, "reason must be a string value")
-	assert.Equal(t, "sort scope mismatch", s)
+	// Regression guard (#1103): reason must not be in public Details.
+	_, ok := ecErr.FindAttr("reason")
+	assert.False(t, ok, "reason must not appear in public Details (wire-leaking regression #1103)")
+	// Reason must still surface in internal Error() string.
+	assert.Contains(t, ecErr.Error(), "sort scope mismatch",
+		"reason must still surface in Error() for server-side diagnostics")
 }
 
 func TestExecutePagedQuery_ContextMismatch(t *testing.T) {
@@ -205,11 +206,12 @@ func TestExecutePagedQuery_ContextMismatch(t *testing.T) {
 	var ecErr *errcode.Error
 	require.ErrorAs(t, err, &ecErr)
 	assert.Equal(t, errcode.ErrCursorInvalid, ecErr.Code)
-	reasonAttr, ok := ecErr.FindAttr("reason")
-	require.True(t, ok)
-	s, ok := reasonAttr.Value().(string)
-	require.True(t, ok, "reason must be a string value")
-	assert.Equal(t, "query context mismatch", s)
+	// Regression guard (#1103): reason must not be in public Details.
+	_, ok := ecErr.FindAttr("reason")
+	assert.False(t, ok, "reason must not appear in public Details (wire-leaking regression #1103)")
+	// Reason must still surface in internal Error() string.
+	assert.Contains(t, ecErr.Error(), "query context mismatch",
+		"reason must still surface in Error() for server-side diagnostics")
 }
 
 func TestExecutePagedQuery_OnCursorErr_Decode(t *testing.T) {

--- a/framework/runtime/audit/ledger/mem_cross_tenant_store.go
+++ b/framework/runtime/audit/ledger/mem_cross_tenant_store.go
@@ -90,6 +90,9 @@ func (m *MemCrossTenantStore) QueryCrossTenant(
 		return nil, errcode.New(errcode.KindInternal, errcode.ErrInternal,
 			errMsgCrossTenantObligation)
 	}
+	if err := ValidateQueryFilters(filters); err != nil {
+		return nil, err
+	}
 	if len(params.Sort) == 0 {
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"audit ledger: cross-tenant query requires a non-empty sort")

--- a/framework/runtime/audit/ledger/mem_store.go
+++ b/framework/runtime/audit/ledger/mem_store.go
@@ -228,6 +228,28 @@ func (m *MemStore) GetBySeq(ctx context.Context, vis tenant.RowVisibility, seq i
 	return copyEntry(e), nil
 }
 
+// validateQueryArgs validates the mandatory preconditions shared by all MemStore
+// query paths. Extracted from Query to keep cognitive complexity ≤ 15.
+func validateQueryArgs(t tenant.TenantID, vis tenant.RowVisibility, filters AuditFilters, params query.ListParams) error {
+	if err := ValidateQueryTenant(t); err != nil {
+		return err
+	}
+	if err := ValidateQueryFilters(filters); err != nil {
+		return err
+	}
+	if err := vis.Validate(); err != nil {
+		return err
+	}
+	if vis.Scope() == tenant.RowScopeAll {
+		return RowScopeAllUnsupportedError()
+	}
+	if len(params.Sort) == 0 {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"audit ledger: query requires a non-empty sort")
+	}
+	return nil
+}
+
 // Query returns entries matching the supplied filters using keyset cursor
 // pagination: candidates are filtered, sorted by params.Sort, then ApplyCursor
 // skips past params.CursorValues and returns up to params.FetchLimit() (Limit+1)
@@ -241,18 +263,8 @@ func (m *MemStore) Query(
 	_ context.Context, t tenant.TenantID, vis tenant.RowVisibility,
 	filters AuditFilters, params query.ListParams,
 ) ([]*Entry, error) {
-	if err := ValidateQueryTenant(t); err != nil {
+	if err := validateQueryArgs(t, vis, filters, params); err != nil {
 		return nil, err
-	}
-	if err := vis.Validate(); err != nil {
-		return nil, err
-	}
-	if vis.Scope() == tenant.RowScopeAll {
-		return nil, RowScopeAllUnsupportedError()
-	}
-	if len(params.Sort) == 0 {
-		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-			"audit ledger: query requires a non-empty sort")
 	}
 
 	m.mu.Lock()

--- a/framework/runtime/audit/ledger/multi_store.go
+++ b/framework/runtime/audit/ledger/multi_store.go
@@ -76,6 +76,9 @@ func (m *MultiStore) Query(
 	if err := ValidateQueryFilters(filters); err != nil {
 		return nil, err
 	}
+	if vis.Scope() == tenant.RowScopeAll {
+		return nil, RowScopeAllUnsupportedError()
+	}
 	if len(params.Sort) == 0 {
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"audit ledger: query requires a non-empty sort")

--- a/framework/runtime/audit/ledger/multi_store.go
+++ b/framework/runtime/audit/ledger/multi_store.go
@@ -73,6 +73,9 @@ func (m *MultiStore) Query(
 	if err := ValidateQueryTenant(t); err != nil {
 		return nil, err
 	}
+	if err := ValidateQueryFilters(filters); err != nil {
+		return nil, err
+	}
 	if len(params.Sort) == 0 {
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"audit ledger: query requires a non-empty sort")

--- a/framework/runtime/audit/ledger/store.go
+++ b/framework/runtime/audit/ledger/store.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/idutil"
 	"github.com/ghbvf/gocell/framework/pkg/query"
 	"github.com/ghbvf/gocell/framework/pkg/tenant"
 )
@@ -113,6 +114,51 @@ func ValidateQueryTenant(t tenant.TenantID) error {
 		return nil
 	}
 	return t.Validate()
+}
+
+// ValidateQueryFilters is the single fail-closed filter validation chokepoint
+// shared by every Store.Query backend (MemStore / PG LedgerStore / MultiStore).
+// It is the defense-in-depth counterpart to ValidateQueryTenant: just as every
+// backend calls ValidateQueryTenant to reject a garbage tenant, every backend
+// calls ValidateQueryFilters to reject garbage ID filters before they reach SQL
+// predicates or logs (CWE-117 log injection + unbounded input to SQL predicate).
+//
+// Rules per field:
+//   - ActorID, SubjectID, TraceID: validated via idutil.SafeID.Validate (SafeID
+//     charset ASCII letters/digits/._:/- + MaxMetadataIDLen). Empty is allowed
+//     ("no filter"). The SafeID charset excludes newlines, tabs, control chars and
+//     most punctuation that could trigger log injection or SQL injection.
+//   - EventType: length cap only (len > MaxMetadataIDLen). EventType is a dotted
+//     label (e.g. "event.type.v1") — the dot and other separators are valid label
+//     chars but outside the SafeID charset, so charset validation is NOT applied.
+//     A length cap is the minimum hygiene that bounds database predicate size.
+//
+// Empty values for all fields are valid ("no filter").
+//
+// On any violation this function returns errcode.KindInvalid / ErrValidationFailed
+// with the offending field name in a WithInternal attr (never on wire).
+func ValidateQueryFilters(f AuditFilters) error {
+	if err := idutil.SafeID(f.ActorID).Validate(); err != nil {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"invalid query filter: actorId format",
+			errcode.WithInternal(errcode.InternalAttr("field", "actorId")))
+	}
+	if err := idutil.SafeID(f.SubjectID).Validate(); err != nil {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"invalid query filter: subjectId format",
+			errcode.WithInternal(errcode.InternalAttr("field", "subjectId")))
+	}
+	if err := idutil.SafeID(f.TraceID).Validate(); err != nil {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"invalid query filter: traceId format",
+			errcode.WithInternal(errcode.InternalAttr("field", "traceId")))
+	}
+	if len(f.EventType) > idutil.MaxMetadataIDLen {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"invalid query filter: eventType too long",
+			errcode.WithInternal(errcode.InternalAttr("field", "eventType")))
+	}
+	return nil
 }
 
 // QuerySort returns the canonical ordering for audit ledger listings: newest

--- a/framework/runtime/audit/ledger/store.go
+++ b/framework/runtime/audit/ledger/store.go
@@ -117,11 +117,13 @@ func ValidateQueryTenant(t tenant.TenantID) error {
 }
 
 // ValidateQueryFilters is the single fail-closed filter validation chokepoint
-// shared by every Store.Query backend (MemStore / PG LedgerStore / MultiStore).
-// It is the defense-in-depth counterpart to ValidateQueryTenant: just as every
-// backend calls ValidateQueryTenant to reject a garbage tenant, every backend
-// calls ValidateQueryFilters to reject garbage ID filters before they reach SQL
-// predicates or logs (CWE-117 log injection + unbounded input to SQL predicate).
+// shared by every Store.Query backend (MemStore / PG LedgerStore / MultiStore)
+// AND by every CrossTenantQueryStore.QueryCrossTenant backend (MemCrossTenantStore
+// / AuditCrossTenantStore). It is the defense-in-depth counterpart to
+// ValidateQueryTenant: just as every backend calls ValidateQueryTenant to reject a
+// garbage tenant, every backend calls ValidateQueryFilters to reject garbage ID
+// filters before they reach SQL predicates or logs (CWE-117 log injection +
+// unbounded input to SQL predicate).
 //
 // Rules per field:
 //   - ActorID, SubjectID, TraceID: validated via idutil.SafeID.Validate (SafeID

--- a/framework/runtime/audit/ledger/store_test.go
+++ b/framework/runtime/audit/ledger/store_test.go
@@ -1,0 +1,112 @@
+package ledger_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/errcode/errcodetest"
+	"github.com/ghbvf/gocell/framework/pkg/idutil"
+	"github.com/ghbvf/gocell/framework/runtime/audit/ledger"
+)
+
+// TestValidateQueryFilters exercises the ledger-layer ValidateQueryFilters
+// chokepoint directly (defense-in-depth unit test, #1742 / #2199).
+// Handler tests cover the wire-boundary path; this test covers the store-layer
+// path that non-handler callers (e.g. direct store access, cross-tenant backends)
+// also traverse.
+func TestValidateQueryFilters(t *testing.T) {
+	// unsafeChar is outside the SafeID charset (newline, tabs, @ etc.).
+	const unsafeChar = "@"
+	// longID exceeds MaxMetadataIDLen.
+	longID := strings.Repeat("a", idutil.MaxMetadataIDLen+1)
+	// longEventType exceeds MaxMetadataIDLen.
+	longEventType := strings.Repeat("e", idutil.MaxMetadataIDLen+1)
+	// validDotEventType is a dotted label within the length cap — dots are valid
+	// event-type separators and must NOT be rejected by the length-only check.
+	validDotEventType := "event.type.v1"
+
+	cases := []struct {
+		name     string
+		filters  ledger.AuditFilters
+		wantErr  bool
+		wantCode errcode.Code
+	}{
+		{
+			name:    "all empty is valid (no filter)",
+			filters: ledger.AuditFilters{},
+			wantErr: false,
+		},
+		{
+			name:    "valid non-empty actorId",
+			filters: ledger.AuditFilters{ActorID: "actor-123"},
+			wantErr: false,
+		},
+		{
+			name:     "actorId with unsafe char rejected",
+			filters:  ledger.AuditFilters{ActorID: "actor" + unsafeChar + "injection"},
+			wantErr:  true,
+			wantCode: errcode.ErrValidationFailed,
+		},
+		{
+			name:     "subjectId with unsafe char rejected",
+			filters:  ledger.AuditFilters{SubjectID: "subject" + unsafeChar + "x"},
+			wantErr:  true,
+			wantCode: errcode.ErrValidationFailed,
+		},
+		{
+			name:     "traceId with unsafe char rejected",
+			filters:  ledger.AuditFilters{TraceID: "trace" + unsafeChar + "x"},
+			wantErr:  true,
+			wantCode: errcode.ErrValidationFailed,
+		},
+		{
+			name:     "actorId exceeding MaxMetadataIDLen rejected",
+			filters:  ledger.AuditFilters{ActorID: longID},
+			wantErr:  true,
+			wantCode: errcode.ErrValidationFailed,
+		},
+		{
+			name:     "subjectId exceeding MaxMetadataIDLen rejected",
+			filters:  ledger.AuditFilters{SubjectID: longID},
+			wantErr:  true,
+			wantCode: errcode.ErrValidationFailed,
+		},
+		{
+			name:     "traceId exceeding MaxMetadataIDLen rejected",
+			filters:  ledger.AuditFilters{TraceID: longID},
+			wantErr:  true,
+			wantCode: errcode.ErrValidationFailed,
+		},
+		{
+			name:     "eventType exceeding length cap rejected",
+			filters:  ledger.AuditFilters{EventType: longEventType},
+			wantErr:  true,
+			wantCode: errcode.ErrValidationFailed,
+		},
+		{
+			name:    "eventType with dots within cap is valid (dotted label)",
+			filters: ledger.AuditFilters{EventType: validDotEventType},
+			wantErr: false,
+		},
+		{
+			name:    "eventType at exact MaxMetadataIDLen is valid",
+			filters: ledger.AuditFilters{EventType: strings.Repeat("e", idutil.MaxMetadataIDLen)},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ledger.ValidateQueryFilters(tc.filters)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ValidateQueryFilters(%+v): expected error, got nil", tc.filters)
+				}
+				errcodetest.AssertCode(t, err, tc.wantCode)
+			} else if err != nil {
+				t.Fatalf("ValidateQueryFilters(%+v): unexpected error: %v", tc.filters, err)
+			}
+		})
+	}
+}

--- a/framework/runtime/audit/ledger/storetest/suite.go
+++ b/framework/runtime/audit/ledger/storetest/suite.go
@@ -387,6 +387,7 @@ func Run(t *testing.T, factory Factory, protocol *ledger.Protocol) {
 	t.Run("Query_ByTraceID", func(t *testing.T) { runQueryByTraceID(t, factory) })
 	t.Run("Query_VisibilityObligations", func(t *testing.T) { runQueryVisibilityObligations(t, factory) })
 	t.Run("GetBySeq_VisibilityObligations", func(t *testing.T) { runGetBySeqVisibilityObligations(t, factory) })
+	t.Run("Query_InvalidCharFilter_Rejected", func(t *testing.T) { runQueryInvalidCharFilterRejected(t, factory) })
 }
 
 // runAppendTailRoundTrip: Append persists entry; Tail advances; GetBySeq returns entry.
@@ -1768,6 +1769,9 @@ func RunCrossTenantQueryConformance(t *testing.T, factory CrossTenantFactory) {
 	t.Run("CrossTenant_Filter_TraceID", func(t *testing.T) {
 		runCTFilterTraceID(t, factory)
 	})
+	t.Run("CrossTenant_InvalidCharFilter_Rejected", func(t *testing.T) {
+		runCTInvalidCharFilterRejected(t, factory)
+	})
 }
 
 // conformance tenant UUIDs for cross-tenant tests (distinct from the existing
@@ -2129,4 +2133,48 @@ func runCTFilterTraceID(t *testing.T, factory CrossTenantFactory) {
 	if len(traceYRows) != 1 {
 		t.Errorf("TraceID filter: got %d rows for trace-Y, want 1", len(traceYRows))
 	}
+}
+
+// runQueryInvalidCharFilterRejected asserts that Store.Query rejects an
+// AuditFilters with an unsafe char in ActorID (ValidateQueryFilters defense-in-depth,
+// #1742 / #2199). This is a cross-backend conformance case: every backend that
+// adds a Store.Query implementation must call ValidateQueryFilters or this test
+// catches the omission. At least one entry is seeded so MemStore's path actually
+// reaches the validation gate.
+func runQueryInvalidCharFilterRejected(t *testing.T, factory Factory) {
+	t.Helper()
+	store, _, fc, cleanup := factory(t)
+	defer cleanup()
+
+	// Seed one entry so the store is non-empty (anti-vacuity: rejection must come
+	// from ValidateQueryFilters, not from "zero rows returned").
+	e := NewEntryFixture(t, "invalid-filter-evt", "filter.test", "actor", fc.Now())
+	if err := store.Append(context.Background(), e); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	// '@' is outside the SafeID charset — ValidateQueryFilters must reject it.
+	_, err := store.Query(context.Background(), tenant.TenantID(""),
+		mustRowVisibility(t, tenant.RowScopeTenant, ""),
+		ledger.AuditFilters{ActorID: "actor@injection"},
+		query.ListParams{Limit: 10, Sort: ledger.QuerySort()})
+	errcodetest.AssertCode(t, err, errcode.ErrValidationFailed)
+}
+
+// runCTInvalidCharFilterRejected asserts that CrossTenantQueryStore.QueryCrossTenant
+// rejects an AuditFilters with an unsafe char in ActorID (ValidateQueryFilters
+// defense-in-depth, F1 of #2199 review). Seeds real entries so the rejection is
+// non-vacuous (the store must actively reject, not merely return zero rows).
+func runCTInvalidCharFilterRejected(t *testing.T, factory CrossTenantFactory) {
+	t.Helper()
+	seed := ctSeed(epochAnchor) // seed real entries (anti-vacuity)
+	store, cleanup := factory(t, seed)
+	defer cleanup()
+
+	ctv := tenant.NewCrossTenantVisibility()
+	// '@' is outside the SafeID charset — ValidateQueryFilters must reject it.
+	_, err := store.QueryCrossTenant(context.Background(), ctv,
+		ledger.AuditFilters{ActorID: "actor@injection"},
+		query.ListParams{Limit: 50, Sort: ledger.QuerySort()})
+	errcodetest.AssertCode(t, err, errcode.ErrValidationFailed)
 }


### PR DESCRIPTION
## Summary

auditquery + 分页加固三连：修空 Payload 致 List 5xx（#2199）、为 audit id 过滤器加 fail-closed 校验夹点（#1742）、堵 cursorInvalid 经 4xx Details 泄漏 keyset 结构（#1103）。

## Why / 背景

三条均为既有 backlog（pre-existing，多由历史 PR review 的 OUT_OF_SCOPE finding 转入），合并为一组「audit query / 分页」加固：

- **#2199**（Cx1 bug）：`toListResponseDataItem` 无条件 `json.RawMessage(redaction.RedactPayload(e.Payload))`。空 payload → `json.RawMessage([]byte{})` 装入 `any` 字段非 nil → 过 generated `ToMap` 的 `!= nil` → `json.Marshal` 空 RawMessage 报 "unexpected end of JSON input" → List 走 5xx。
- **#1742**（arch-opt，defense-in-depth）：`actorId`/`subjectId`/`traceId` 查询参数无长度/格式校验，不可信输入无界透传至 SQL 谓词 **与日志**（CWE-117）；当前 injection 由 pgx bound-param 兜底，但缺输入卫生上界。
- **#1103**（bug，info disclosure）：`cursorInvalid` 把 runtime reason（keyset 列数/列名/scope/context）经 `WithDetails(PublicString)` 下发 4xx wire，泄漏内部分页模型。

## 方案要点

- **#2199**：`toListResponseDataItem` 改为先建 item、仅当 `len(raw) > 0` 才赋 `Payload`；空则保持 interface nil → omitempty 省略 `payload` key。（实测 `any`-typed optional wire 字段全 repo 仅此一处，单点修即彻底，无需 codegen 通用守卫。）
- **#1742**：复刻本包 `ValidateQueryTenant` 既有范式，新增 `ledger.ValidateQueryFilters` fail-closed 夹点，在 mem/multi/pg **三个 backend Query 入口**紧随 tenant 校验调用（单源、含 internal caller 纵深防御）；handler `buildAuditFilters` 用 `idutil.SafeID(x).Validate()` 在 wire 边界返 400，**且置于 `logAdminAuditQuery` 之前**（CWE-117）。`AuditFilters` 字段**保持 string**——sizing 显示 typing 会涟漪 11 测试文件/5 包，且 `idutil.SafeID` 自述为 wire-boundary 守卫（`SafeID(raw)` 可绕过、仅 Medium），夹点校验是更faithful 的载体。AI-robust 评级 **Medium**（runtime fail-closed 夹点、3 backend 单源，与 #1618 tenant guard 同层）。
- **#1103**：三处移除公开 `WithDetails`，reason（含 got/want）折入字符串仅经 `WithInternal`（服务端日志可见）；**删除 `cursorInvalidExtra`** ——删后游标错误无任何 public-detail API，泄漏不可表达（局部漏斗）；测试翻转为「公开 details 无 reason/got/want」回归守卫。

## Refs

Closes #2199
Closes #1742
Closes #1103

- 复刻范式 ref: `framework/runtime/audit/ledger/store.go` `ValidateQueryTenant`（#1618 tenant-axis typed guard 先例）
- 关联（未纳入，保持延后）：#1321（actor_id/subject_id 索引，flag-cond，trigger 未触发，CONCURRENTLY 与 pre-GA 迁移规则冲突）

## Risk / 兼容性

- **wire 行为变更（pre-GA，无外部消费方，原子更新）**：
  - #1742 新增 400：非法 `actorId/subjectId/traceId`（非 SafeID 字符集 / 超 `MaxMetadataIDLen`）或超长 `eventType` 现返回 400（此前静默透传）。`http.audit.list.v1` contract.yaml **已声明 400**，仅补充 description；codegen DTO verify 无 drift。
  - #1103 删除 4xx 响应中的 `reason`/`got`/`want` detail（信息披露收敛）；客户端只需 const message「invalid cursor; restart from first page」。
- 无 migration、无新 errcode 前缀（复用 `ErrValidationFailed` / `ErrCursorInvalid`）、无 Go 兼容 shim。
- 删 `cursorInvalidExtra` 影响所有 keyset 分页消费者（configcore List、featureflag、auditcore）——已同 PR 原子更新其测试断言。

## Implementation matrix（contract-fanout）

| 变更 | contract | generated | cell/slice | tests | docs |
|------|----------|-----------|------------|-------|------|
| #2199 空 payload | 无 | 无（DTO 不变） | handler.go | handler_test.go | — |
| #1742 id 校验 | 400 description 补充 | 无 drift（verify 通过） | handler.go + ledger/store.go + 3 backend | handler_test.go | contract.yaml |
| #1103 cursor leak | 无（details 非命名字段） | 无 | — | 6 测试文件回归守卫 | — |

## Test plan

- [x] `go build ./framework/... ./corecells/... ./adapters/postgres/...` + `-tags=integration` 本地通过
- [x] `go test`（framework/pkg/{query,pgquery}、framework/runtime/audit、corecells/{auditcore,configcore}、adapters/postgres）全绿
- [x] `golangci-lint run ./...` 0 issues（framework / corecells / adapters/postgres 三模块）
- [x] `gocell verify` 契约 codegen 无 drift；archtest 0 new failures（2 项 pre-existing 与本 diff 无关）
