### PR TITLE
fix(archtest): #2148 panic vacuity 收敛 Production + errcode satellite 覆盖；#2149 examples 纳入生产治理

### DIFF
--- a/adapters/postgres/journaling_outbox_writer.go
+++ b/adapters/postgres/journaling_outbox_writer.go
@@ -61,7 +61,8 @@ var (
 // clock.MustHaveClock).
 func NewJournalingOutboxWriter(inner *OutboxWriter, projectionTopics []string) outbox.Writer {
 	if inner == nil {
-		panic(panicregister.Approved("journaling-outbox-writer-nil-inner", nil))
+		panic(panicregister.Approved("journaling-outbox-writer-nil-inner",
+			errcode.Assertion("NewJournalingOutboxWriter: inner OutboxWriter is required (nil rejected)")))
 	}
 	set := make(map[string]struct{}, len(projectionTopics))
 	for _, t := range projectionTopics {

--- a/examples/iotdevice/auth.go
+++ b/examples/iotdevice/auth.go
@@ -17,7 +17,7 @@ const (
 	jwtAudienceEnv            = "GOCELL_JWT_AUDIENCE"
 )
 
-func newJWTVerifierFromEnv() (*auth.JWTVerifier, error) {
+func newJWTVerifierFromEnv(clk clock.Clock) (*auth.JWTVerifier, error) {
 	issuer := strings.TrimSpace(os.Getenv(jwtIssuerEnv))
 	if issuer == "" {
 		return nil, fmt.Errorf("%s must be set", jwtIssuerEnv)
@@ -27,11 +27,11 @@ func newJWTVerifierFromEnv() (*auth.JWTVerifier, error) {
 		return nil, fmt.Errorf("%s must be set", jwtAudienceEnv)
 	}
 
-	keySet, err := auth.LoadKeySetFromEnv(clock.Real())
+	keySet, err := auth.LoadKeySetFromEnv(clk)
 	if err != nil {
 		return nil, fmt.Errorf("load JWT key set from environment: %w", err)
 	}
-	verifier, err := auth.NewJWTVerifier(keySet, clock.Real(),
+	verifier, err := auth.NewJWTVerifier(keySet, clk,
 		auth.WithExpectedAudiences(audience),
 		auth.WithExpectedIssuer(issuer))
 	if err != nil {
@@ -40,7 +40,7 @@ func newJWTVerifierFromEnv() (*auth.JWTVerifier, error) {
 	return verifier, nil
 }
 
-func newInternalAuthChainFromEnv() ([]kauth.ListenerAuth, error) {
+func newInternalAuthChainFromEnv(clk clock.Clock) ([]kauth.ListenerAuth, error) {
 	secret := os.Getenv(iotdeviceServiceSecretEnv)
 	if secret == "" {
 		return nil, fmt.Errorf("%s must be set for the internal listener", iotdeviceServiceSecretEnv)
@@ -50,7 +50,7 @@ func newInternalAuthChainFromEnv() ([]kauth.ListenerAuth, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load %s: %w", iotdeviceServiceSecretEnv, err)
 	}
-	store, err := auth.NewInMemoryNonceStore(auth.ServiceTokenNonceTTL, clock.Real())
+	store, err := auth.NewInMemoryNonceStore(auth.ServiceTokenNonceTTL, clk)
 	if err != nil {
 		return nil, fmt.Errorf("create internal listener nonce store: %w", err)
 	}

--- a/examples/iotdevice/localtoken/main.go
+++ b/examples/iotdevice/localtoken/main.go
@@ -14,10 +14,13 @@ import (
 	"github.com/ghbvf/gocell/framework/runtime/auth"
 )
 
+// defaultTokenTTL is the default lifetime for locally issued development tokens.
+const defaultTokenTTL = 8 * time.Hour
+
 func main() {
 	subject := flag.String("subject", "iotdevice-local-admin", "JWT subject")
 	roles := flag.String("roles", strings.Join(defaultRoles(), ","), "comma-separated roles")
-	ttl := flag.Duration("ttl", 8*time.Hour, "token TTL")
+	ttl := flag.Duration("ttl", defaultTokenTTL, "token TTL")
 	flag.Parse()
 
 	token, err := issueToken(*subject, *roles, *ttl)

--- a/examples/iotdevice/main_test.go
+++ b/examples/iotdevice/main_test.go
@@ -24,7 +24,7 @@ const testServiceKey = "test-service-secret-at-least-32-bytes!!"
 func TestInternalAuthChainMissingServiceSecretFailsFast(t *testing.T) {
 	t.Setenv(iotdeviceServiceSecretEnv, "")
 
-	_, err := newInternalAuthChainFromEnv()
+	_, err := newInternalAuthChainFromEnv(clock.Real())
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), iotdeviceServiceSecretEnv)
@@ -33,7 +33,7 @@ func TestInternalAuthChainMissingServiceSecretFailsFast(t *testing.T) {
 func TestInternalAuthChainContainsServiceToken(t *testing.T) {
 	t.Setenv(iotdeviceServiceSecretEnv, testServiceKey)
 
-	chain, err := newInternalAuthChainFromEnv()
+	chain, err := newInternalAuthChainFromEnv(clock.Real())
 
 	require.NoError(t, err)
 	require.NotEmpty(t, chain)
@@ -43,13 +43,13 @@ func TestInternalAuthChainContainsServiceToken(t *testing.T) {
 func TestJWTVerifierFromEnvRequiresIssuerAndAudience(t *testing.T) {
 	t.Setenv(jwtIssuerEnv, "")
 	t.Setenv(jwtAudienceEnv, "gocell")
-	_, err := newJWTVerifierFromEnv()
+	_, err := newJWTVerifierFromEnv(clock.Real())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), jwtIssuerEnv)
 
 	t.Setenv(jwtIssuerEnv, "iotdevice-local")
 	t.Setenv(jwtAudienceEnv, "")
-	_, err = newJWTVerifierFromEnv()
+	_, err = newJWTVerifierFromEnv(clock.Real())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), jwtAudienceEnv)
 }
@@ -59,7 +59,7 @@ func TestJWTVerifierFromEnvAcceptsRS256AndRejectsDemoOrHS256Tokens(t *testing.T)
 	t.Setenv(jwtIssuerEnv, "iotdevice-local")
 	t.Setenv(jwtAudienceEnv, "gocell")
 
-	verifier, err := newJWTVerifierFromEnv()
+	verifier, err := newJWTVerifierFromEnv(clock.Real())
 	require.NoError(t, err)
 
 	keySet, err := auth.LoadKeySetFromEnv(clock.Real())

--- a/examples/iotdevice/mqtt.go
+++ b/examples/iotdevice/mqtt.go
@@ -42,6 +42,9 @@ const (
 	// before fail-fast, leaving headroom for transient network jitter without
 	// hanging startup indefinitely.
 	defaultMQTTConnectDeadline = 30 * time.Second
+	// mqttPublishTimeout is the per-publish deadline passed to mqtt.NewConfig and
+	// used for the connection close fallback on publisher-init failure.
+	mqttPublishTimeout = 5 * time.Second
 )
 
 // mqttConnectDeadline resolves the bootstrap connect deadline from
@@ -180,7 +183,7 @@ func buildMQTTDirectPublisher(
 	// timing/backoff use NewConfig defaults; see adapters/mqtt.With* for TLS/auth/etc.
 	cfg, err := mqtt.NewConfig(clientID, brokers,
 		mqtt.WithConnectDeadline(connectDeadline),
-		mqtt.WithPublishTimeout(5*time.Second),
+		mqtt.WithPublishTimeout(mqttPublishTimeout),
 	)
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("mqtt config: %w", err)
@@ -196,7 +199,7 @@ func buildMQTTDirectPublisher(
 
 	pub, err := mqtt.NewPublisher(clk, conn, ns)
 	if err != nil {
-		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		closeCtx, cancel := context.WithTimeout(context.Background(), mqttPublishTimeout)
 		defer cancel()
 		if cerr := conn.Close(closeCtx); cerr != nil {
 			logger.Warn("iotdevice: mqtt connection close after publisher-init failure",

--- a/examples/iotdevice/run.go
+++ b/examples/iotdevice/run.go
@@ -73,18 +73,18 @@ func runIotdevice(ctx context.Context, assemblyID string, assemblyCellIDs []stri
 	}
 	_ = mods // cell construction is done directly below; mods only validates drift
 
-	internalAuthChain, err := newInternalAuthChainFromEnv()
-	if err != nil {
-		return fmt.Errorf("configure internal listener auth: %w", err)
-	}
-	jwtVerifier, err := newJWTVerifierFromEnv()
-	if err != nil {
-		return fmt.Errorf("configure JWT verifier: %w", err)
-	}
-
 	// Single root clock shared by assembly, bootstrap, eventbus, and cell.
 	// ref: docs/architecture/202605021500-adr-kernel-clock-injection.md
 	clk := clock.Real()
+
+	internalAuthChain, err := newInternalAuthChainFromEnv(clk)
+	if err != nil {
+		return fmt.Errorf("configure internal listener auth: %w", err)
+	}
+	jwtVerifier, err := newJWTVerifierFromEnv(clk)
+	if err != nil {
+		return fmt.Errorf("configure JWT verifier: %w", err)
+	}
 
 	// In-memory event bus for demo mode.
 	eb := eventbus.New(clk)

--- a/examples/ssobff/app.go
+++ b/examples/ssobff/app.go
@@ -95,6 +95,26 @@ const (
 // Required: NewSSOBFFApp fails fast when absent.
 const ssobffDatabaseURLEnv = "DATABASE_URL"
 
+// Duration constants for ssobff composition-root timeouts and token TTL.
+// Each name expresses the semantic rather than the bare value so callers
+// never need to look up what "5s" means in context.
+const (
+	// infraCleanupTimeout bounds the deferred close of managed infra
+	// resources (Redis/RabbitMQ) when NewSSOBFFApp fails before fully loading.
+	infraCleanupTimeout = 5 * time.Second
+	// poolCleanupTimeout bounds the deferred pool.Close call when
+	// NewSSOBFFApp fails after the PG pool is opened but before the app
+	// finishes loading.
+	poolCleanupTimeout = 5 * time.Second
+	// bootstrapAuditAppendTimeout is the detached context deadline given to
+	// the bootstrap auth-failure audit append (fire-and-forget relative to
+	// the request context).
+	bootstrapAuditAppendTimeout = 2 * time.Second
+	// ssobffJWTTokenTTL is the lifetime of tokens issued by the ssobff JWT
+	// issuer. 15 min matches the platform default in cmd/corebundle.
+	ssobffJWTTokenTTL = 15 * time.Minute
+)
+
 // SSOBFFApp is the shared ssobff composition root used by main and tests.
 //
 // Topology-gated: demo topology uses in-memory event bus + in-memory idempotency
@@ -335,7 +355,7 @@ func NewSSOBFFApp(opts ...SSOBFFAppOption) (*SSOBFFApp, error) {
 	loaded := false
 	defer func() {
 		if !loaded {
-			cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), infraCleanupTimeout)
 			defer cancel()
 			closeManagedResources(cleanupCtx, infra.rd.Resources)
 			closeManagedResources(cleanupCtx, infra.transport.Resources)
@@ -378,7 +398,7 @@ func NewSSOBFFApp(opts ...SSOBFFAppOption) (*SSOBFFApp, error) {
 	}
 	defer func() {
 		if !loaded {
-			cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), poolCleanupTimeout)
 			defer cancel()
 			_ = pool.Close(cleanupCtx)
 		}
@@ -579,7 +599,7 @@ func newSSOBFFAuthFailObserver(logger *slog.Logger, acPtr **accesscore.AccessCor
 				slog.String("client_ip_hash", ipHash.String()))
 			return
 		}
-		appendCtx, cancel := ctxutil.WithDetachedTimeout(ctx, 2*time.Second)
+		appendCtx, cancel := ctxutil.WithDetachedTimeout(ctx, bootstrapAuditAppendTimeout)
 		defer cancel()
 		if err := (*acPtr).RecordBootstrapAuthFail(appendCtx, reason, ipHash); err != nil {
 			logger.ErrorContext(ctx, "bootstrap_audit_append_failed",
@@ -951,7 +971,7 @@ func newSSOBFFJWT(topo bootstrap.Topology, clk clock.Clock) (*auth.JWTIssuer, *a
 	if err != nil {
 		return nil, nil, fmt.Errorf("ssobff: load JWT key set: %w", err)
 	}
-	jwtIssuer, err := auth.NewJWTIssuer(keySet, ssobffJWTIssuer, 15*time.Minute, clk,
+	jwtIssuer, err := auth.NewJWTIssuer(keySet, ssobffJWTIssuer, ssobffJWTTokenTTL, clk,
 		auth.WithIssuerAudiencesFromSlice([]string{ssobffJWTAudience}))
 	if err != nil {
 		return nil, nil, fmt.Errorf("ssobff: create JWT issuer: %w", err)

--- a/examples/todoorder/auth.go
+++ b/examples/todoorder/auth.go
@@ -20,7 +20,7 @@ const (
 	operatorAdminPasswordEnv  = "GOCELL_OPERATOR_ADMIN_PASSWORD"
 )
 
-func newJWTVerifierFromEnv() (*auth.JWTVerifier, error) {
+func newJWTVerifierFromEnv(clk clock.Clock) (*auth.JWTVerifier, error) {
 	issuer := strings.TrimSpace(os.Getenv(jwtIssuerEnv))
 	if issuer == "" {
 		return nil, fmt.Errorf("%s must be set", jwtIssuerEnv)
@@ -30,11 +30,11 @@ func newJWTVerifierFromEnv() (*auth.JWTVerifier, error) {
 		return nil, fmt.Errorf("%s must be set", jwtAudienceEnv)
 	}
 
-	keySet, err := auth.LoadKeySetFromEnv(clock.Real())
+	keySet, err := auth.LoadKeySetFromEnv(clk)
 	if err != nil {
 		return nil, fmt.Errorf("load JWT key set from environment: %w", err)
 	}
-	verifier, err := auth.NewJWTVerifier(keySet, clock.Real(),
+	verifier, err := auth.NewJWTVerifier(keySet, clk,
 		auth.WithExpectedAudiences(audience),
 		auth.WithExpectedIssuer(issuer))
 	if err != nil {
@@ -43,7 +43,7 @@ func newJWTVerifierFromEnv() (*auth.JWTVerifier, error) {
 	return verifier, nil
 }
 
-func newInternalAuthChainFromEnv() ([]kauth.ListenerAuth, error) {
+func newInternalAuthChainFromEnv(clk clock.Clock) ([]kauth.ListenerAuth, error) {
 	secret := os.Getenv(todoorderServiceSecretEnv)
 	if secret == "" {
 		return nil, fmt.Errorf("%s must be set for the internal listener", todoorderServiceSecretEnv)
@@ -53,7 +53,7 @@ func newInternalAuthChainFromEnv() ([]kauth.ListenerAuth, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load %s: %w", todoorderServiceSecretEnv, err)
 	}
-	store, err := auth.NewInMemoryNonceStore(auth.ServiceTokenNonceTTL, clock.Real())
+	store, err := auth.NewInMemoryNonceStore(auth.ServiceTokenNonceTTL, clk)
 	if err != nil {
 		return nil, fmt.Errorf("create internal listener nonce store: %w", err)
 	}
@@ -74,13 +74,13 @@ func newInternalAuthChainFromEnv() ([]kauth.ListenerAuth, error) {
 // port; the projection rebuild endpoint then stays programmatic-only (mirrors
 // the readyz-verbose opt-in in run.go). When set, the plan is gated by a per-IP
 // token-bucket rate limiter (defeats credential brute-force).
-func newOperatorAuthFromEnv() (kauth.AuthOperator, bool, error) {
+func newOperatorAuthFromEnv(clk clock.Clock) (kauth.AuthOperator, bool, error) {
 	username := strings.TrimSpace(os.Getenv(operatorAdminUsernameEnv))
 	password := os.Getenv(operatorAdminPasswordEnv) // not trimmed — passwords may contain whitespace
 	if username == "" || password == "" {
 		return kauth.AuthOperator{}, false, nil
 	}
-	limiter := ratelimit.New(ratelimit.Config{Rate: 1, Burst: 5}, clock.Real())
+	limiter := ratelimit.New(ratelimit.Config{Rate: 1, Burst: 5}, clk)
 	// onAuthFail is nil in this demo. Production consumers should pass a non-nil
 	// observer to route operator auth failures (401/429) to an audit log for
 	// brute-force visibility (see runtime/auth.BootstrapAuthFailObserver).

--- a/examples/todoorder/cells/ordercell/cell.go
+++ b/examples/todoorder/cells/ordercell/cell.go
@@ -94,6 +94,7 @@ func WithLogger(l *slog.Logger) Option {
 // +cell:listener:ref=cell.PrimaryListener,prefix=/api/v1
 type OrderCell struct {
 	*cell.BaseCell
+	clk        clock.Clock
 	repo       domain.OrderRepository
 	authorizer auth.Authorizer // todoorder example-owned PDP (orderAuthorizer); set in initInternal
 	txRunner   persistence.CellTxManager
@@ -125,10 +126,13 @@ type OrderCell struct {
 	projectionSvc *orderprojection.Service
 }
 
-// NewOrderCell creates a new OrderCell with the given options.
-func NewOrderCell(opts ...Option) *OrderCell {
+// NewOrderCell creates a new OrderCell with the given options. clk is a required
+// position parameter; pass clock.Real() from the composition root.
+func NewOrderCell(clk clock.Clock, opts ...Option) *OrderCell {
+	clock.MustHaveClock(clk, "ordercell.NewOrderCell")
 	c := &OrderCell{
 		BaseCell: cell.MustNewBaseCell(loadCellMetadata()),
+		clk:      clk,
 		logger:   slog.Default(),
 	}
 	for _, o := range opts {
@@ -172,7 +176,7 @@ func (c *OrderCell) initInternal(ctx context.Context, reg cell.Registrar) error 
 	c.authorizer = newOrderAuthorizer(c.repo)
 
 	// order-create slice — unified outbox path, no publisher fork.
-	createSvc, err := ordercreate.NewService(clock.Real(), c.repo, c.logger,
+	createSvc, err := ordercreate.NewService(c.clk, c.repo, c.logger,
 		ordercreate.WithEmitter(c.emitter),
 		ordercreate.WithTxManager(c.txRunner),
 	)
@@ -216,7 +220,7 @@ func (c *OrderCell) initInternal(ctx context.Context, reg cell.Registrar) error 
 	// order-confirm slice (L2 OutboxFact) — PATCH status to confirmed, publishes
 	// event.order-status-changed.v1 through the same emitter+txRunner sink as
 	// order-create.
-	confirmSvc, err := orderconfirm.NewService(clock.Real(), c.repo, c.logger,
+	confirmSvc, err := orderconfirm.NewService(c.clk, c.repo, c.logger,
 		orderconfirm.WithEmitter(c.emitter),
 		orderconfirm.WithTxManager(c.txRunner),
 	)
@@ -268,7 +272,7 @@ func (c *OrderCell) Authorizer() auth.Authorizer {
 // After this call, pendingOutboxWriter is cleared and c.emitter is the
 // composed sealed CellEmitter.
 func (c *OrderCell) resolveOutboxDeps(mode outbox.DurabilityMode) error {
-	resolved, err := outbox.ResolveCellEmitter(clock.Real(), outbox.CellEmitterInputs{
+	resolved, err := outbox.ResolveCellEmitter(c.clk, outbox.CellEmitterInputs{
 		EmitterConfig: outbox.EmitterConfig{
 			CellID:       "ordercell",
 			Mode:         mode,

--- a/examples/todoorder/cells/ordercell/cell_test.go
+++ b/examples/todoorder/cells/ordercell/cell_test.go
@@ -46,7 +46,7 @@ var _ persistence.TxRunner = demoTxRunner{}
 
 // newTestCell creates an OrderCell with NoopWriter + demoTxRunner (unified outbox path).
 func newTestCell() *OrderCell {
-	return NewOrderCell(
+	return NewOrderCell(clock.Real(),
 		WithRepository(mem.NewOrderRepository()),
 		WithOutboxWriter(outbox.WrapWriterForCell(outbox.NoopWriter{})),
 		WithTxManager(persistence.WrapForCell(demoTxRunner{})),
@@ -122,7 +122,7 @@ func TestOrderCell_InitDefaults(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewOrderCell(tt.opts...)
+			c := NewOrderCell(clock.Real(), tt.opts...)
 			err := c.Init(context.Background(), newTestRec())
 			if tt.wantErr {
 				require.Error(t, err)
@@ -138,7 +138,7 @@ func TestOrderCell_InitDefaults(t *testing.T) {
 }
 
 func TestOrderCell_DefaultInit_DemoModeRequiresExplicitOutboxPair(t *testing.T) {
-	c := NewOrderCell()
+	c := NewOrderCell(clock.Real())
 	err := c.Init(context.Background(), newTestRec())
 	require.Error(t, err)
 	var ecErrDefault *errcode.Error
@@ -167,7 +167,7 @@ func TestOrderCell_DemoMode_RejectsHalfConfiguredPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewOrderCell(tt.opts...)
+			c := NewOrderCell(clock.Real(), tt.opts...)
 			err := c.Init(context.Background(), newTestRec())
 			require.Error(t, err)
 			var ecErrReject *errcode.Error
@@ -178,7 +178,7 @@ func TestOrderCell_DemoMode_RejectsHalfConfiguredPath(t *testing.T) {
 }
 
 func TestOrderCell_DurableMode_RejectsNoopWriter(t *testing.T) {
-	c := NewOrderCell(
+	c := NewOrderCell(clock.Real(),
 		WithOutboxWriter(outbox.WrapWriterForCell(outbox.NoopWriter{})),
 		WithTxManager(persistence.WrapForCell(demoTxRunner{})),
 	)
@@ -194,7 +194,7 @@ func TestOrderCell_DurableMode_RejectsNoopWriter(t *testing.T) {
 // to inject a production cursor codec must not silently fall back to the
 // public demo key baked into the source tree.
 func TestOrderCell_DurableMode_RejectsMissingCursorCodec(t *testing.T) {
-	c := NewOrderCell(
+	c := NewOrderCell(clock.Real(),
 		WithRepository(mem.NewOrderRepository()),
 		WithOutboxWriter(outbox.WrapWriterForCell(&orderRecordingWriter{})),
 		WithTxManager(persistence.WrapForCell(orderLocalTxRunner{})),
@@ -228,7 +228,7 @@ func (orderLocalTxRunner) RunInTx(ctx context.Context, fn func(context.Context) 
 }
 
 func TestOrderCell_DemoMode_AllowsNoopWriter(t *testing.T) {
-	c := NewOrderCell(
+	c := NewOrderCell(clock.Real(),
 		WithOutboxWriter(outbox.WrapWriterForCell(outbox.NoopWriter{})),
 		WithTxManager(persistence.WrapForCell(demoTxRunner{})),
 	)

--- a/examples/todoorder/cells/ordercell/slices/orderconfirm/service.go
+++ b/examples/todoorder/cells/ordercell/slices/orderconfirm/service.go
@@ -143,7 +143,7 @@ func (s *Service) Confirm(ctx context.Context, req *confirmv1.Request) (confirmv
 	}
 
 	// Build outbox entry before tx (marshal errors should not roll back)
-	changedAt := time.Now().UTC()
+	changedAt := s.clk.Now().UTC()
 	entry, err := s.buildStatusChangedEntry(ctx, order.ID, oldStatus, order.Status, changedAt)
 	if err != nil {
 		return nil, err

--- a/examples/todoorder/localtoken/main.go
+++ b/examples/todoorder/localtoken/main.go
@@ -14,10 +14,13 @@ import (
 	"github.com/ghbvf/gocell/framework/runtime/auth"
 )
 
+// defaultTokenTTL is the default lifetime for locally-issued development tokens.
+const defaultTokenTTL = 8 * time.Hour
+
 func main() {
 	subject := flag.String("subject", "todoorder-local-customer", "JWT subject")
 	roles := flag.String("roles", ordercell.RoleCustomer, "comma-separated roles")
-	ttl := flag.Duration("ttl", 8*time.Hour, "token TTL")
+	ttl := flag.Duration("ttl", defaultTokenTTL, "token TTL")
 	flag.Parse()
 
 	token, err := issueToken(*subject, *roles, *ttl)

--- a/examples/todoorder/main_test.go
+++ b/examples/todoorder/main_test.go
@@ -24,7 +24,7 @@ const testServiceKey = "test-service-secret-at-least-32-bytes!!"
 func TestInternalAuthChainMissingServiceSecretFailsFast(t *testing.T) {
 	t.Setenv(todoorderServiceSecretEnv, "")
 
-	_, err := newInternalAuthChainFromEnv()
+	_, err := newInternalAuthChainFromEnv(clock.Real())
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), todoorderServiceSecretEnv)
@@ -33,7 +33,7 @@ func TestInternalAuthChainMissingServiceSecretFailsFast(t *testing.T) {
 func TestInternalAuthChainContainsServiceToken(t *testing.T) {
 	t.Setenv(todoorderServiceSecretEnv, testServiceKey)
 
-	chain, err := newInternalAuthChainFromEnv()
+	chain, err := newInternalAuthChainFromEnv(clock.Real())
 
 	require.NoError(t, err)
 	require.NotEmpty(t, chain)
@@ -43,13 +43,13 @@ func TestInternalAuthChainContainsServiceToken(t *testing.T) {
 func TestJWTVerifierFromEnvRequiresIssuerAndAudience(t *testing.T) {
 	t.Setenv(jwtIssuerEnv, "")
 	t.Setenv(jwtAudienceEnv, "gocell")
-	_, err := newJWTVerifierFromEnv()
+	_, err := newJWTVerifierFromEnv(clock.Real())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), jwtIssuerEnv)
 
 	t.Setenv(jwtIssuerEnv, "todoorder-local")
 	t.Setenv(jwtAudienceEnv, "")
-	_, err = newJWTVerifierFromEnv()
+	_, err = newJWTVerifierFromEnv(clock.Real())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), jwtAudienceEnv)
 }
@@ -59,7 +59,7 @@ func TestJWTVerifierFromEnvAcceptsRS256AndRejectsDemoOrHS256Tokens(t *testing.T)
 	t.Setenv(jwtIssuerEnv, "todoorder-local")
 	t.Setenv(jwtAudienceEnv, "gocell")
 
-	verifier, err := newJWTVerifierFromEnv()
+	verifier, err := newJWTVerifierFromEnv(clock.Real())
 	require.NoError(t, err)
 
 	keySet, err := auth.LoadKeySetFromEnv(clock.Real())

--- a/examples/todoorder/run.go
+++ b/examples/todoorder/run.go
@@ -106,6 +106,8 @@ func buildTodoorderBootstrap(assemblyID string, assemblyCellIDs []string, addrs 
 		return nil, err
 	}
 
+	// Single root clock shared by assembly, bootstrap, eventbus, claimer, and cell.
+	// ref: docs/architecture/202605021500-adr-kernel-clock-injection.md
 	clk := clock.Real()
 
 	internalAuthChain, err := newInternalAuthChainFromEnv(clk)
@@ -136,7 +138,7 @@ func buildTodoorderBootstrap(assemblyID string, assemblyCellIDs []string, addrs 
 	)
 
 	// Build assembly and register the cell.
-	asm := assembly.New(clock.Real(), assembly.Config{ID: assemblyID, DurabilityMode: outbox.DurabilityDemo})
+	asm := assembly.New(clk, assembly.Config{ID: assemblyID, DurabilityMode: outbox.DurabilityDemo})
 	if err := asm.Register(oc); err != nil {
 		return nil, fmt.Errorf("register ordercell: %w", err)
 	}
@@ -182,8 +184,8 @@ func buildTodoorderBootstrap(assemblyID string, assemblyCellIDs []string, addrs 
 	// without it bootstrap fails fast at startup. Demo uses an in-memory
 	// idempotency claimer (single-process only); production would inject a
 	// distributed claimer (e.g. Redis).
-	claimer := idempotency.NewInMemClaimer(clock.Real())
-	consumerBase, err := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{}, clock.Real())
+	claimer := idempotency.NewInMemClaimer(clk)
+	consumerBase, err := outbox.NewConsumerBase(claimer, outbox.ConsumerBaseConfig{}, clk)
 	if err != nil {
 		return nil, fmt.Errorf("consumer base: %w", err)
 	}
@@ -230,7 +232,7 @@ func buildTodoorderBootstrap(assemblyID string, assemblyCellIDs []string, addrs 
 		)
 	}
 
-	return bootstrap.New(clock.Real(), opts...), nil
+	return bootstrap.New(clk, opts...), nil
 }
 
 // runTodoorderModules validates that assembly.yaml cells (assemblyCellIDs)

--- a/examples/todoorder/run.go
+++ b/examples/todoorder/run.go
@@ -106,11 +106,13 @@ func buildTodoorderBootstrap(assemblyID string, assemblyCellIDs []string, addrs 
 		return nil, err
 	}
 
-	internalAuthChain, err := newInternalAuthChainFromEnv()
+	clk := clock.Real()
+
+	internalAuthChain, err := newInternalAuthChainFromEnv(clk)
 	if err != nil {
 		return nil, fmt.Errorf("configure internal listener auth: %w", err)
 	}
-	jwtVerifier, err := newJWTVerifierFromEnv()
+	jwtVerifier, err := newJWTVerifierFromEnv(clk)
 	if err != nil {
 		return nil, fmt.Errorf("configure JWT verifier: %w", err)
 	}
@@ -126,7 +128,7 @@ func buildTodoorderBootstrap(assemblyID string, assemblyCellIDs []string, addrs 
 	// Events are validated by NoopWriter then discarded. In production, inject
 	// a real outbox.Writer (e.g., postgres.OutboxWriter) + persistence.TxRunner
 	// (e.g., postgres.TxManager) for durable event delivery via relay.
-	oc := ordercell.NewOrderCell(
+	oc := ordercell.NewOrderCell(clk,
 		ordercell.WithOutboxWriter(outbox.WrapWriterForCell(outbox.NoopWriter{})),
 		ordercell.WithTxManager(persistence.WrapForCell(demoTxRunner{})),
 		ordercell.WithCursorCodec(cursorCodec),
@@ -160,7 +162,7 @@ func buildTodoorderBootstrap(assemblyID string, assemblyCellIDs []string, addrs 
 	// Operator control-plane (AdminListener) — configured only when operator
 	// credentials are present in the environment, so the demo still starts out
 	// of the box (the projection rebuild endpoint then stays programmatic-only).
-	operatorAuth, operatorEnabled, err := newOperatorAuthFromEnv()
+	operatorAuth, operatorEnabled, err := newOperatorAuthFromEnv(clk)
 	if err != nil {
 		return nil, fmt.Errorf("configure admin listener auth: %w", err)
 	}

--- a/tools/archtest/clock_invariants.go
+++ b/tools/archtest/clock_invariants.go
@@ -92,6 +92,19 @@ var clockAllowedRealCallerPaths = []string{
 	"tests/e2e/internal/clients/clients.go",   // e2e suite composition root
 	"corecells/accesscore/internal/testutil/", // SessionRepoForTest / RealSessionRepo
 	"corecells/configcore/configcoretest/",    // BuildWriteService / BuildSubscribeService default clock
+	// Example composition roots (#2149): demo entrypoints mint the real clock
+	// once and inject it downward, exactly like cmd/ above. File-level (not
+	// directory-level) so deep-component example files (auth.go, cells/…) stay
+	// governed and must accept an injected clock.Clock.
+	"examples/corebundlestarter/run.go",
+	"examples/demo/run.go",
+	"examples/iotdevice/run.go",
+	"examples/iotdevice/localtoken/main.go",
+	"examples/orderfulfillment/run.go",
+	"examples/ssobff/app.go",
+	"examples/todoorder/run.go",
+	"examples/todoorder/localtoken/main.go",
+	"examples/webhookdemo/run.go",
 }
 
 // clockIsAllowedRealCallerPath reports whether rel is exempt from the gate.

--- a/tools/archtest/clock_invariants_test.go
+++ b/tools/archtest/clock_invariants_test.go
@@ -20,7 +20,9 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -239,6 +241,51 @@ func TestClockChecksDoNotUseProdscanPatternsExtended(t *testing.T) {
 		if !sawProduction {
 			t.Errorf("%s must call Production(...) so clock invariants scan go.work satellite modules", name)
 		}
+	}
+}
+
+// TestClockAllowedRealCallerPathsNoStale is the no-stale reverse-guard for the
+// examples/* composition-root entries added to clockAllowedRealCallerPaths by
+// #2149. Those 9 hand-maintained file paths would otherwise rot into a
+// vacuous-green exemption if an example is renamed/moved/deleted (the carve-out
+// matches nothing, deep clock.Real() in that example silently re-exempted, but
+// nobody notices). This asserts every examples/* entry still resolves to an
+// existing file on disk — lifting them from Soft to Medium (#2149 review F2).
+//
+// Scope = examples/* only: the allowlist is matched against gate-relative paths
+// (clockIsAllowedRealCallerPath(p.Rel(f))), and for the framework module those
+// rels are framework-module-relative (e.g. "kernel/clock/clock.go", not the
+// workspace-relative "framework/kernel/clock/clock.go"), so a workspace-rooted
+// os.Stat does not resolve them. The examples/* rels ARE workspace-relative
+// (each example is its own go.work member loaded under the workspace root), so
+// they resolve directly. Pre-#2149 entries predate this guard and keep their
+// existing provenance.
+//
+// Residual (Soft): existence ≠ still-a-composition-root; an example whose root
+// file survives but stops being the composition root is not caught. The primary
+// defense remains the gate flagging deep clock.Real() outside the roots.
+func TestClockAllowedRealCallerPathsNoStale(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	checked := 0
+	for _, entry := range clockAllowedRealCallerPaths {
+		if !strings.HasPrefix(entry, "examples/") {
+			continue
+		}
+		checked++
+		abs := filepath.Join(root, filepath.FromSlash(entry))
+		info, err := os.Stat(abs)
+		if err != nil {
+			t.Errorf("clockAllowedRealCallerPaths entry %q does not resolve on disk (renamed/moved/deleted?): %v", entry, err)
+			continue
+		}
+		if info.IsDir() {
+			t.Errorf("clockAllowedRealCallerPaths examples entry %q must be a file (composition root), got a directory", entry)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no examples/* entries checked — anti-vacuity: #2149 added 9 examples composition roots; " +
+			"if they were all removed/renamed this guard would pass trivially")
 	}
 }
 

--- a/tools/archtest/clock_invariants_test.go
+++ b/tools/archtest/clock_invariants_test.go
@@ -171,27 +171,8 @@ func TestClockPositionalInjection(t *testing.T) {
 func TestClockWorkspaceScopeIncludesSatellites(t *testing.T) {
 	t.Parallel()
 
-	required := map[string]bool{
-		"cmd/gocell/main.go":      false,
-		"cmd/gocell/app/check.go": false,
-		"cmd/corebundle/main.go":  false,
-	}
-
-	_ = Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
-		for _, f := range p.Files {
-			rel := filepath.ToSlash(p.Rel(f))
-			if _, ok := required[rel]; ok {
-				required[rel] = true
-			}
-		}
-		return nil
-	})
-
-	for rel, seen := range required {
-		if !seen {
-			t.Errorf("clock workspace production scope did not visit %s; satellite module coverage would be vacuous", rel)
-		}
-	}
+	assertScopeVisits(t, "clock workspace production", Production(TypedOpts{Tests: false}),
+		"cmd/gocell/main.go", "cmd/gocell/app/check.go", "cmd/corebundle/main.go")
 }
 
 func TestClockChecksDoNotUseProdscanPatternsExtended(t *testing.T) {

--- a/tools/archtest/errcode_invariants.go
+++ b/tools/archtest/errcode_invariants.go
@@ -311,8 +311,11 @@ func buildCarvedRangeChecker(f *ast.File, rel string, carveOuts map[carveOut]str
 // file present under both configs is scanned once and multiple violations on a
 // single line are preserved. GoCell's dogfood passes FlatNonDefaultTags(); an
 // external repo passes whatever tags gate its production files — neither is
-// baked in. The scan SCOPE is the running module's prodscan patterns (resolved
-// by findModuleRoot from its go.mod), never the platform module.
+// baked in. The scan SCOPE is the running module's satellite-inclusive prodscan
+// patterns (PatternsWithSatellites: base + tests/ + tools/ + go.work satellite
+// parents + top-level module roots, #2148) — errcode stays on prodscan patterns
+// rather than Production() because it must also cover tools/ and tests/
+// production files, which Production() excludes.
 //
 // skip excludes a rule's allowlisted relative paths (e.g. pkg/errcode/ itself,
 // the migration destination); perFile is the rule's per-file AST/types scanner.
@@ -328,7 +331,7 @@ func runErrcodeTypedScan(
 	}
 
 	root := findModuleRoot(t)
-	patterns := prodscan.PatternsExtended(root)
+	patterns := prodscan.PatternsWithSatellites(root)
 
 	visited := map[string]bool{}
 	var out []Diagnostic

--- a/tools/archtest/errcode_invariants_test.go
+++ b/tools/archtest/errcode_invariants_test.go
@@ -1162,26 +1162,9 @@ func TestErrcodeScanScopeIncludesSatellites(t *testing.T) {
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
 	root := findModuleRoot(t)
-	required := map[string]bool{
-		"cmd/gocell/main.go":     false,
-		"cmd/corebundle/main.go": false,
-	}
-	_ = Run(t, Typed(TypedOpts{Tests: false}, prodscan.PatternsWithSatellites(root)),
-		func(p *Pass) []Diagnostic {
-			for _, f := range p.Files {
-				rel := filepath.ToSlash(p.Rel(f))
-				if _, ok := required[rel]; ok {
-					required[rel] = true
-				}
-			}
-			return nil
-		})
-	for rel, seen := range required {
-		if !seen {
-			t.Errorf("errcode scan scope (prodscan.PatternsWithSatellites) did not visit %s; "+
-				"satellite coverage would be vacuous", rel)
-		}
-	}
+	assertScopeVisits(t, "errcode (prodscan.PatternsWithSatellites)",
+		Typed(TypedOpts{Tests: false}, prodscan.PatternsWithSatellites(root)),
+		"cmd/gocell/main.go", "cmd/corebundle/main.go")
 }
 
 // ─── import anchors ───────────────────────────────────────────────────────────

--- a/tools/archtest/errcode_invariants_test.go
+++ b/tools/archtest/errcode_invariants_test.go
@@ -869,7 +869,7 @@ func TestErrcodePrefixOwnership01(t *testing.T) {
 	}
 
 	root := findModuleRoot(t)
-	patterns := prodscan.PatternsExtended(root)
+	patterns := prodscan.PatternsWithSatellites(root)
 
 	visited := map[string]bool{}
 	canaryObserved := map[string]bool{}
@@ -920,7 +920,7 @@ func TestErrcodePrefixOwnership01(t *testing.T) {
 		t.Errorf("ERRCODE-PREFIX-OWNERSHIP-01: canary anchor failed — "+
 			"production scan did not observe codes %q (seen=%v) and %q (seen=%v). "+
 			"This means the scan loaded nothing or the scope regressed; "+
-			"check prodscan.PatternsExtended and fileroles.IsProductionCode.",
+			"check prodscan.PatternsWithSatellites and fileroles.IsProductionCode.",
 			canaryA, canaryObserved[canaryA], canaryB, canaryObserved[canaryB])
 	}
 
@@ -1079,11 +1079,76 @@ func TestErrcodePrefixOwnership01_SentinelConstEval(t *testing.T) {
 	}
 }
 
+// TestErrcodeProductionScansUseSatelliteScope locks #2148: the two errcode
+// production scans — runErrcodeTypedScan (shared by MESSAGE-CONST-LITERAL-01,
+// EXPORTED-ERROR-NEW-01, …) and TestErrcodePrefixOwnership01
+// (ERRCODE-PREFIX-OWNERSHIP-01) — must resolve their scan patterns via
+// prodscan.PatternsWithSatellites, the satellite-inclusive scope, never
+// prodscan.PatternsExtended, which drops the go.work satellite parents (cmd/,
+// adapters/, examples/) and the top-level module roots (corecells/,
+// cellmodules/). errcode intentionally stays on prodscan patterns (not
+// Production()) because it must also cover tools/ and tests/ production files,
+// which Production() excludes.
+//
+// AI-robust: Medium (type-aware AST scan of the two scan-entry functions; a
+// regression back to PatternsExtended re-vacates satellite coverage and fails
+// here). Mirrors TestClockChecksDoNotUseProdscanPatternsExtended. Satellite
+// inclusion is a per-gate opt-in by name (see prodscan.PatternsWithSatellites
+// godoc) — this guard is scoped to errcode's two functions, not a global ban.
+func TestErrcodeProductionScansUseSatelliteScope(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	targets := []struct{ file, fn string }{
+		{"errcode_invariants.go", "runErrcodeTypedScan"},
+		{"errcode_invariants_test.go", "TestErrcodePrefixOwnership01"},
+	}
+	for _, tg := range targets {
+		path := filepath.Join(root, "tools", "archtest", tg.file)
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parse %s: %v", tg.file, err)
+		}
+		var found, sawSatellites bool
+		EachInChildren[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
+			if fn.Name == nil || fn.Body == nil || fn.Name.Name != tg.fn {
+				return
+			}
+			found = true
+			EachInSubtree[ast.CallExpr](fn.Body, func(call *ast.CallExpr) {
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return
+				}
+				ident, ok := sel.X.(*ast.Ident)
+				if !ok || ident.Name != "prodscan" {
+					return
+				}
+				switch sel.Sel.Name {
+				case "PatternsWithSatellites":
+					sawSatellites = true
+				case "PatternsExtended":
+					t.Errorf("%s.%s must not call prodscan.PatternsExtended; it drops go.work "+
+						"satellite modules — use PatternsWithSatellites (#2148)", tg.file, tg.fn)
+				}
+			})
+		})
+		if !found {
+			t.Errorf("%s: function %s not found (renamed?); update "+
+				"TestErrcodeProductionScansUseSatelliteScope", tg.file, tg.fn)
+		}
+		if !sawSatellites {
+			t.Errorf("%s.%s must call prodscan.PatternsWithSatellites so errcode scans "+
+				"go.work satellite modules (#2148)", tg.file, tg.fn)
+		}
+	}
+}
+
 // ─── import anchors ───────────────────────────────────────────────────────────
 
 // These blank-identifier references keep frequently-used imports live so that
 // go tooling (goimports, vet) does not remove them between edits.
 var (
-	_ = prodscan.PatternsExtended
+	_ = prodscan.PatternsWithSatellites
 	_ = fileroles.IsProductionCode
 )

--- a/tools/archtest/errcode_invariants_test.go
+++ b/tools/archtest/errcode_invariants_test.go
@@ -1095,6 +1095,12 @@ func TestErrcodePrefixOwnership01_SentinelConstEval(t *testing.T) {
 // here). Mirrors TestClockChecksDoNotUseProdscanPatternsExtended. Satellite
 // inclusion is a per-gate opt-in by name (see prodscan.PatternsWithSatellites
 // godoc) — this guard is scoped to errcode's two functions, not a global ban.
+//
+// Residual (Soft, accepted): pure AST name-match on `prodscan.PatternsWithSatellites`
+// — an import alias (e.g. `ps "…/prodscan"; ps.PatternsWithSatellites`) would bypass
+// it. Kept Soft because both files' import blocks are trivially audited, and the
+// actual satellite coverage is independently proven by the anti-vacuity test
+// TestErrcodeScanScopeIncludesSatellites.
 func TestErrcodeProductionScansUseSatelliteScope(t *testing.T) {
 	t.Parallel()
 	root := findModuleRoot(t)
@@ -1140,6 +1146,40 @@ func TestErrcodeProductionScansUseSatelliteScope(t *testing.T) {
 		if !sawSatellites {
 			t.Errorf("%s.%s must call prodscan.PatternsWithSatellites so errcode scans "+
 				"go.work satellite modules (#2148)", tg.file, tg.fn)
+		}
+	}
+}
+
+// TestErrcodeScanScopeIncludesSatellites is the self-contained anti-vacuity
+// companion to TestErrcodeProductionScansUseSatelliteScope (#2149 review F3):
+// the AST guard proves errcode calls prodscan.PatternsWithSatellites; this proves
+// that scope actually visits satellite-module production files, so errcode
+// satellite coverage (#2148) is non-vacuous. Mirrors
+// TestPanicRegisteredScopeIncludesSatellites / TestClockWorkspaceScopeIncludesSatellites.
+func TestErrcodeScanScopeIncludesSatellites(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+	root := findModuleRoot(t)
+	required := map[string]bool{
+		"cmd/gocell/main.go":     false,
+		"cmd/corebundle/main.go": false,
+	}
+	_ = Run(t, Typed(TypedOpts{Tests: false}, prodscan.PatternsWithSatellites(root)),
+		func(p *Pass) []Diagnostic {
+			for _, f := range p.Files {
+				rel := filepath.ToSlash(p.Rel(f))
+				if _, ok := required[rel]; ok {
+					required[rel] = true
+				}
+			}
+			return nil
+		})
+	for rel, seen := range required {
+		if !seen {
+			t.Errorf("errcode scan scope (prodscan.PatternsWithSatellites) did not visit %s; "+
+				"satellite coverage would be vacuous", rel)
 		}
 	}
 }

--- a/tools/archtest/helpers_test.go
+++ b/tools/archtest/helpers_test.go
@@ -57,6 +57,35 @@ func findArchTestDir(t *testing.T) string {
 	return filepath.Join(root, "tools", "archtest")
 }
 
+// assertScopeVisits fails t for any required module-relative path that `scope`
+// does not load. It is the shared anti-vacuity body for the satellite-coverage
+// tests of the workspace-scoped governance gates (panic / errcode / clock):
+// each proves its scan scope actually reaches the satellite and examples
+// modules, so the gate is not silently vacuous there. `rule` labels the gate in
+// the failure message. Single-sourced here so the (previously triplicated)
+// scan+assert block is not flagged as duplicated code (#2252).
+func assertScopeVisits(t *testing.T, rule string, scope RunScope, paths ...string) {
+	t.Helper()
+	required := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		required[p] = false
+	}
+	_ = Run(t, scope, func(p *Pass) []Diagnostic {
+		for _, f := range p.Files {
+			rel := filepath.ToSlash(p.Rel(f))
+			if _, ok := required[rel]; ok {
+				required[rel] = true
+			}
+		}
+		return nil
+	})
+	for rel, seen := range required {
+		if !seen {
+			t.Errorf("%s scan scope did not visit %s; satellite coverage would be vacuous", rule, rel)
+		}
+	}
+}
+
 // TestFindCellProductionGoFiles_IncludesExamples is a Wave 1 RED test for
 // Part B scanning-root unification. It asserts the metadata-rooted helper
 // returns at least one cell file under examples/. Pre-refactor the helper

--- a/tools/archtest/panic_invariants.go
+++ b/tools/archtest/panic_invariants.go
@@ -271,22 +271,30 @@ func scanPanicBuiltinShadows(
 
 // shouldSkipForPanicRegistered returns true for paths that must not be
 // scanned by PANIC-REGISTERED-01 (test files, generated code, testdata, etc.).
-// Preserved verbatim from the pre-migration rule so gocell behavior is
-// identical; the skip set is two kinds:
+// The skip set is two kinds:
 //
 //   - UNIVERSAL (correct for any module): "_test.go", "vendor/", "generated/",
-//     "examples/", "testdata/", "node_modules/". An external repo's own files
-//     under these are non-production by the same convention.
+//     "testdata/", "node_modules/". An external repo's own files under these are
+//     non-production by the same convention.
 //   - GoCell-SPECIFIC (a gocell layout artifact): "tools/archtest/",
 //     "worktrees/", ".git/", "/auditcoretest/". An external repo simply lacks
 //     these trees, so the arm never matches — harmless, but it is gocell noise
 //     in an importable rule.
 //
-// Generalizing the skip set for external consumers (single-sourcing it through
-// tools/internal/fileroles.IsProductionCode and/or a consumer-supplied
-// SkipPaths) is part of the scan-scope generalization tracked with the rest of
-// the rule migration in #1302; it is deliberately NOT changed here to keep this
-// foundation PR's PANIC-REGISTERED-01 behavior byte-for-byte identical.
+// examples/ is NOT skipped: example projects are real binaries held to the same
+// production governance as the rest of the platform (#2149), so PANIC-REGISTERED-01
+// must scan their production files. This is the single-sourced classification of
+// tools/internal/fileroles.IsProductionCode (which returns true for examples/);
+// TestPanicRegisteredDoesNotSkipExamples binds this arm's examples treatment to
+// that source so the drift codex flagged on PR #2252 cannot silently recur.
+//
+// This skip set is still a SEPARATE copy of the production-file classifier rather
+// than fully delegating to fileroles.IsProductionCode: the two diverge beyond
+// examples/ (fileroles also treats **/conformance.go and the gocell test-helper
+// packages — locktest/, outboxtest/, … — as test code, which this set does not),
+// and fileroles encodes gocell-specific helper-package names that an importable
+// external-cell rule cannot assume. Collapsing the two needs a consumer-supplied
+// SkipPaths seam; that full single-sourcing is tracked in #1302.
 func shouldSkipForPanicRegistered(rel string) bool {
 	switch {
 	case strings.HasSuffix(rel, "_test.go"):
@@ -294,8 +302,6 @@ func shouldSkipForPanicRegistered(rel string) bool {
 	case strings.HasPrefix(rel, "vendor/"):
 		return true
 	case strings.HasPrefix(rel, "generated/"):
-		return true
-	case strings.HasPrefix(rel, "examples/"):
 		return true
 	case strings.HasPrefix(rel, "tools/archtest/"): // gocell-specific
 		return true

--- a/tools/archtest/panic_invariants.go
+++ b/tools/archtest/panic_invariants.go
@@ -313,16 +313,24 @@ func shouldSkipForPanicRegistered(rel string) bool {
 	return false
 }
 
-// CheckPanicRegistered runs PANIC-REGISTERED-01 over the running module and
-// returns its diagnostics. It is the importable [CellRule] body wrapped by
-// [StandardCellRules]; GoCell's TestPanicRegistered calls it directly so the
-// gate has a single source. The scan SCOPE is the running module (resolved from
-// its go.mod by Run(t, Typed(...))); cfg.BuildTags supplies the build tags for
-// the second pass so panics behind the consumer's //go:build directives are
-// scanned too.
+// CheckPanicRegistered runs PANIC-REGISTERED-01 over the workspace production
+// package set and returns its diagnostics. It is the importable [CellRule] body
+// wrapped by [StandardCellRules]; GoCell's TestPanicRegistered calls it directly
+// so the gate has a single source. The scan SCOPE is Production(...) — the
+// workspace-aware scope that expands to one ./<dir>/... per go.work member
+// (typeseval.LoadProductionPackages), so satellite modules (cmd/, adapters/,
+// examples/, corecells/, cellmodules/) are scanned; for an external
+// single-module cell Production() reduces to that module via workspace.Modules'
+// single-module fallback. cfg.BuildTags supplies the build tags for the second
+// pass so panics behind the consumer's //go:build directives are scanned too.
+//
+// Before #2148 this used Typed(./...), which at GoCell's module-less workspace
+// root resolves to zero packages — leaving the entire production tree silently
+// unscanned (vacuous). Converged onto the same Production() scope its sibling
+// TestPanicLogRedact already uses.
 //
 // The default build config is always scanned; when cfg.BuildTags is non-empty a
-// second Run(t, Typed(...)) load covers files behind those tags, deduped by
+// second Production(...) load covers files behind those tags, deduped by
 // "rel:line:reason". GoCell's dogfood passes FlatNonDefaultTags(); an external
 // repo passes its own production tags. See the long note in the prior
 // TestPanicRegistered body / ADR 202605190000 §Alternatives for why a single
@@ -337,9 +345,9 @@ func CheckPanicRegistered(t *testing.T, cfg ConfigForExternalCell) []Diagnostic 
 		return nil
 	}
 
-	_ = Run(t, Typed(TypedOpts{}, []string{"./..."}), scan)
+	_ = Run(t, Production(TypedOpts{Tests: false}), scan)
 	if len(cfg.BuildTags) > 0 {
-		_ = Run(t, Typed(TypedOpts{Tags: cfg.BuildTags}, []string{"./..."}), scan)
+		_ = Run(t, Production(TypedOpts{Tests: false, Tags: cfg.BuildTags}), scan)
 	}
 
 	sort.Slice(violations, func(i, j int) bool {

--- a/tools/archtest/panic_invariants_test.go
+++ b/tools/archtest/panic_invariants_test.go
@@ -235,31 +235,13 @@ func TestPanicRegisteredUsesProductionScope(t *testing.T) {
 // TestClockWorkspaceScopeIncludesSatellites.
 func TestPanicRegisteredScopeIncludesSatellites(t *testing.T) {
 	t.Parallel()
-	required := map[string]bool{
-		"cmd/gocell/main.go":     false,
-		"cmd/corebundle/main.go": false,
-		// examples/ is production code held to PANIC-REGISTERED-01 (#2149); prove
-		// the Production() scope LOADS an examples production file (the FILTER side
-		// — that shouldSkipForPanicRegistered does not drop it again — is held by
-		// TestPanicRegisteredDoesNotSkipExamples). Also the disk-existence no-stale
-		// anchor for that test's examples fixture: rename/delete fails here.
-		"examples/iotdevice/run.go": false,
-	}
-	_ = Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
-		for _, f := range p.Files {
-			rel := filepath.ToSlash(p.Rel(f))
-			if _, ok := required[rel]; ok {
-				required[rel] = true
-			}
-		}
-		return nil
-	})
-	for rel, seen := range required {
-		if !seen {
-			t.Errorf("PANIC-REGISTERED-01 Production scope did not visit %s; "+
-				"satellite coverage would be vacuous", rel)
-		}
-	}
+	// examples/iotdevice/run.go proves the Production() scope LOADS an examples
+	// production file (the FILTER side — that shouldSkipForPanicRegistered does
+	// not drop it again — is held by TestPanicRegisteredDoesNotSkipExamples,
+	// #2149); it is also that test's disk-existence no-stale anchor (rename/delete
+	// fails here).
+	assertScopeVisits(t, "PANIC-REGISTERED-01 Production", Production(TypedOpts{Tests: false}),
+		"cmd/gocell/main.go", "cmd/corebundle/main.go", "examples/iotdevice/run.go")
 }
 
 // TestPanicRegisteredDoesNotSkipExamples is the FILTER-stage companion to

--- a/tools/archtest/panic_invariants_test.go
+++ b/tools/archtest/panic_invariants_test.go
@@ -168,6 +168,86 @@ func TestPanicRegistered(t *testing.T) {
 		CheckPanicRegistered(t, ConfigForExternalCell{BuildTags: FlatNonDefaultTags()}))
 }
 
+// TestPanicRegisteredUsesProductionScope locks #2148's vacuity fix:
+// CheckPanicRegistered must scan via Production(...) — the workspace-aware scope
+// that expands to one ./<dir>/... per go.work member (see
+// typeseval.LoadProductionPackages) — never Typed(./...), which at GoCell's
+// module-less workspace root resolves to ZERO packages, leaving the entire
+// production tree silently unscanned. Its sibling TestPanicLogRedact already
+// uses Production(); this converges both panic gates onto one scope.
+//
+// AI-robust: Medium (type-aware AST scan; a regression to Typed(./...) re-vacates
+// the dogfood scan and fails here). Mirrors
+// TestClockChecksDoNotUseProdscanPatternsExtended. Production() subsumes the
+// external single-module cell via workspace.Modules' single-module fallback, so
+// no transport-specific dual-path is needed.
+func TestPanicRegisteredUsesProductionScope(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	path := filepath.Join(root, "tools", "archtest", "panic_invariants.go")
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse panic_invariants.go: %v", err)
+	}
+	var found, sawProduction bool
+	EachInChildren[ast.FuncDecl](file, func(fn *ast.FuncDecl) {
+		if fn.Name == nil || fn.Body == nil || fn.Name.Name != "CheckPanicRegistered" {
+			return
+		}
+		found = true
+		EachInSubtree[ast.CallExpr](fn.Body, func(call *ast.CallExpr) {
+			ident, ok := call.Fun.(*ast.Ident)
+			if !ok {
+				return
+			}
+			switch ident.Name {
+			case "Production":
+				sawProduction = true
+			case "Typed":
+				t.Errorf("CheckPanicRegistered must use Production(...) scope, not Typed(./...); " +
+					"Typed drops go.work satellites and is vacuous at the module-less workspace root (#2148)")
+			}
+		})
+	})
+	if !found {
+		t.Errorf("CheckPanicRegistered not found in panic_invariants.go (renamed?); " +
+			"update TestPanicRegisteredUsesProductionScope")
+	}
+	if !sawProduction {
+		t.Errorf("CheckPanicRegistered must call Production(...) so PANIC-REGISTERED-01 scans " +
+			"the whole workspace including satellites (#2148)")
+	}
+}
+
+// TestPanicRegisteredScopeIncludesSatellites is the self-contained anti-vacuity
+// companion: it proves the Production() scope that CheckPanicRegistered now uses
+// actually visits satellite-module production files, so PANIC-REGISTERED-01
+// coverage is non-vacuous after #2148. Mirrors
+// TestClockWorkspaceScopeIncludesSatellites.
+func TestPanicRegisteredScopeIncludesSatellites(t *testing.T) {
+	t.Parallel()
+	required := map[string]bool{
+		"cmd/gocell/main.go":     false,
+		"cmd/corebundle/main.go": false,
+	}
+	_ = Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
+		for _, f := range p.Files {
+			rel := filepath.ToSlash(p.Rel(f))
+			if _, ok := required[rel]; ok {
+				required[rel] = true
+			}
+		}
+		return nil
+	})
+	for rel, seen := range required {
+		if !seen {
+			t.Errorf("PANIC-REGISTERED-01 Production scope did not visit %s; "+
+				"satellite coverage would be vacuous", rel)
+		}
+	}
+}
+
 // TestScanPanicBuiltinShadows is the reverse self-check for the one declared
 // blind spot of the pure-AST panic detection (see scanPanicBuiltinShadows
 // godoc): the rule matches the `panic` builtin by name, so a declaration that

--- a/tools/archtest/panic_invariants_test.go
+++ b/tools/archtest/panic_invariants_test.go
@@ -181,6 +181,12 @@ func TestPanicRegistered(t *testing.T) {
 // TestClockChecksDoNotUseProdscanPatternsExtended. Production() subsumes the
 // external single-module cell via workspace.Modules' single-module fallback, so
 // no transport-specific dual-path is needed.
+//
+// Residual (Soft, accepted): matches the bare-Ident call form `Production(...)`
+// (same-package direct call). A migration to a qualified form
+// (`archtest.Production(...)`, a SelectorExpr) would slip past this scan — update
+// the matcher then. The non-vacuous coverage itself is held by the companion
+// TestPanicRegisteredScopeIncludesSatellites.
 func TestPanicRegisteredUsesProductionScope(t *testing.T) {
 	t.Parallel()
 	root := findModuleRoot(t)

--- a/tools/archtest/panic_invariants_test.go
+++ b/tools/archtest/panic_invariants_test.go
@@ -45,6 +45,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/tools/internal/fileroles"
 )
 
 // panicLogRedactViol is the PANIC-LOG-REDACT-01 diagnostic.
@@ -236,6 +238,12 @@ func TestPanicRegisteredScopeIncludesSatellites(t *testing.T) {
 	required := map[string]bool{
 		"cmd/gocell/main.go":     false,
 		"cmd/corebundle/main.go": false,
+		// examples/ is production code held to PANIC-REGISTERED-01 (#2149); prove
+		// the Production() scope LOADS an examples production file (the FILTER side
+		// — that shouldSkipForPanicRegistered does not drop it again — is held by
+		// TestPanicRegisteredDoesNotSkipExamples). Also the disk-existence no-stale
+		// anchor for that test's examples fixture: rename/delete fails here.
+		"examples/iotdevice/run.go": false,
 	}
 	_ = Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
 		for _, f := range p.Files {
@@ -250,6 +258,45 @@ func TestPanicRegisteredScopeIncludesSatellites(t *testing.T) {
 		if !seen {
 			t.Errorf("PANIC-REGISTERED-01 Production scope did not visit %s; "+
 				"satellite coverage would be vacuous", rel)
+		}
+	}
+}
+
+// TestPanicRegisteredDoesNotSkipExamples is the FILTER-stage companion to
+// TestPanicRegisteredScopeIncludesSatellites: loading an examples file into the
+// scan is necessary but not sufficient — shouldSkipForPanicRegistered must also
+// not drop it again. Codex's PR #2252 review (cluster C1) caught exactly that
+// drift: #2149 put examples/ under production governance and CheckPanicRegistered
+// scans it via Production(), but the rule's own file filter still skipped the
+// whole examples/ tree, so PANIC-REGISTERED-01 over examples was false-green.
+//
+// This binds the filter's examples treatment to the single source
+// fileroles.IsProductionCode (which returns true for examples/): the positive
+// fixture must be BOTH unskipped here AND production per fileroles, so the two
+// classifiers cannot drift apart on examples/ again. The fixture's disk
+// existence is held by TestPanicRegisteredScopeIncludesSatellites (same path),
+// so no extra stat is needed here.
+//
+// AI-robust: Medium (runtime guard; re-adding the examples skip turns this RED).
+// A Hard form — deriving the skip set from fileroles so a separate examples arm
+// is unexpressible — needs a consumer-supplied SkipPaths seam for the importable
+// external-cell rule; that full single-sourcing is tracked in #1302.
+func TestPanicRegisteredDoesNotSkipExamples(t *testing.T) {
+	t.Parallel()
+	const examplesProd = "examples/iotdevice/run.go"
+	if shouldSkipForPanicRegistered(examplesProd) {
+		t.Errorf("shouldSkipForPanicRegistered(%q) = true; examples/ is production code "+
+			"and must be scanned by PANIC-REGISTERED-01 (#2149/#2252 C1)", examplesProd)
+	}
+	if !fileroles.IsProductionCode(examplesProd) {
+		t.Errorf("fileroles.IsProductionCode(%q) = false; the examples production "+
+			"classification drifted from the single source — re-sync the filter", examplesProd)
+	}
+	// Anti-vacuity: the skip set must still drop genuine non-production paths,
+	// so the examples-arm removal did not blunt the whole filter.
+	for _, rel := range []string{"examples/iotdevice/run_test.go", "vendor/x/y.go", "generated/z.go"} {
+		if !shouldSkipForPanicRegistered(rel) {
+			t.Errorf("shouldSkipForPanicRegistered(%q) = false; the skip set is broken", rel)
 		}
 	}
 }

--- a/tools/archtest/prod_invariants_test.go
+++ b/tools/archtest/prod_invariants_test.go
@@ -55,11 +55,11 @@ func TestProdDurationConst(t *testing.T) {
 	}
 
 	root := findModuleRoot(t)
-	// PatternsWithSatellites adds the cmd/adapters satellite parents the typed
-	// loader expands to real members — #2136. (examples/ production files are
-	// filtered out below by fileroles.IsProductionCode, so its production duration
-	// literals stay demo-exempt; the satellite increment is shared, the filter
-	// handles the examples/ asymmetry.)
+	// PatternsWithSatellites adds the cmd/adapters/examples satellite parents the
+	// typed loader expands to real members — #2136. examples/ production files are
+	// IN scope: fileroles.IsProductionCode now RETAINS them (#2149 removed the
+	// examples/ demo-exemption), so their production duration literals are gated
+	// like the rest of the platform — not filtered out below.
 	patterns := prodscan.PatternsWithSatellites(root)
 
 	var violations []string

--- a/tools/internal/fileroles/fileroles.go
+++ b/tools/internal/fileroles/fileroles.go
@@ -15,7 +15,9 @@
 // file under a top-level Go directory (cmd/, kernel/, runtime/, adapters/,
 // cells/, examples/, pkg/, tests/, tools/) that is NOT test code, NOT
 // vendored, NOT generated, NOT under any testdata/ tree, and NOT inside
-// the archtest tooling itself.
+// the archtest tooling itself. examples/ production code (main.go, cell.go,
+// …) is in scope: example projects are real binaries the platform gates must
+// hold to the same production discipline (#2149).
 //
 // Both predicates take module-relative paths in forward-slash form
 // ("kernel/outbox/consumer.go", not absolute paths or backslashes). The
@@ -109,10 +111,12 @@ func IsTestCode(rel string) bool {
 //   - vendor/, generated/ — third-party / generated content
 //   - any path containing testdata/ — Go's reserved fixture directory
 //   - any /conformance.go — driver-conformance suites are test code
-//   - examples/ — example projects ship documentation, not production binaries
 //
 // Inclusions: any other Go file under cmd/, kernel/, runtime/, adapters/,
-// cells/, pkg/, tests/, tools/ that is not caught by IsTestCode.
+// cells/, examples/, pkg/, tests/, tools/ that is not caught by IsTestCode.
+// examples/ production code is in scope (#2149): example binaries are held to
+// the same production governance (errcode / clock / panic / duration) as the
+// rest of the platform.
 func IsProductionCode(rel string) bool {
 	if rel == "" {
 		return false
@@ -125,8 +129,6 @@ func IsProductionCode(rel string) bool {
 	case strings.HasPrefix(rel, "generated/"):
 		return false
 	case strings.HasPrefix(rel, "testdata/"), strings.Contains(rel, "/testdata/"):
-		return false
-	case strings.HasPrefix(rel, "examples/"):
 		return false
 	}
 	return !IsTestCode(rel)

--- a/tools/internal/fileroles/fileroles_test.go
+++ b/tools/internal/fileroles/fileroles_test.go
@@ -114,7 +114,7 @@ func TestIsProductionCode(t *testing.T) {
 		{"locktest helper", "runtime/distlock/locktest/fake_clock.go", false},
 		{"commandtest helper", "kernel/command/commandtest/inmem.go", false},
 
-		{"examples (test or prod)", "examples/ssobff/main.go", false},
+		{"examples production", "examples/ssobff/main.go", true},
 		{"examples test", "examples/ssobff/walkthrough_test.go", false},
 
 		{"archtest self", "tools/archtest/test_time_literal_test.go", false},


### PR DESCRIPTION
## Summary

收口生产代码治理扫描覆盖：修复 PANIC-REGISTERED-01 的 workspace vacuity，把 errcode 扫描扩到 satellite，并把 examples/ 纳入生产治理（#2148 + #2149）。

## Why / 背景

PR #2143 把 duration 家族 gate 扩到 satellite 后，其余 typeseval-path gate 的覆盖留有缺口：

- **PANIC-REGISTERED-01 实为 vacuous**：`CheckPanicRegistered` 用 `Typed(./...)`，但本仓 workspace 根**无 go.mod**（`go list ./...` = 0 包），整棵生产树漏扫。其 sibling PANIC-LOG-REDACT-01 早已用 `Production()`。收敛后立即抓出一个真实违规（adapters/postgres，untyped nil panic payload）——证明该 gate 此前形同虚设。
- **errcode 仅扫 satellite-free 集**：`PatternsExtended` 不含 cmd/adapters/examples/corecells/cellmodules。
- **examples/ 整体豁免生产治理**：`fileroles.IsProductionCode` 短路 `examples/`，demo 代码不受 errcode/clock/duration/panic 约束、可积累不符约束写法。

方向：让这些 gate 真正覆盖它们该覆盖的生产代码（含 satellites + examples），demo 模型生产最佳实践。

## 改动

**#2148 — gate satellite/workspace 覆盖：**
- `CheckPanicRegistered`：`Typed(./...)` → `Production()`（双 build-tag pass，与 sibling 逐字同构；`workspace.Modules` 单模块 fallback 覆盖外部 cell，无 dual-path）。
- errcode 两个生产扫描（`runErrcodeTypedScan` + `TestErrcodePrefixOwnership01`）：`PatternsExtended` → `PatternsWithSatellites`。
- 真实违规修复：`adapters/postgres/journaling_outbox_writer.go` `panicregister.Approved(..., nil)` → `errcode.Assertion(...)`（typed payload，仿 `clock.MustHaveClock`）。
- 新增 scoped 回归守卫 + anti-vacuity：`TestErrcodeProductionScansUseSatelliteScope`、`TestPanicRegisteredUsesProductionScope`、`TestPanicRegisteredScopeIncludesSatellites`（仿既有 clock 守卫，AI-robust **Medium**）。

**#2149 — examples 纳入生产治理：**
- `fileroles.IsProductionCode` 移除 `examples/` 豁免。
- `KERNEL-CLOCK-LEAF-FALLBACK-01` carve-out 扩到 9 个 examples composition root（file-level，与 `cmd/` 同等；深层组件不豁免）。
- 修 examples 深层违规：iotdevice/todoorder 的 `auth.go`/`cell.go`/`service.go` 线程注入 `clock.Clock`；iotdevice/ssobff/todoorder 共 8 处 duration 抽 package const。

## Refs

- Closes #2148
- Closes #2149
- 相关：#2143（duration satellite 扩展，范本）、#2202（go.work 派生 prodscan，本轮关单 wontfix）

## Risk / 兼容性

- **无 wire/contract 变更**：纯 archtest 治理基建 + examples 内部接线 + 1 处 adapter panic payload。无契约扇出。
- examples 部分构造器签名新增 `clock.Clock` 位置参（`NewOrderCell`、example-local `newJWTVerifier*` 等）——均为 examples 内部，非平台导出 API，随同 PR 原子更新，无外部消费方。
- **已知 PRE-EXISTING 失败（与本 PR 无关，不在本 PR 修）**：full archtest 套件（nightly，非 per-PR）另有 2 个失败 —— `examples/orderfulfillment/run.go` 缺 `bootstrap.WithConsumerBase`、`framework/kernel/governance/rules_topo13_test.go` typed CellID builder 违规。已 stash 验证二者在 `origin/develop` 同样失败、scope 与本 PR 改动正交。建议各开 backlog issue 单独处理。

## Test plan

- [x] 全 workspace 构建通过（`hack/verify-workspace.sh`，30 模块）
- [x] 受影响 gate 全绿（errcode / clock / panic / duration + 新增守卫；`adapters/postgres` 真实违规已修）
- [x] `golangci-lint run`（tools `--build-tags=archtest,releasesmoke` / adapters/postgres / 3 examples）0 issues
- [x] integration-tag 构建通过（adapters/postgres + 3 examples）
- [x] tools 模块单测 + 3 examples 单测通过
