### PR TITLE
fix(ci,devops): 清除 dependabot 幽灵 golangci group + archtest 重指向 + docker-compose 卫生收口 [#2160][#2219]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,17 +5,13 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      # NOTE (#2160): since #1565/#2125 no workflow `uses:` golangci/golangci-lint-action
-      # — the real golangci-lint pin is now hack/lib/golangci-lint.sh::GOLANGCI_LINT_VERSION
-      # (a `go install @version` shell literal, absent from any go.mod), so neither this
-      # github-actions group nor the gomod ecosystem auto-bumps it: golangci-lint version
-      # upgrades are MANUAL by accepted decision pending #2160. This group is retained as a
-      # placeholder (and to satisfy DEPENDABOT-COVERAGE-GOLANGCI-01) until #2160 decides
-      # whether to redirect coverage to the real pin source; it is NOT a merge condition of
-      # PR #2158 (the archtest-convergence PR), which deliberately leaves this state as-is.
-      golangci-lint:
-        patterns:
-          - "golangci/golangci-lint-action"
+      # golangci/golangci-lint-action is NOT listed here — it was removed from
+      # all workflows in #1565/#2125. The real golangci-lint pin lives in
+      # hack/lib/golangci-lint.sh::GOLANGCI_LINT_VERSION (a `go install @version`
+      # shell literal, absent from any go.mod); version upgrades are manual per
+      # the accepted strategy in #2160; patch-pinning of the constant is
+      # archtest-guarded by CI-PINNING-WORKFLOW-DIGEST-01.
+      # DEPENDABOT-NO-GHOST-GOLANGCI-01 prevents re-adding a ghost group here.
       github-actions:
         patterns:
           - "*"

--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -914,7 +914,7 @@ jobs:
       GOCELL_APP_PASSWORD: gocell-app-restricted-pw-ci
       # RabbitMQ serving user password. compose uses ${E2E_RABBITMQ_PASSWORD:?} with
       # no software fallback; declared here to satisfy Sonar hardcoded-credential blocker.
-      E2E_RABBITMQ_PASSWORD: gocell-e2e-rmq-pwd
+      E2E_RABBITMQ_PASSWORD: gocell-e2e-rmq-restricted-pw-ci
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/_build-lint.yml
+++ b/.github/workflows/_build-lint.yml
@@ -912,6 +912,9 @@ jobs:
     env:
       E2E_PG_PASSWORD: gocell-e2e-ci-pwd
       GOCELL_APP_PASSWORD: gocell-app-restricted-pw-ci
+      # RabbitMQ serving user password. compose uses ${E2E_RABBITMQ_PASSWORD:?} with
+      # no software fallback; declared here to satisfy Sonar hardcoded-credential blocker.
+      E2E_RABBITMQ_PASSWORD: gocell-e2e-rmq-pwd
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -142,6 +142,9 @@ services:
       interval: 3s
       timeout: 3s
       retries: 40
+      # 15s: corebundle starts after migrate completes + redis/rabbitmq healthy;
+      # the longest upstream dependency (rabbitmq) itself has start_period: 15s,
+      # so this matches that ceiling and avoids premature failure countdown.
       start_period: 15s
 
 volumes:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -142,7 +142,7 @@ services:
       interval: 3s
       timeout: 3s
       retries: 40
-      start_period: 5s
+      start_period: 15s
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,9 @@ services:
       start_period: 15s
 
   minio:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    # digest from tests/testutil/images.go::MinIOImage; manually pinned
+    # (dependabot does not cover the root docker-compose.yml).
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: gocell

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,12 @@
 # Production deployments MUST inject all secrets via a secret manager
 # (Vault, GitHub Secrets, or equivalent) — never from this file.
 #
+# Because these services carry FIXED, committed dev credentials, every host
+# port below is published to 127.0.0.1 (loopback) only — never 0.0.0.0 — so the
+# dev-only boundary is enforced by the port-publish semantics, not just this
+# comment. A developer workstation must not expose these backing services to its
+# LAN. This is machine-guarded by COMPOSE-DEV-LOOPBACK-BIND-01 (tools/archtest).
+#
 # For a fail-fast "bring-your-own-password" variant that uses ${VAR:?} and
 # refuses to start with a missing secret, see docker-compose.local.yml.
 
@@ -23,7 +29,7 @@ services:
       POSTGRES_PASSWORD: gocell_dev
       POSTGRES_DB: gocell_dev
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -36,7 +42,7 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
@@ -50,8 +56,8 @@ services:
       RABBITMQ_DEFAULT_USER: gocell
       RABBITMQ_DEFAULT_PASS: gocell_dev
     ports:
-      - "5672:5672"
-      - "15672:15672"
+      - "127.0.0.1:5672:5672"
+      - "127.0.0.1:15672:15672"
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
       interval: 10s
@@ -68,8 +74,8 @@ services:
       MINIO_ROOT_USER: gocell
       MINIO_ROOT_PASSWORD: gocell_dev_secret
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
     volumes:
       - minio_data:/data
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,20 @@
+# LOCAL DEVELOPMENT INFRASTRUCTURE ONLY
+# ======================================
+# This compose file starts the local dev backing services (Postgres, Redis,
+# RabbitMQ, MinIO). It is NOT a deployment template.
+#
+# All credential-shaped values below (POSTGRES_PASSWORD: gocell_dev,
+# RABBITMQ_DEFAULT_PASS: gocell_dev, MINIO_ROOT_PASSWORD: gocell_dev_secret)
+# are NON-PRODUCTION placeholder literals intended solely for zero-config
+# local development on a developer workstation. They MUST NOT be reused in
+# any staging, CI, or production environment.
+#
+# Production deployments MUST inject all secrets via a secret manager
+# (Vault, GitHub Secrets, or equivalent) — never from this file.
+#
+# For a fail-fast "bring-your-own-password" variant that uses ${VAR:?} and
+# refuses to start with a missing secret, see docker-compose.local.yml.
+
 services:
   postgres:
     image: postgres:15-alpine
@@ -43,7 +60,7 @@ services:
       start_period: 15s
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: gocell
@@ -54,7 +71,9 @@ services:
     volumes:
       - minio_data:/data
     healthcheck:
-      test: ["CMD", "mc", "ready", "local"]
+      # curl is present in minio/minio images; mc is also present but curl
+      # against the liveness endpoint is more portable and avoids mc alias setup.
+      test: ["CMD", "curl", "-fsS", "http://localhost:9000/minio/health/live"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/hack/lib/golangci-lint.sh
+++ b/hack/lib/golangci-lint.sh
@@ -14,6 +14,10 @@
 # in _build-lint.yml) was removed and CI resolves the binary via
 # gocell::golangci_lint::ensure. Patch-pinning of this constant is archtest-
 # guarded by CI-PINNING-WORKFLOW-DIGEST-01 (tools/archtest/ci_pinning_test.go).
+# Version upgrades are MANUAL — dependabot does not cover this pin (no go.mod
+# tool dep, no renovate); bump both this constant and the gofumpt sync below
+# together. This is the accepted strategy per #2160; DEPENDABOT-NO-GHOST-
+# GOLANGCI-01 prevents re-adding a ghost dependabot group for the removed action.
 #
 # Sync requirement (manual, not statically enforced):
 #

--- a/tests/e2e/.env.e2e.example
+++ b/tests/e2e/.env.e2e.example
@@ -29,4 +29,5 @@ GOCELL_APP_PASSWORD=gocell-app-restricted-pw-e2e
 # defaulting to guest:guest or any other known credential.
 # Must be URL-safe: RFC 3986 unreserved only (A-Za-z0-9._~-); interpolated
 # into the AMQP userinfo in GOCELL_AMQP_URL.
-E2E_RABBITMQ_PASSWORD=...replace-me
+# Recommended: openssl rand -hex 16.
+E2E_RABBITMQ_PASSWORD=gocell-e2e-rmq-pwd-replace-me

--- a/tests/e2e/.env.e2e.example
+++ b/tests/e2e/.env.e2e.example
@@ -22,3 +22,11 @@ E2E_PG_PASSWORD=gocell-e2e-pwd-replace-me
 # Must be URL-safe: RFC 3986 unreserved only (A-Za-z0-9._~-); interpolated into
 # the SQL heredoc AND the serving DSN userinfo. Recommended: openssl rand -hex 16.
 GOCELL_APP_PASSWORD=gocell-app-restricted-pw-e2e
+
+# Password for the RabbitMQ serving user `gocell` in the e2e harness.
+# The compose file uses ${E2E_RABBITMQ_PASSWORD:?} with NO software fallback —
+# missing this var fails compose-up with a clear error rather than silently
+# defaulting to guest:guest or any other known credential.
+# Must be URL-safe: RFC 3986 unreserved only (A-Za-z0-9._~-); interpolated
+# into the AMQP userinfo in GOCELL_AMQP_URL.
+E2E_RABBITMQ_PASSWORD=...replace-me

--- a/tests/e2e/docker-compose.e2e.yaml
+++ b/tests/e2e/docker-compose.e2e.yaml
@@ -60,10 +60,15 @@ services:
 
   # RabbitMQ: postgres (durable) topology wires a real broker as the outbox
   # transport (#1940) — corebundle fail-closes at startup without GOCELL_AMQP_URL.
-  # Default guest:guest@127.0.0.1:5672 under host networking; e2e-only fixture.
+  # Credentials are injected via E2E_RABBITMQ_PASSWORD (no software fallback).
+  # CI workflow declares it in the e2e job env block; local devs use
+  # tests/e2e/.env.e2e.example as a starting point.
   rabbitmq:
     image: rabbitmq:3-alpine
     network_mode: host
+    environment:
+      RABBITMQ_DEFAULT_USER: gocell
+      RABBITMQ_DEFAULT_PASS: ${E2E_RABBITMQ_PASSWORD:?E2E_RABBITMQ_PASSWORD must be set}
     healthcheck:
       # check_port_connectivity (not -q ping): ping only confirms the Erlang node
       # is up, which happens BEFORE the AMQP 5672 listener binds — corebundle's
@@ -129,7 +134,7 @@ services:
       # outbox relay to a real broker (not the in-process bus). Required in
       # postgres+real mode — corebundle fail-closes without it. Loopback host
       # under host-network topology.
-      GOCELL_AMQP_URL: amqp://guest:guest@127.0.0.1:5672/
+      GOCELL_AMQP_URL: amqp://gocell:${E2E_RABBITMQ_PASSWORD:?E2E_RABBITMQ_PASSWORD must be set}@127.0.0.1:5672/
 
       # Production control-plane tokens (e2e-only values; not secret material).
       GOCELL_SERVICE_SECRET: e2e-service-secret-32-bytes-xxxxx!

--- a/tools/archtest/ci_pinning_test.go
+++ b/tools/archtest/ci_pinning_test.go
@@ -1,24 +1,19 @@
 //go:build archtest
 
 // INVARIANT: CI-PINNING-WORKFLOW-DIGEST-01
-//   - INVARIANT: DEPENDABOT-COVERAGE-GOLANGCI-01
+//   - INVARIANT: DEPENDABOT-NO-GHOST-GOLANGCI-01
 //
 // CI-PINNING-WORKFLOW-DIGEST-01: golangci-lint pinned to patch version; all external workflow uses pinned to SHA
-// DEPENDABOT-COVERAGE-GOLANGCI-01: dependabot root github-actions block covers
+// DEPENDABOT-NO-GHOST-GOLANGCI-01: dependabot must NOT contain any group whose patterns include
 //
-//	golangci/golangci-lint-action and a root gomod block is present; the decode is
-//	tolerant of unmodeled orchestration fields (a typo in an asserted field
-//	collapses to its zero value and still reds the guard)
-//
-// Known limitation (#2160): since #1565/#2125 no workflow `uses:`
-// golangci/golangci-lint-action anymore — the real lint pin moved to
-// hack/lib/golangci-lint.sh::GOLANGCI_LINT_VERSION (a `go install @version`
-// shell literal, absent from any go.mod). So the dependabot golangci-lint group
-// this guard requires currently covers a ghost action and does NOT make the real
-// pin auto-updatable. The guard is kept as-is pending the supply-chain
-// auto-upgrade decision (redirect to the real pin source vs. go.mod tool dep vs.
-// accept manual bump) tracked in #2160; this note keeps the guard honest rather
-// than implying live dependabot coverage of the real golangci-lint pin.
+//	"golangci/golangci-lint-action" — that action was removed in #1565/#2125 and its
+//	dependabot group is a ghost that implies false auto-update coverage of the real lint
+//	pin. The real pin lives in hack/lib/golangci-lint.sh::GOLANGCI_LINT_VERSION (a
+//	`go install @version` shell literal, absent from any go.mod); version upgrades are
+//	manual per the accepted strategy in #2160; patch-pinning of the constant is
+//	archtest-guarded by CI-PINNING-WORKFLOW-DIGEST-01. This guard prevents an AI
+//	collaborator from "helpfully" re-adding the ghost group. Additionally, dependabot
+//	must still contain a root github-actions block and a root gomod block.
 package archtest
 
 import (
@@ -217,112 +212,67 @@ func TestValidateLocalUsesResolveAcceptsExistingTarget(t *testing.T) {
 	require.NoError(t, validateLocalUsesResolve(root, "fixture.yml", body))
 }
 
-func TestDependabotCoversCIAndGolangCILint(t *testing.T) {
+// TestDependabotNoGhostGolangCILint reads the real .github/dependabot.yml and
+// verifies the new DEPENDABOT-NO-GHOST-GOLANGCI-01 invariant: no group must
+// cover golangci/golangci-lint-action (removed in #1565/#2125), and both a
+// root github-actions block and a root gomod block must be present.
+//
+// INVARIANT: DEPENDABOT-NO-GHOST-GOLANGCI-01.
+func TestDependabotNoGhostGolangCILint(t *testing.T) {
 	root := findModuleRoot(t)
 	body, err := os.ReadFile(filepath.Clean(filepath.Join(root, ".github", "dependabot.yml")))
 	require.NoError(t, err, ".github/dependabot.yml must exist")
 
-	require.NoError(t, validateDependabotCoversCIAndGolangCILint(body))
+	require.NoError(t, validateDependabotNoGhostGolangCILint(body))
 }
 
-func TestDependabotCoversCIAndGolangCILintRejectsGroupNameOnly(t *testing.T) {
-	body := []byte(`version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      golangci-lint:
-        patterns:
-          - "actions/*"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-`)
-	require.Error(t, validateDependabotCoversCIAndGolangCILint(body),
-		"group names must not satisfy the guard unless a pattern covers the action")
-}
-
-func TestDependabotCoversCIAndGolangCILintRejectsNonRootPatternOnly(t *testing.T) {
-	body := []byte(`version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
-  - package-ecosystem: "github-actions"
-    directory: "/tools"
-    schedule:
-      interval: "weekly"
-    groups:
-      golangci:
-        patterns:
-          - "golangci/golangci-lint-action"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-`)
-	require.Error(t, validateDependabotCoversCIAndGolangCILint(body),
-		"golangci-lint action pattern must be attached to the root github-actions update")
-}
-
-func TestDependabotCoversCIAndGolangCILintAllowsGroupExclusions(t *testing.T) {
-	body := []byte(`version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      golangci-lint:
-        patterns:
-          - "golangci/golangci-lint-action"
-      github-actions:
-        patterns:
-          - "*"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      go-special:
-        patterns:
-          - "example.com/special/*"
-      go-other:
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "example.com/special/*"
-`)
-	require.NoError(t, validateDependabotCoversCIAndGolangCILint(body))
-}
-
-// TestDependabotCoversCIAndGolangCILintToleratesUnmodeledFields locks the
-// guard's tolerant-evolution contract: dependabot.yml legitimately carries
-// orchestration fields the guard does not assert on — ignore (with full
-// dependency-name/versions/update-types), open-pull-requests-limit, labels.
-// The validator must check only the coverage invariant (root github-actions
-// covers golangci + root gomod) and stay tolerant of schema growth. A strict
-// KnownFields(true) decode here would
-// red on every new dependabot field while adding nothing to the assertion —
-// that fragility caused #925 (trigger: #911 added `ignore:`). This test
-// prevents a "helpful" reintroduction of strict decode: with strict decode
-// re-added, the unmodeled fields below (open-pull-requests-limit / labels /
-// ignore + sub-fields) make the decode error and this NoError assertion red.
+// TestDependabotNoGhostGolangCILintRejectsGhostGroup is the anti-vacuity red
+// case for the ghost-action ban. Any group whose patterns contain
+// "golangci/golangci-lint-action" must be rejected, regardless of which
+// ecosystem or directory the update belongs to.
 //
-// INVARIANT: DEPENDABOT-COVERAGE-GOLANGCI-01
+// INVARIANT: DEPENDABOT-NO-GHOST-GOLANGCI-01 — ghost group ban anti-vacuity.
+func TestDependabotNoGhostGolangCILintRejectsGhostGroup(t *testing.T) {
+	body := []byte(`version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+      golangci-lint:
+        patterns:
+          - "golangci/golangci-lint-action"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+`)
+	require.Error(t, validateDependabotNoGhostGolangCILint(body),
+		"any group whose patterns include golangci/golangci-lint-action must be rejected")
+}
+
+// TestDependabotNoGhostGolangCILintToleratesUnmodeledFields locks the guard's
+// tolerant-evolution contract: dependabot.yml legitimately carries orchestration
+// fields the guard does not assert on — ignore (with full dependency-name /
+// versions / update-types), open-pull-requests-limit, labels. The validator must
+// check only the ghost-ban + root-coverage invariant and stay tolerant of schema
+// growth. A strict KnownFields(true) decode here would red on every new dependabot
+// field while adding nothing to the assertion — that fragility caused #925
+// (trigger: #911 added `ignore:`). This test prevents a "helpful" reintroduction
+// of strict decode: with strict decode re-added, the unmodeled fields below
+// (open-pull-requests-limit / labels / ignore + sub-fields) make the decode error
+// and this NoError assertion red.
+//
+// INVARIANT: DEPENDABOT-NO-GHOST-GOLANGCI-01 — tolerant decode contract.
 //
 // The fixture MUST retain those unmodeled fields — they are the regression
-// trip-wire; shrinking the fixture to only modeled fields would silently
-// turn this test into a tautology that no longer catches strict-decode reentry.
-func TestDependabotCoversCIAndGolangCILintToleratesUnmodeledFields(t *testing.T) {
+// trip-wire; shrinking the fixture to only modeled fields would silently turn
+// this test into a tautology that no longer catches strict-decode reentry.
+func TestDependabotNoGhostGolangCILintToleratesUnmodeledFields(t *testing.T) {
 	body := []byte(`version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -333,9 +283,6 @@ updates:
     labels:
       - "dependencies"
     groups:
-      golangci-lint:
-        patterns:
-          - "golangci/golangci-lint-action"
       github-actions:
         patterns:
           - "*"
@@ -354,45 +301,16 @@ updates:
         patterns:
           - "*"
 `)
-	require.NoError(t, validateDependabotCoversCIAndGolangCILint(body))
+	require.NoError(t, validateDependabotNoGhostGolangCILint(body))
 }
 
-// TestDependabotCoversCIAndGolangCILintRejectsGroupsFieldTypo is the
-// blind-spot self-check for dropping strict decode (#925): a typo in an
-// *asserted* field must still red the guard. Here `groops:` (typo of
-// `groups:`) is tolerantly ignored, leaving Groups empty, so the root
-// github-actions block can no longer cover golangci/golangci-lint-action and
-// the guard reds. This proves tolerant decode stays fail-closed on the fields
-// the guard reads — the safety claim that justified removing KnownFields(true).
+// TestDependabotNoGhostGolangCILintRejectsDirectoriesListWithoutRoot is the
+// anti-vacuity red case for the plural directories form: a `directories:` list
+// that omits "/" must NOT satisfy the root gomod coverage check, proving the
+// plural-path check tests membership of "/" rather than mere presence of the field.
 //
-// INVARIANT: DEPENDABOT-COVERAGE-GOLANGCI-01 — groups-field typo test.
-func TestDependabotCoversCIAndGolangCILintRejectsGroupsFieldTypo(t *testing.T) {
-	body := []byte(`version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    groops:
-      golangci-lint:
-        patterns:
-          - "golangci/golangci-lint-action"
-  - package-ecosystem: "gomod"
-    directory: "/"
-`)
-	require.Error(t, validateDependabotCoversCIAndGolangCILint(body),
-		"a typo in the asserted `groups` field must red the guard, not pass silently")
-}
-
-// TestDependabotCoversCIAndGolangCILintAcceptsDirectoriesList locks the guard's
-// support for dependabot's plural `directories:` list form. dependabot natively
-// supports both singular `directory:` (one dir) and plural `directories:` (a
-// list / glob); the real .github/dependabot.yml uses the plural form for its
-// gomod block to cover the workspace's many sub-modules. The guard must detect
-// root ("/") coverage in EITHER form — modeling only `directory:` made the
-// gomod root check silently fail (#2113). Anti-vacuity companion below proves
-// the plural path is not a tautology.
-//
-// INVARIANT: DEPENDABOT-COVERAGE-GOLANGCI-01 — plural directories list form.
-func TestDependabotCoversCIAndGolangCILintAcceptsDirectoriesList(t *testing.T) {
+// INVARIANT: DEPENDABOT-NO-GHOST-GOLANGCI-01 — plural directories without root.
+func TestDependabotNoGhostGolangCILintRejectsDirectoriesListWithoutRoot(t *testing.T) {
 	body := []byte(`version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -400,37 +318,9 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      golangci-lint:
+      github-actions:
         patterns:
-          - "golangci/golangci-lint-action"
-  - package-ecosystem: "gomod"
-    directories:
-      - "/"
-      - "/tools"
-    schedule:
-      interval: "weekly"
-`)
-	require.NoError(t, validateDependabotCoversCIAndGolangCILint(body),
-		"plural `directories:` list containing / must satisfy the root gomod coverage check")
-}
-
-// TestDependabotCoversCIAndGolangCILintRejectsDirectoriesListWithoutRoot is the
-// anti-vacuity red case for the plural form: a `directories:` list that omits
-// "/" must NOT satisfy the root gomod coverage check, proving the plural-path
-// check tests membership of "/" rather than mere presence of the field.
-//
-// INVARIANT: DEPENDABOT-COVERAGE-GOLANGCI-01 — plural directories without root.
-func TestDependabotCoversCIAndGolangCILintRejectsDirectoriesListWithoutRoot(t *testing.T) {
-	body := []byte(`version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      golangci-lint:
-        patterns:
-          - "golangci/golangci-lint-action"
+          - "*"
   - package-ecosystem: "gomod"
     directories:
       - "/tools"
@@ -438,19 +328,53 @@ updates:
     schedule:
       interval: "weekly"
 `)
-	require.Error(t, validateDependabotCoversCIAndGolangCILint(body),
+	require.Error(t, validateDependabotNoGhostGolangCILint(body),
 		"a plural `directories:` list without / must not satisfy the root gomod coverage check")
 }
 
-// dependabotConfig models only the fields validateDependabotCoversCIAndGolangCILint
+// TestDependabotNoGhostGolangCILintRejectsAssertedFieldTypo is the blind-spot
+// self-check for dropping strict decode (#925): a typo in an *asserted* field
+// must still red the guard. Here `groops:` (typo of `groups:`) is tolerantly
+// ignored, leaving Groups empty for the github-actions update, so the guard
+// cannot verify the absence of ghost patterns — but more critically, with the
+// empty Groups map the gomod root check still passes (gomod block has no groups
+// with ghost patterns). The real failure here is the github-actions root block
+// itself: since there are no groups at all on it, the YAML decode collapses
+// groups to nil, which means the guard correctly sees no ghost. But the typo
+// in the gomod `directory:` field (spelled `directori:`) collapses to empty
+// string, so coversRoot() returns false → hasGoMod=false → guard reds.
+// This proves tolerant decode stays fail-closed on the fields the guard reads.
+//
+// INVARIANT: DEPENDABOT-NO-GHOST-GOLANGCI-01 — asserted-field typo test.
+func TestDependabotNoGhostGolangCILintRejectsAssertedFieldTypo(t *testing.T) {
+	body := []byte(`version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "gomod"
+    directori: "/"
+    schedule:
+      interval: "weekly"
+`)
+	require.Error(t, validateDependabotNoGhostGolangCILint(body),
+		"a typo in the asserted `directory` field must red the guard, not pass silently")
+}
+
+// dependabotConfig models only the fields validateDependabotNoGhostGolangCILint
 // asserts on. The decode is intentionally tolerant (no KnownFields(true)):
 // dependabot.yml legitimately grows orchestration fields (ignore /
 // open-pull-requests-limit / labels / reviewers / …) that the coverage guard
 // does not care about, and strict decode would red on each one while adding
 // nothing to the assertion (a typo in a field the guard *does* read collapses
-// it to its zero value, so the pattern match fails and the guard reds anyway).
+// it to its zero value, so the check fails and the guard reds anyway).
 // The tolerant-decode contract is locked by the fixtures above
-// (ToleratesUnmodeledFields + RejectsGroupsFieldTypo). See #925.
+// (ToleratesUnmodeledFields + RejectsAssertedFieldTypo). See #925.
 type dependabotConfig struct {
 	Updates []dependabotUpdate `yaml:"updates"`
 }
@@ -475,46 +399,18 @@ func (u dependabotUpdate) coversRoot() bool {
 }
 
 // dependabotGroup deliberately models only Patterns. The guard asks whether a
-// group's Patterns contains the required action, never what is excluded, so
-// exclude-patterns is left unmodeled and tolerantly ignored (see the
-// AllowsGroupExclusions fixture).
+// group's Patterns contains the ghost action, never what is excluded, so
+// exclude-patterns is left unmodeled and tolerantly ignored.
 type dependabotGroup struct {
 	Patterns []string `yaml:"patterns"`
 }
 
-func validateDependabotCoversCIAndGolangCILint(body []byte) error {
-	var cfg dependabotConfig
-	if err := yaml.Unmarshal(body, &cfg); err != nil {
-		return fmt.Errorf("parse dependabot.yml: %w", err)
-	}
-
-	var hasGitHubActions bool
-	var hasGoMod bool
-	for _, update := range cfg.Updates {
-		switch update.PackageEcosystem {
-		case "github-actions":
-			if update.coversRoot() {
-				hasGitHubActions = true
-				if rootGitHubActionsUpdateCoversGolangCI(update) {
-					return validateDependabotHasGoModRoot(cfg)
-				}
-			}
-		case "gomod":
-			if update.coversRoot() {
-				hasGoMod = true
-			}
-		}
-	}
-	if !hasGitHubActions {
-		return fmt.Errorf("dependabot must update GitHub Actions pins from directory /")
-	}
-	if !hasGoMod {
-		return fmt.Errorf("dependabot must update Go module pins from directory /")
-	}
-	return fmt.Errorf("dependabot root github-actions groups must explicitly pattern-match golangci/golangci-lint-action")
-}
-
-func rootGitHubActionsUpdateCoversGolangCI(update dependabotUpdate) bool {
+// anyGroupCoversGhost reports whether any group in the given update has a
+// pattern matching the removed golangci/golangci-lint-action. This is used to
+// detect ghost coverage — the action was removed in #1565/#2125 so any
+// dependabot group covering it creates a misleading impression that the real
+// lint pin (hack/lib/golangci-lint.sh) is auto-updated.
+func anyGroupCoversGhost(update dependabotUpdate) bool {
 	for _, group := range update.Groups {
 		if slices.Contains(group.Patterns, "golangci/golangci-lint-action") {
 			return true
@@ -523,13 +419,51 @@ func rootGitHubActionsUpdateCoversGolangCI(update dependabotUpdate) bool {
 	return false
 }
 
-func validateDependabotHasGoModRoot(cfg dependabotConfig) error {
+// validateDependabotNoGhostGolangCILint enforces DEPENDABOT-NO-GHOST-GOLANGCI-01:
+//  1. No update group (in any ecosystem or directory) must pattern-match
+//     "golangci/golangci-lint-action" — that action is a ghost since #1565/#2125.
+//     The real lint pin is hack/lib/golangci-lint.sh::GOLANGCI_LINT_VERSION (manual
+//     bump per #2160; patch-pin guarded by CI-PINNING-WORKFLOW-DIGEST-01).
+//  2. A root github-actions update (directory "/") must exist.
+//  3. A root gomod update (directory "/" or directories list containing "/") must exist.
+func validateDependabotNoGhostGolangCILint(body []byte) error {
+	var cfg dependabotConfig
+	if err := yaml.Unmarshal(body, &cfg); err != nil {
+		return fmt.Errorf("parse dependabot.yml: %w", err)
+	}
+
+	var hasGitHubActionsRoot bool
+	var hasGoModRoot bool
+
 	for _, update := range cfg.Updates {
-		if update.PackageEcosystem == "gomod" && update.coversRoot() {
-			return nil
+		// Ghost ban: reject any group covering the removed action, regardless of ecosystem.
+		if anyGroupCoversGhost(update) {
+			return fmt.Errorf("dependabot.yml must not contain a group with pattern " +
+				"\"golangci/golangci-lint-action\": that action was removed in " +
+				"#1565/#2125; the real lint pin is hack/lib/golangci-lint.sh " +
+				"(manual bump per #2160, patch-pin by CI-PINNING-WORKFLOW-DIGEST-01); " +
+				"remove the ghost group to prevent false auto-update coverage")
+		}
+
+		switch update.PackageEcosystem {
+		case "github-actions":
+			if update.coversRoot() {
+				hasGitHubActionsRoot = true
+			}
+		case "gomod":
+			if update.coversRoot() {
+				hasGoModRoot = true
+			}
 		}
 	}
-	return fmt.Errorf("dependabot must update Go module pins from directory /")
+
+	if !hasGitHubActionsRoot {
+		return fmt.Errorf("dependabot must have a github-actions update covering directory /")
+	}
+	if !hasGoModRoot {
+		return fmt.Errorf("dependabot must have a gomod update covering directory /")
+	}
+	return nil
 }
 
 func validateWorkflowUsesPinned(path string, body []byte) error {

--- a/tools/archtest/ci_pinning_test.go
+++ b/tools/archtest/ci_pinning_test.go
@@ -14,6 +14,10 @@
 //	archtest-guarded by CI-PINNING-WORKFLOW-DIGEST-01. This guard prevents an AI
 //	collaborator from "helpfully" re-adding the ghost group. Additionally, dependabot
 //	must still contain a root github-actions block and a root gomod block.
+//
+// AI-robust grade: Medium — content-scan（CI 期机器可判定；Hard 不可达：dependabot.yml 是
+// YAML，字段存在/通配语义无编译期 schema 强制）。Known blind spots: 见 anyGroupCoversGhost
+// （通配残留 / 大小写）。
 package archtest
 
 import (
@@ -227,13 +231,22 @@ func TestDependabotNoGhostGolangCILint(t *testing.T) {
 }
 
 // TestDependabotNoGhostGolangCILintRejectsGhostGroup is the anti-vacuity red
-// case for the ghost-action ban. Any group whose patterns contain
-// "golangci/golangci-lint-action" must be rejected, regardless of which
-// ecosystem or directory the update belongs to.
+// case for the ghost-action ban. Any group whose patterns match
+// golangci/golangci-lint-action — whether by exact name, trailing-wildcard
+// glob ("golangci/*", "golangci/golangci-lint*"), or "@version" suffix
+// ("golangci/golangci-lint-action@v6") — must be rejected, regardless of
+// which ecosystem or directory the update belongs to.
 //
 // INVARIANT: DEPENDABOT-NO-GHOST-GOLANGCI-01 — ghost group ban anti-vacuity.
 func TestDependabotNoGhostGolangCILintRejectsGhostGroup(t *testing.T) {
-	body := []byte(`version: 2
+	gomodBlock := `
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+`
+	actionsBlockWithPattern := func(pattern string) []byte {
+		return []byte(`version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -245,14 +258,25 @@ updates:
           - "*"
       golangci-lint:
         patterns:
-          - "golangci/golangci-lint-action"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-`)
-	require.Error(t, validateDependabotNoGhostGolangCILint(body),
-		"any group whose patterns include golangci/golangci-lint-action must be rejected")
+          - "` + pattern + `"
+` + gomodBlock)
+	}
+
+	cases := []struct {
+		name    string
+		pattern string
+	}{
+		{"exact", "golangci/golangci-lint-action"},
+		{"org-wildcard", "golangci/*"},
+		{"name-prefix-wildcard", "golangci/golangci-lint*"},
+		{"version-suffix", "golangci/golangci-lint-action@v6"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Error(t, validateDependabotNoGhostGolangCILint(actionsBlockWithPattern(tc.pattern)),
+				"pattern %q must be rejected as ghost coverage of golangci/golangci-lint-action", tc.pattern)
+		})
+	}
 }
 
 // TestDependabotNoGhostGolangCILintToleratesUnmodeledFields locks the guard's
@@ -332,21 +356,16 @@ updates:
 		"a plural `directories:` list without / must not satisfy the root gomod coverage check")
 }
 
-// TestDependabotNoGhostGolangCILintRejectsAssertedFieldTypo is the blind-spot
-// self-check for dropping strict decode (#925): a typo in an *asserted* field
-// must still red the guard. Here `groops:` (typo of `groups:`) is tolerantly
-// ignored, leaving Groups empty for the github-actions update, so the guard
-// cannot verify the absence of ghost patterns — but more critically, with the
-// empty Groups map the gomod root check still passes (gomod block has no groups
-// with ghost patterns). The real failure here is the github-actions root block
-// itself: since there are no groups at all on it, the YAML decode collapses
-// groups to nil, which means the guard correctly sees no ghost. But the typo
-// in the gomod `directory:` field (spelled `directori:`) collapses to empty
-// string, so coversRoot() returns false → hasGoMod=false → guard reds.
-// This proves tolerant decode stays fail-closed on the fields the guard reads.
+// TestDependabotNoGhostGolangCILintAcceptsDirectoriesListWithRoot is the GREEN
+// companion to TestDependabotNoGhostGolangCILintRejectsDirectoriesListWithoutRoot.
+// It locks the plural-accept path: a `directories:` list that INCLUDES "/" must
+// satisfy the root gomod coverage check and must not be incorrectly rejected.
 //
-// INVARIANT: DEPENDABOT-NO-GHOST-GOLANGCI-01 — asserted-field typo test.
-func TestDependabotNoGhostGolangCILintRejectsAssertedFieldTypo(t *testing.T) {
+// Fixture: github-actions root (patterns: ["*"], no ghost) + gomod with
+// directories: ["/", "/tools"] — "/" is present so coversRoot() is true.
+//
+// INVARIANT: DEPENDABOT-NO-GHOST-GOLANGCI-01 — plural directories with root (GREEN).
+func TestDependabotNoGhostGolangCILintAcceptsDirectoriesListWithRoot(t *testing.T) {
 	body := []byte(`version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -358,12 +377,51 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "gomod"
+    directories:
+      - "/"
+      - "/tools"
+    schedule:
+      interval: "weekly"
+`)
+	require.NoError(t, validateDependabotNoGhostGolangCILint(body),
+		"a plural `directories:` list containing / must satisfy the root gomod coverage check")
+}
+
+// TestDependabotNoGhostGolangCILintRejectsGoModRootFieldTypo verifies that a typo
+// in the gomod root-assertion field (directory/directories) makes coversRoot()
+// collapse to false, causing hasGoMod=false and the guard to red. This is the
+// blind-spot self-check for tolerant decode (#925): the guard only asserts on a
+// small set of fields (ghost patterns + root coverage); a typo in a field the
+// guard *does* read must still fail-closed rather than pass silently.
+//
+// Specifically: `directori:` (typo of `directory:`) is tolerantly decoded to the
+// zero value (empty string), so coversRoot() returns false → hasGoMod=false → guard
+// reds. This is distinct from the ghost-ban itself: the fixture has no ghost
+// patterns; it exercises the gomod root-assertion path only.
+//
+// Note: `groops:` (a typo of `groups:`) on the github-actions block is also present
+// in the fixture — it is tolerantly ignored and leaves Groups nil; since there are
+// no ghost patterns the ghost-ban itself does not trigger here.
+//
+// INVARIANT: DEPENDABOT-NO-GHOST-GOLANGCI-01 — gomod root field typo (fail-closed).
+func TestDependabotNoGhostGolangCILintRejectsGoModRootFieldTypo(t *testing.T) {
+	body := []byte(`version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groops:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "gomod"
     directori: "/"
     schedule:
       interval: "weekly"
 `)
 	require.Error(t, validateDependabotNoGhostGolangCILint(body),
-		"a typo in the asserted `directory` field must red the guard, not pass silently")
+		"a typo in the asserted `directory` field must red the guard (hasGoMod=false), not pass silently")
 }
 
 // dependabotConfig models only the fields validateDependabotNoGhostGolangCILint
@@ -405,15 +463,56 @@ type dependabotGroup struct {
 	Patterns []string `yaml:"patterns"`
 }
 
+// patternCoversGhost reports whether a single dependabot pattern p would match
+// the removed golangci/golangci-lint-action. dependabot patterns support a
+// trailing "*" glob and an optional "@version" suffix (stripped before
+// matching); exact matches and non-empty-prefix trailing-wildcard matches are
+// detected.
+//
+// A bare "*" (all-packages wildcard with empty non-star prefix) is intentionally
+// excluded: it is a legitimate catch-all used for the github-actions group and
+// does not single out golangci specifically. Only patterns with a non-empty
+// golangci-scoped prefix (e.g. "golangci/*", "golangci/golangci-lint*") are
+// considered ghost coverage.
+//
+// Known blind spots (documented per DEPENDABOT-NO-GHOST-GOLANGCI-01):
+//   - Case sensitivity: dependabot patterns are case-sensitive; uppercase variants
+//     (e.g. "Golangci/*") are not a real bypass and are intentionally not handled.
+//   - Complex globs: mid-pattern "?" or character-class "[…]" are not parsed;
+//     such patterns are not standard dependabot practice and are not handled.
+func patternCoversGhost(p string) bool {
+	const ghost = "golangci/golangci-lint-action"
+	// Strip optional @version suffix (e.g. "golangci/golangci-lint-action@v6").
+	p = strings.SplitN(p, "@", 2)[0]
+	// Exact match.
+	if p == ghost {
+		return true
+	}
+	// Trailing-wildcard prefix match: covers "golangci/*", "golangci/golangci-lint*", etc.
+	// Require a non-empty prefix so that the bare "*" catch-all is not treated as ghost
+	// coverage (it does not single out the golangci organization).
+	if strings.HasSuffix(p, "*") {
+		prefix := strings.TrimSuffix(p, "*")
+		if prefix != "" && strings.HasPrefix(ghost, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // anyGroupCoversGhost reports whether any group in the given update has a
-// pattern matching the removed golangci/golangci-lint-action. This is used to
-// detect ghost coverage — the action was removed in #1565/#2125 so any
-// dependabot group covering it creates a misleading impression that the real
-// lint pin (hack/lib/golangci-lint.sh) is auto-updated.
+// pattern that would match the removed golangci/golangci-lint-action. This is
+// used to detect ghost coverage — the action was removed in #1565/#2125 so any
+// dependabot group covering it (including via trailing-wildcard globs such as
+// "golangci/*") creates a misleading impression that the real lint pin
+// (hack/lib/golangci-lint.sh) is auto-updated. See patternCoversGhost for the
+// matching rules and residual blind spots.
 func anyGroupCoversGhost(update dependabotUpdate) bool {
 	for _, group := range update.Groups {
-		if slices.Contains(group.Patterns, "golangci/golangci-lint-action") {
-			return true
+		for _, p := range group.Patterns {
+			if patternCoversGhost(p) {
+				return true
+			}
 		}
 	}
 	return false

--- a/tools/archtest/compose_dev_loopback_bind_test.go
+++ b/tools/archtest/compose_dev_loopback_bind_test.go
@@ -1,0 +1,181 @@
+//go:build archtest
+
+// INVARIANT: COMPOSE-DEV-LOOPBACK-BIND-01
+//
+// The repo-root docker-compose.yml is the zero-config local-dev quick-start
+// stack, and it ships FIXED, committed dev credentials (POSTGRES_PASSWORD:
+// gocell_dev, RABBITMQ_DEFAULT_PASS: gocell_dev, MINIO_ROOT_PASSWORD:
+// gocell_dev_secret). Because those credentials are known to anyone with the
+// repo, every published host port MUST bind to 127.0.0.1 (loopback) rather than
+// the docker default 0.0.0.0 — otherwise a developer workstation exposes
+// Postgres / Redis / RabbitMQ / MinIO (with known credentials) to its LAN or any
+// host interface. This guard makes the dev-only boundary enforced by the
+// port-publish semantics, not just declared in the file-header comment (#2250
+// F1: "dev-only 语义停留在注释层，没有被 compose 端口发布语义强制").
+//
+// AI-robust grade: Medium — content-scan (machine-checkable at CI time; an edit
+// that drops the 127.0.0.1 prefix is a reviewer-visible diff that reds this
+// test). Hard is unreachable: docker-compose YAML has no type-system way to pin a
+// host IP onto a port string, and Go has no compile-time equivalent.
+//
+// Scope: ONLY the repo-root docker-compose.yml. docker-compose.local.yml uses
+// ${VAR:?} (caller-supplied, non-committed) credentials plus a shared netns, and
+// tests/e2e/docker-compose.e2e.yaml uses network_mode: host with no published
+// ports — both have a different risk model and are intentionally out of scope of
+// the fixed-credential loopback invariant.
+//
+// Blind spots (disclosed):
+//   - Only short-syntax ports ("[IP:]HOST:CONTAINER[/proto]") are parsed;
+//     long-syntax (- target:/published:/host_ip:) and IPv6 host IPs are not. The
+//     root file uses IPv4 short syntax; a future switch must extend hostIsLoopback.
+//   - Asserts only the literal 127.0.0.1 host-IP prefix, not runtime reachability.
+package archtest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// composeLoopbackRuleID is the rule identifier for COMPOSE-DEV-LOOPBACK-BIND-01.
+const composeLoopbackRuleID = "COMPOSE-DEV-LOOPBACK-BIND-01"
+
+// loopbackHostIP is the only host IP a fixed-credential dev service may publish on.
+const loopbackHostIP = "127.0.0.1"
+
+// composeNonLoopbackPorts parses body as a Docker Compose YAML and returns one
+// violation string per short-syntax published port whose host side is not bound
+// to 127.0.0.1, plus the total number of published ports inspected (for the
+// caller's anti-vacuity assertion).
+//
+// Pure helper (no testing side-effects) so the RED/GREEN fixtures below can drive
+// it directly without touching the file system.
+func composeNonLoopbackPorts(body []byte) (violations []string, checked int) {
+	var doc struct {
+		Services map[string]struct {
+			Ports []string `yaml:"ports"`
+		} `yaml:"services"`
+	}
+	if err := yaml.Unmarshal(body, &doc); err != nil {
+		return []string{fmt.Sprintf("parse error: %v", err)}, 0
+	}
+	for name, svc := range doc.Services {
+		for _, p := range svc.Ports {
+			checked++
+			if !hostIsLoopback(p) {
+				violations = append(violations,
+					fmt.Sprintf("service %q publishes port %q without a %s host IP "+
+						"(binds 0.0.0.0; fixed-credential dev infra must bind loopback)",
+						name, p, loopbackHostIP))
+			}
+		}
+	}
+	return violations, checked
+}
+
+// hostIsLoopback reports whether a docker-compose short-syntax port string binds
+// its host port to 127.0.0.1. Short syntax is "[HOST_IP:]HOST:CONTAINER[/proto]";
+// only the three-part "IP:HOST:CONTAINER" form carries an explicit host IP, so a
+// bare "HOST:CONTAINER" (binds every interface) or "CONTAINER" (random host port
+// on every interface) is not loopback-bound.
+func hostIsLoopback(portSpec string) bool {
+	spec := portSpec
+	if i := strings.IndexByte(spec, '/'); i >= 0 { // strip /tcp|/udp protocol suffix
+		spec = spec[:i]
+	}
+	parts := strings.Split(spec, ":")
+	if len(parts) != 3 {
+		return false
+	}
+	return parts[0] == loopbackHostIP
+}
+
+// TestComposeDevLoopbackBind enforces COMPOSE-DEV-LOOPBACK-BIND-01 against the
+// repo-root docker-compose.yml.
+//
+// Anti-vacuity: asserts at least 4 published ports were inspected. The root file
+// publishes 6 (postgres, redis, rabbitmq×2, minio×2); a count below 4 means the
+// parse or file path broke and the guard would otherwise be vacuously green.
+func TestComposeDevLoopbackBind(t *testing.T) {
+	root := findModuleRoot(t)
+	path := filepath.Clean(filepath.Join(root, "docker-compose.yml"))
+	body, err := os.ReadFile(path)
+	require.NoError(t, err, "%s: repo-root docker-compose.yml must exist", composeLoopbackRuleID)
+
+	violations, checked := composeNonLoopbackPorts(body)
+	for _, v := range violations {
+		t.Errorf("%s: docker-compose.yml: %s", composeLoopbackRuleID, v)
+	}
+	require.GreaterOrEqualf(t, checked, 4,
+		"%s: inspected only %d published ports in docker-compose.yml — expected ≥4; "+
+			"parse or path may be broken", composeLoopbackRuleID, checked)
+}
+
+// TestComposeDevLoopbackBind_RejectsNonLoopbackPort is the anti-vacuity RED case:
+// a bare HOST:CONTAINER publish (and a container-only publish) must be flagged.
+func TestComposeDevLoopbackBind_RejectsNonLoopbackPort(t *testing.T) {
+	cases := map[string]string{
+		"bare-host-container": `
+services:
+  postgres:
+    image: postgres:15-alpine
+    ports:
+      - "5432:5432"
+`,
+		"container-only": `
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379"
+`,
+		"wrong-host-ip": `
+services:
+  minio:
+    image: minio/minio
+    ports:
+      - "0.0.0.0:9000:9000"
+`,
+		"mixed-one-bad": `
+services:
+  postgres:
+    ports:
+      - "127.0.0.1:5432:5432"
+  redis:
+    ports:
+      - "6379:6379"
+`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			violations, _ := composeNonLoopbackPorts([]byte(body))
+			require.NotEmptyf(t, violations, "expected a violation for case %q", name)
+		})
+	}
+}
+
+// TestComposeDevLoopbackBind_AcceptsLoopbackPorts is the GREEN case: every port
+// bound to 127.0.0.1 (including a /tcp protocol suffix) passes with zero
+// violations, and a service without any ports is skipped.
+func TestComposeDevLoopbackBind_AcceptsLoopbackPorts(t *testing.T) {
+	body := `
+services:
+  postgres:
+    ports:
+      - "127.0.0.1:5432:5432"
+  rabbitmq:
+    ports:
+      - "127.0.0.1:5672:5672"
+      - "127.0.0.1:15672:15672/tcp"
+  migrate:
+    image: migrate
+`
+	violations, checked := composeNonLoopbackPorts([]byte(body))
+	require.Empty(t, violations, "expected no violations: %v", violations)
+	require.Equal(t, 3, checked, "expected 3 published ports inspected")
+}


### PR DESCRIPTION
## Summary

合并修复两个 CI / 基建卫生 backlog：**#2160**（清除 dependabot 监视的已移除 `golangci-lint-action` 幽灵 group，把 archtest 守卫从「要求幽灵」反转为「禁止幽灵」）+ **#2219**（docker-compose 5 项卫生 / 安全收口）。两者文件零重叠。

## Why / 背景

**#2160** — 自 #1565/#2125 起 golangci-lint 改由 shell 字面量 `hack/lib/golangci-lint.sh::GOLANGCI_LINT_VERSION` pin（`go install @version`），`golangci/golangci-lint-action` 在所有 workflow 已 **0 `uses:`**。但 `.github/dependabot.yml` 仍保留监视它的 `golangci-lint` group，且 archtest `DEPENDABOT-COVERAGE-GOLANGCI-01` 反而**要求**该 group 存在——守的是幽灵，误导性地暗示 dependabot 在守 golangci-lint 版本（实则不覆盖，版本升级是纯手动）。本 PR 删幽灵 group、把不变量反转为 `DEPENDABOT-NO-GHOST-GOLANGCI-01`（禁止再为已移除 action 加 group + 保留 root github-actions/gomod 覆盖），并把 manual-bump 落为文档化既定策略。

**#2219** — PR #2217 内置 review 在 docker-compose 文件发现 5 项既存卫生 / 安全项（OUT_OF_SCOPE 于该 PR）：O1 根 compose 无 dev-only 声明、O2 e2e rabbitmq `guest:guest`、O3 minio healthcheck 用不在镜像内的 `mc`、O4 `minio:latest` 未固定、O5 corebundle `start_period` 偏低。

## Refs

Closes #2160
Closes #2219

Source：#2160 ← PR #2158 finding F-B3；#2219 ← PR #2217 review O1–O5。Discovered via `/ship`。

## Risk / 兼容性

- **#2160**：仅 CI 工具治理配置 + archtest，无 wire / 契约 / production Go 变更。不向后兼容地全量改名不变量 ID（`DEPENDABOT-COVERAGE-GOLANGCI-01` → `DEPENDABOT-NO-GHOST-GOLANGCI-01`，无兼容别名），引用全收敛在 `ci_pinning_test.go` + `dependabot.yml`。新守卫 = Medium content-scan（已是天花板，YAML 禁某 key 无 Hard 载体），保留 anti-vacuity 红用例（幽灵-present 红 + gomod-no-root 红）。`gofumpt↔golangci vendor-sync`（既存 reviewer-enforced Soft）与 staleness/renovate/go.mod-tool 为**显式非目标**（manual-honest，用户裁定）。
- **#2219 O2**：e2e rabbitmq 从默认 `guest`（loopback-restricted）改为 CI/.env 注入密码的自定义用户 `gocell`（4 处 lockstep：compose `environment` + corebundle `GOCELL_AMQP_URL` + `_build-lint.yml` e2e env + `.env.e2e.example`），对齐同文件 postgres 已用的 `${VAR:?}` fail-fast 模式；缺密码启动期 fail-fast（本地 `config` 已验证报错、无软回退）。corebundle 启动期真实 auth 该用户。
- **#2219 O3/O4**：minio 固定到验证存在的 `RELEASE.2025-09-07T16-13-09Z`，healthcheck 改 `["CMD","curl","-fsS","http://localhost:9000/minio/health/live"]`（镜像内 `curl` 存在，本地 `up` 实测 `healthy`）。
- **预存且无关（非本 PR 引入）**：nightly archtest 的 `TestFixtureCellIDTypedBuilder` / `TestProjectionConsumerBaseWiring` 在 `origin/develop`（bfaf4dd02，无本 PR 改动）同样 FAIL（违规在 `kernel/governance/rules_topo13_test.go`），与本 PR 8 文件不相交。本 PR 的 `DEPENDABOT-NO-GHOST-GOLANGCI-01` 与 `COMPOSE-HEALTHCHECK-START-PERIOD-01`（#2219 改动落在其扫描范围）均本地通过。

## Test plan

- [x] archtest 反转守卫 TDD 红→绿：先改测试对含幽灵的 `dependabot.yml` 报红，删幽灵后转绿
- [x] `go test -tags=archtest -run 'DependabotNoGhost|ComposeHealthcheck' ./tools/archtest/` 全绿
- [x] `golangci-lint run --build-tags=archtest ./tools/archtest/...` 0 issues
- [x] `docker compose -f docker-compose.yml up -d minio` 实测 `healthy`（O3/O4，含 RELEASE tag 存在性验证）
- [x] e2e compose `config` 插值校验：注入 `E2E_RABBITMQ_PASSWORD` 解析正确 + 缺值 `:?` fail-fast
- [x] 无 production Go 改动；docker-compose 改动经 `docker compose config` 校验

🤖 Generated with [Claude Code](https://claude.com/claude-code)
