### PR TITLE
docs(303): 运行时契约注册中心方向 ADR + speckit 分解 [#2230]

### DIFF
--- a/docs/architecture/202606162119-303-adr-runtime-contract-registry.md
+++ b/docs/architecture/202606162119-303-adr-runtime-contract-registry.md
@@ -9,7 +9,7 @@
   控制面/数据面转发的架构形态；③ 完整威胁矩阵 + 每行补偿 sub-issue 指针；④ 与既有扇出
   archtest 的 scope 边界。注册中心的**实现**——`registrycore` cell、`contract_registrations`
   表、状态机、governance gate adapter、数据面运行时增删、conformance 探测——一律属下游
-  US2-US18（#2231–#2248），**不在本 ADR 落地**。证据底座：
+  US2-US18（#2231 + #2233–#2248；#2232 为无关 CI issue、非本 epic），**不在本 ADR 落地**。证据底座：
   `specs/070-runtime-contract-registry/{spec,research,tasks}.md`。
 
 ## Context

--- a/docs/architecture/202606162119-303-adr-runtime-contract-registry.md
+++ b/docs/architecture/202606162119-303-adr-runtime-contract-registry.md
@@ -1,0 +1,194 @@
+# ADR: 运行时契约注册中心 — dual-track 治理 + 进程外控制面/数据面转发
+
+- Status: Accepted
+- Date: 2026-06-16
+- Issue: #2230 (Epic #303, Wave-1 US1), Closes #2230
+- Scope: **方向裁决（directional）**。本 ADR 裁定「框架是否、以何种治理模型支持**运行时**契约
+  注册（外部进程外 cell 经 API 注册 + admin 审批上线，框架不重编译/部署）」，并锁定四项形态：
+  ① dual-track 治理边界（in-tree 编译期 Hard vs out-of-tree runtime gate Medium）；② 进程外
+  控制面/数据面转发的架构形态；③ 完整威胁矩阵 + 每行补偿 sub-issue 指针；④ 与既有扇出
+  archtest 的 scope 边界。注册中心的**实现**——`registrycore` cell、`contract_registrations`
+  表、状态机、governance gate adapter、数据面运行时增删、conformance 探测——一律属下游
+  US2-US18（#2231–#2248），**不在本 ADR 落地**。证据底座：
+  `specs/070-runtime-contract-registry/{spec,research,tasks}.md`。
+
+## Context
+
+### 缘起：#303 从 pri-p2 小问题升级为 Epic
+
+#303 原始诉求是给消费型 cell 加 `WithExtraTopics` option（业务方发新 topic 自动被消费）。
+该诉求**前提已过时**：auditcore 早已没有硬编码 `Topics` 数组，订阅由 cellgen 从 `slice.yaml`
+`contractUsages[role=subscribe]` **单源派生**进 `cell_gen.go`，`cellID` 是 `Registrar.Subscribe`
+第 4 个位置必填参（编译期 HARD 契约，ADR `202605111000`）。`WithExtraTopics` 方向与当下
+codegen-funnel 收口哲学相反——它把已收口成静态派生的订阅重新打开成 runtime 可变 option。
+
+产品决策由此升级：把「扩展订阅」从一次性编译期 option，提升为**持续运行的平台能力**——框架
+上线后保持运行，外部 cell 经 API 随时提交契约注册，framework admin 审批通过后契约即上线生效，
+**无需重新编译/部署框架二进制**。原始诉求 #659（`CELL-CONSUMER-EXTRA-TOPICS-OPTION-01`）已被
+本 epic 取代并 closed as superseded。
+
+### 核心张力：runtime 注册 vs 宪法第一性原理（AI-robust）
+
+GoCell 第一性原理是 **AI-robust**：约束做到「违反不可表达」，靠 codegen funnel + 编译期
+type system + 静态 archtest。整个契约扇出闭环（`DEAD-CONTRACT-01` / `IMPL-DECL-COVER-01` /
+`EMIT-DECL-COVER-01` / `DEAD-CODE-01`）都依赖**契约在编译期可被静态枚举**。
+
+运行时注册把契约的「权威源」从编译期 YAML 搬到 runtime registry，**对动态注册的那部分契约，
+编译期静态治理结构上不可达**。这是真实张力，不能假装没有。本 ADR 的职责就是诚实地 reconcile
+它，而非用「也算 Hard」的措辞掩盖降级。
+
+### 代码现状（已读源码，分解前提）
+
+- `framework/kernel/registry/contract.go`：`ContractRegistry` **完全只读**——`NewContractRegistry(project)`
+  一次性构建 `contracts/byKind/byOwner` map，读时 `deepCopyContract`，**无 mutation API**；doc
+  注明「populated once during assembly bootstrap and remain immutable afterward」。
+- `framework/runtime/eventrouter/router.go`：「声明 then `Run`-once」——`runGuard sync.Once`
+  保证 `Run` 只一次，`handlers []handlerConfig` 受 `mu sync.Mutex` 保护，**Run 后冻结、无运行时
+  增删**；全局单 `runCtx`（cancel 即全停）。
+- `framework/kernel/governance/validate.go`：`Validator` 是纯 Go 校验器，今天只被
+  `gocell validate` CLI 调用。
+
+**关键洞察**：`governance.Validator` 与 `ContractRegistry` 本就是纯 Go runtime 代码，今天只是
+被 CLI 调用。把它们接到一个注册 API 上即可 runtime 化——**运行时注册校验 ≈ 把 `gocell validate`
+从 CI 搬到注册端点**。admin 审批是替代编译期 CI gate 的人工补偿控制。
+
+## 核心裁决 1：dual-track reconciliation（canonical anchor）
+
+> 注：本节「reconcile」指消解「runtime 注册」与「AI-robust 宪法」的概念张力，与
+> `kernel/reconcile`（L4 desired-state 收敛控制环）无关，勿混。
+
+**裁定：框架 MUST 以 dual-track 治理模型支持运行时契约注册——in-tree 轨道编译期 Hard 治理
+全保留不动摇，out-of-tree 轨道由 runtime governance gate（Medium）+ 自动 conformance + admin
+人审 + 审计落账补偿。两轨并存、信任根不同、不互相降级。**
+
+| 轨道 | 契约来源 | 治理方式 | 信任根 | AI-robust 评级 |
+|------|---------|---------|--------|----------------|
+| **In-tree cells**（框架自带 + 编译进二进制） | 编译期 YAML，可静态枚举 | 现有编译期静态治理（cellgen / archtest 扇出闭环 / `gocell validate`）**全部保留不变** | build-time，framework 自身 trust root | **Hard**（不动摇） |
+| **Out-of-tree cells**（运行时注册，进程外） | runtime registry，编译期不可枚举 | 注册时跑同一套 `governance.Validator` + admin 审批 state machine + 自动 conformance + 审计落账 | register-time + admin 人审 | **Medium**（runtime guard + 人审） |
+
+**【诚实评级，不伪装 Hard】** 本 epic 引入的 out-of-tree 治理是 **runtime governance gate
+（Medium 形态：runtime invariant guard + 人审）**，不是 Hard 编译期收口。这是 out-of-tree
+契约在 Go 下能达到的天花板：动态注册的契约编译期不存在，type system / golden / archtest
+对它结构性不可达。本 ADR 在威胁矩阵中逐项显式记录这一点，**任何下游实现不得用「也算
+Hard」措辞掩盖此降级**（AI-robust 章程：Soft 严禁、Medium 须显式登记 Hard 化路径或盲区）。
+
+**为何 Medium 可接受**：① in-tree Hard trust root 不动摇——框架自身 + 编译进二进制的外部 cell
+仍是完全静态可验证的；② out-of-tree 的 Medium 不是「降级 allow-all」，而是把 `gocell validate`
+的同一套规则搬到注册端点 + 叠加人审 gate；③ 进程边界提供天然隔离（见核心裁决 2）。
+
+## 核心裁决 2：进程外控制面 + 数据面转发（架构形态）
+
+**裁定：注册中心采用进程外控制面形态。外部 cell 是独立进程/服务；注册中心管理其契约元数据 +
+订阅意图 + 端点地址。框架运行时退化为「契约控制面 + 事件/HTTP 数据面转发」——in-tree 二进制
+保持完全静态可验证，out-of-tree 只贡献元数据与网络端点。**
+
+```
+外部 cell ──submit──▶ registrycore ──governance gate──▶ probing(自动 conformance) ──▶ pending-approval
+（独立进程）          (#2233-2237)      (#2234)            (#2247/#2248)                  │
+                                                                          admin ──approve──▶ active
+                                                                          (#2238/#2239)      │
+                                                                                             ▼
+                                                              EventRouter / HTTP Router 运行时加载订阅/路由
+                                                              (#2240/#2241/#2242) ──转发──▶ 外部 cell 端点 (#2244)
+```
+
+状态机：`submitted → probing → (conformant → pending-approval → approved | rejected) → active → retired`。
+
+**范式对标（research.md §2/§4 实拉源码）**：
+- **K8s CRD + API aggregation layer**：CRD 运行时注册新资源类型而不重启 apiserver；
+  `NamesAccepted`→`Established` condition 状态机与本状态机高度同构（→ #2245 唯一性校验、#2233
+  状态机）；admission webhook = 同步 inline 门 + CRD controller = 异步 condition，直接对应
+  GoCell 同步 governance gate（#2234）+ 异步 conformance/审批收敛。
+- **Envoy xDS**：控制面声明 → 数据面无重启加载；NACK 保留 last-good（坏配置永不生效）→
+  数据面版本化 diff + 版本回退 fail-closed（#2241）。
+- **Confluent Schema Registry**：`/compatibility`(dry-run) + `/versions`(写入) 双端点共用校验
+  逻辑 → `:check`/`submit` 双入口共用 `Validator`（#2234）；append-only log 作真源 → PG
+  append-only 迁移历史（#2236）。
+
+**为何这是正确形态**（不是引入服务网格）：进程边界与 GoCell「cell 间只经 contract 通信」「数据
+主权」「`assemblies/` = 物理打包」一脉相承——进程外 cell 本就该经 contract + 网络端点交互。
+注册中心**不**在运行时夺取宿主权限、**不**引入 sidecar、**不**做控制面下发配置改宿主；它只是
+把「contract 声明 + 端点登记」从启动期一次性扩展为运行期可增删，数据面转发复用既有 contract
+transport（见核心裁决 3）。
+
+## 核心裁决 3：数据面转发复用 #1423/#1966，不另造跨进程栈
+
+**裁定：进程外数据面转发（topic 事件 / HTTP 请求 → 外部 cell 网络端点）MUST 复用 #1423/#1966
+的 location-transparent remote transport（`CellTransport` remote 实现 + `Resolver` cellID→endpoint
++ service token 出站签名 + principal/tenant 跨进程传播），不为 #303 另造一套跨进程同步栈。**
+
+依据：#1423 ADR（`202606131142-1423`）已裁定框架提供 location-transparent contract transport
+seam，其 §「discovery 接口形态与 #303 共享」已显式预留。#303 的端点注册（#2244）= 在该 seam 上
+增加「运行时端点登记 + 转发」，故 **#2244 gated 在 #1966 remote transport 就位之后**。数据面的
+运行时增删能力（EventRouter add/remove #2240/#2241、HTTP Router 动态 route #2242）是 #303 自有
+（eventrouter Run-once → 运行时可变），转发的网络客户端层复用 #1423。
+
+## 威胁矩阵（每行配补偿 sub-issue）
+
+| # | 威胁 | 补偿措施 | 落地 sub-issue |
+|---|------|---------|----------------|
+| T1 | **恶意注册**：未授权方注册伪造契约 | 注册端点鉴权 + admin 审批 gate（approved 才能 active）+ RBAC + 限流 | #2234（gate）、#2238（审批/RBAC）、#2246（鉴权/限流） |
+| T2 | **审批旁路**：active 态契约绕过审批直接生效 | 状态机不变式（sealed state，只有 approved→active）+ 审计强制落账 | #2233（sealed 状态机）、#2239（审计） |
+| T3 | **命名空间冲突**：runtime 契约与 in-tree 契约 ID/topic/HTTP path 撞车 | 注册时 `(kind,domain-path,version,owner)` 四元组唯一性校验 + 外部契约强制命名空间前缀（对标 CRD NamesAccepted） | #2245 |
+| T4 | **consistency 越权**：runtime cell 声明超出 actor ceiling 的一致性级别 | 复用 actors.yaml `maxConsistencyLevel` 语义的 runtime 形态，超限 fail-closed | #2245 |
+| T5 | **数据面动态加载并发**：add/remove subscription 与正在消费的 goroutine 竞争 | per-handler 子 ctx 隔离 + map 锁 + Close 三阶段 drain；版本化 diff + 回退 fail-closed | #2240、#2241 |
+| T6 | **conformance 探测 SSRF / 出站攻击面**：框架主动向「提交方声明的任意端点」发请求 | egress allowlist + 鉴权 + 限流，禁裸打任意地址 | #2246 |
+| T7 | **合成租户副作用泄漏**（conformance 写面）：合成租户请求触发真实外发 / 数据漏进共享态 | egress-suppression 标记（禁真实外发）+ 整租户可清除；**hard-depend 多租户 GA #1337 的隔离边界为真** | #2248（gated #1337） |
+| T8 | **gate fail-open**：校验器/租户/store 不可用时放行 | `FailurePolicy=Fail` fail-closed（对标 K8s admission 默认）——缺 Authorizer / 缺租户 / store 不可用 / 无适用 permit → deny | #2234、#2238 |
+| T9 | **审计不可追溯**：审批/激活无留痕 | submit/approve/reject/retire → auditcore hash chain（replayable PII hash/redaction） | #2239 |
+| T10 | **AI-robust 降级被掩盖**：runtime gate 是 Medium 却被当 Hard | 本 ADR 显式记录 Medium 评级 + in-tree Hard 轨道不动摇；下游 PR review 核对评级诚实性 | 本 ADR + 全下游 |
+
+## 与扇出 archtest 的关系（scope 边界声明）
+
+**裁定：`DEAD-CONTRACT-01` / `IMPL-DECL-COVER-01` / `EMIT-DECL-COVER-01` / `DEAD-CODE-01`
+等扇出闭环 invariant 只覆盖 in-tree 静态契约，对 runtime 注册契约 vacuous——这是设计预期，
+不是缺陷。**
+
+理由：这些 archtest 在编译期静态枚举契约并验证 publisher/subscriber/owner 完整性；runtime
+注册契约编译期不存在，故对它们 vacuous。这正是 dual-track 的结构性事实（核心裁决 1）。
+
+**补偿方向**：为 out-of-tree 契约提供等价的 **runtime 扇出校验**——注册时（而非编译期）验证
+publisher/subscriber/owner 完整性，复用 `governance.Validator` 规则的 runtime 形态。这是
+governance gate（#2234）的一部分，并随命名空间/ceiling 校验（#2245）补全。下游实现 MUST 在
+对应 archtest godoc 标注「runtime 注册契约 vacuous = 设计预期」以防误读为覆盖盲区。
+
+## 与相邻工作的边界（不重复造轮子）
+
+| 相邻项 | 关系 | 边界 |
+|--------|------|------|
+| **#1081 / #1090（M9）= Tier-1** | 互补、非二选一 | Tier-1 = 编译期外部 cell（源码编译进二进制，编译期静态治理，trust root）；本 epic = Tier-2（运行时注册，进程外，runtime gate Medium）。#1090 明确**不做**中心运行时 registry → 归本 epic。「一套共享平台 + 多个跨部署外部 cell 互相交互的运行时生态」恰是 #303 的价值主张。 |
+| **#1046（D5/W5 Schema Registry runtime）** | 不同层，非重复 | #1046 = codegen-time schema **hash/compat** policy（wire 兼容性校验）；本 epic = runtime **契约**注册（元数据 + 订阅意图 + 端点）。两者可叠加：注册的契约其 schema 仍可经 #1046 compat 校验。 |
+| **#1423 / #1966（remote transport）** | 数据面转发的真实前置 | 见核心裁决 3。#2244 复用其 `CellTransport` remote + Resolver。 |
+| **#1337（多租户/ABAC）** | conformance 彻底档硬依赖 | #2248（合成租户写面 conformance）的安全保证建立在 tenant 隔离边界为真之上 → 结构性 block 在 #1337 GA 之后；首档（#2247，读/幂等面）不依赖多租户。 |
+
+> 本 ADR 与 #1423 ADR 方向对齐：二者共享 discovery 接口形态，分别承载「运行时注册（控制面）」
+> 与「location-transparent transport（数据面客户端）」两层。外部团队选型：编译期进二进制走
+> Tier-1（#1081）；独立部署运行中服务走 Tier-2（#303）。
+
+## Amendments to prior decisions
+
+- **#659（`CELL-CONSUMER-EXTRA-TOPICS-OPTION-01`）**：原始 `WithExtraTopics` 诉求与 codegen-funnel
+  收口哲学相反，已 closed as superseded by #303（本 ADR Context 已记）。
+- **设计文档 `docs/plans/202605310313-047-runtime-contract-registry-epic.md`**：本 ADR 是其
+  「P0 方向 ADR」产出，正式化其 §3 dual-track + §4 进程外控制面 + §8 威胁矩阵，并补全威胁矩阵的
+  sub-issue 补偿指针（该设计文档撰写时 sub-issue 尚未登记）。
+- 本 ADR 不推翻任何既有已 Accepted 的 ADR；与 `202606131142-1423` 互为引用、方向一致。
+
+## 验收信号（epic 级，本 ADR 锁定，下游交付）
+
+- 外部 cell（进程外）submit 一个 event 契约 → 自动 conformance 通过 → admin approve → 框架
+  **不重启**即开始转发该 topic 事件给外部端点（双进程 journey）。
+- 未审批 / conformance 失败 / reject 的契约 100% 不可激活（状态机不变式 + 审计强制落账）。
+- 全程审计可追溯（auditcore hash chain 含 submit/approve/activate）；replayable PII 0 明文。
+- in-tree 静态治理（archtest 扇出闭环 + `gocell validate`）**零回归**。
+- 威胁矩阵逐行有补偿 sub-issue 且 AI-robust 评级诚实（Medium 不伪装 Hard）。
+
+## 参考
+
+- 设计文档：`docs/plans/202605310313-047-runtime-contract-registry-epic.md`
+- 规格 / 对标 / 任务：`specs/070-runtime-contract-registry/{spec,research,tasks}.md`
+- 相邻 ADR：`docs/architecture/202606131142-1423-adr-cell-deployment-topology.md`（remote transport）
+- 对标源码（research.md §6 全清单）：confluentinc/schema-registry、kubernetes/api admission+apiextensions、
+  pact-foundation/pact-js、envoyproxy/{envoy,go-control-plane}、kubernetes-sigs/controller-runtime、
+  ThreeDotsLabs/watermill、istio/istio
+- AI-robust 章程：`.claude/rules/gocell/ai-robust.md`；扇出闭环：`.claude/rules/gocell/contract-fanout.md`

--- a/docs/architecture/202606162119-303-adr-runtime-contract-registry.md
+++ b/docs/architecture/202606162119-303-adr-runtime-contract-registry.md
@@ -92,7 +92,7 @@ Hard」措辞掩盖此降级**（AI-robust 章程：Soft 严禁、Medium 须显�
                                                               (#2240/#2241/#2242) ──转发──▶ 外部 cell 端点 (#2244)
 ```
 
-状态机：`submitted → probing → (conformant → pending-approval → approved | rejected) → active → retired`。
+状态机（分支式，`rejected` 是终态、无 →active 迁移）：主路径 `submitted → probing → conformant → pending-approval → approved → active → retired`；终态分支 `probing → rejected`（conformance 失败）、`pending-approval → rejected`（admin 拒绝）。`active → retired` 由 admin retire 触发并 remove 数据面订阅/路由。
 
 **范式对标（research.md §2/§4 实拉源码）**：
 - **K8s CRD + API aggregation layer**：CRD 运行时注册新资源类型而不重启 apiserver；
@@ -132,7 +132,7 @@ seam，其 §「discovery 接口形态与 #303 共享」已显式预留。#303 �
 | T3 | **命名空间冲突**：runtime 契约与 in-tree 契约 ID/topic/HTTP path 撞车 | 注册时 `(kind,domain-path,version,owner)` 四元组唯一性校验 + 外部契约强制命名空间前缀（对标 CRD NamesAccepted） | #2245 |
 | T4 | **consistency 越权**：runtime cell 声明超出 actor ceiling 的一致性级别 | 复用 actors.yaml `maxConsistencyLevel` 语义的 runtime 形态，超限 fail-closed | #2245 |
 | T5 | **数据面动态加载并发**：add/remove subscription 与正在消费的 goroutine 竞争 | per-handler 子 ctx 隔离 + map 锁 + Close 三阶段 drain；版本化 diff + 回退 fail-closed | #2240、#2241 |
-| T6 | **conformance 探测 SSRF / 出站攻击面**：框架主动向「提交方声明的任意端点」发请求 | egress allowlist + 鉴权 + 限流，禁裸打任意地址 | #2246 |
+| T6 | **出站攻击面（SSRF / 身份外泄）**：框架主动向「提交方声明的端点」出站——conformance 探测**与** US14 数据面转发（携 service token + principal/tenant）**与** ExternalEndpoint 注册 | **统一 endpoint egress allowlist admission**（egress allowlist + 鉴权 + 限流，禁裸打/内网 metadata 地址；数据面只消费 admitted endpoint，「探测过门、转发裸打」的边界不一致被消除）；US17 探测 blocked-by US16 admission 先就位 | #2246（admission）、#2244（转发只消费 admitted endpoint） |
 | T7 | **合成租户副作用泄漏**（conformance 写面）：合成租户请求触发真实外发 / 数据漏进共享态 | egress-suppression 标记（禁真实外发）+ 整租户可清除；**hard-depend 多租户 GA #1337 的隔离边界为真** | #2248（gated #1337） |
 | T8 | **gate fail-open**：校验器/租户/store 不可用时放行 | `FailurePolicy=Fail` fail-closed（对标 K8s admission 默认）——缺 Authorizer / 缺租户 / store 不可用 / 无适用 permit → deny | #2234、#2238 |
 | T9 | **审计不可追溯**：审批/激活无留痕 | submit/approve/reject/retire → auditcore hash chain（replayable PII hash/redaction） | #2239 |

--- a/specs/070-runtime-contract-registry/research.md
+++ b/specs/070-runtime-contract-registry/research.md
@@ -1,0 +1,100 @@
+# Research: 运行时契约注册中心对标（控制面 + 数据面）
+
+> 来源：两个 `explorer` agent 并行开源探索（2026-06-16）。控制面 agent 对标 Confluent Schema Registry / Kubernetes / Pact / Envoy xDS；数据面 agent 对标 watermill / go-control-plane / controller-runtime / Istio。所有签名/路径均来自实拉源码与官方 API doc。
+
+## 1. GoCell 现状（已读源码，分解前提）
+
+- `framework/kernel/registry/contract.go`：`ContractRegistry` **完全只读**——`NewContractRegistry(project)` 一次性构建 `contracts/byKind/byOwner` map，读时 `deepCopyContract`，**无 mutation API**。doc 注明「populated once during assembly bootstrap and remain immutable afterward」。
+- `framework/runtime/eventrouter/router.go`（770 行）：「声明 then `Run`-once」——`runGuard sync.Once` 保证 `Run` 只一次；`handlers []handlerConfig` 受 `mu sync.Mutex` 保护，**Run 后冻结，无运行时增删**；`Close` 三阶段 StopIntake→cancel→drain；全局单 `runCtx`/`r.cancel`（cancel 即全停）。
+- `framework/kernel/governance/validate.go`：`Validator` 纯 Go 校验器，今天只被 `gocell validate` CLI 调用 → 可直接 runtime 化（「把 `gocell validate` 从 CI 搬到注册端点」）。
+
+## 2. 控制面对标（→ P0/P1/P2/P3/P6/P7）
+
+### 2.1 Confluent Schema Registry — 注册 API + 同步校验门（→ US3/US6）
+
+- **双端点设计**：`POST /subjects/{s}/versions`（写入）与 `POST /compatibility/subjects/{s}/versions/{v}`（dry-run 只判不落库）**共用一套校验逻辑**（`isCompatibleWithPrevious`）。
+- **写前同步校验**：`KafkaSchemaRegistry.register` 严格有序全同步——先 `waitUntilKafkaReaderReachesLastOffset()`（读己之写屏障）→ compatibility check（不兼容直接抛，无中间态）→ 分配 id → append-only log 落库。
+- **Mode=READONLY** 全局闸冻结写入，与 per-subject compatibility 正交。
+- **采纳**：复用 `governance.Validator` 暴露 `:check`(dry-run) + `submit` 双入口；写前同步拒绝（不过不进 submitted）；append-only 事件溯源（载体换 PG outbox，非 Kafka）；leader 接写复用 reconcile leader-elect。
+- **偏离**：GoCell 是契约**元数据**非 schema 字节；多阶段状态机（submitted→probing…）而非 SR 校验完即终态——静态门同步、活体 conformance 异步。
+
+### 2.2 Kubernetes — Admission + CRD condition + Aggregation（→ US1/US2/US7/US15）
+
+- **AdmissionResponse** `{Allowed bool, Result *Status, Warnings []string, AuditAnnotations}` = governance gate 响应模型最佳对标；`ValidatingWebhook.FailurePolicy=Fail`（默认 fail-closed）+ `SideEffects: NoneOnDryRun`（dry-run 抑制副作用）。
+- **CRD 状态机**：`NamesAccepted`（group 内 Group+Plural+Kind 冲突检测）→ `Established`（首次无冲突即激活，后续保持）→ `Terminating`，与 GoCell `submitted/probing/conformant/active/retired` 高度同构。
+- **校验分层**：admission = 同步 inline（写前阻塞）；CRD Established = 异步 controller condition（写后推进）→ 直接对应 GoCell saga(人审)/reconcile(活体收敛) 正交边界，**无需新引擎**。
+- **采纳**：`{allowed,result,warnings}` 响应；FailurePolicy=Fail；dryRun 抑制副作用；NamesAccepted 换成 `(kind,domain-path,version,owner)` 四元组唯一性；同步门 + 异步 condition 分层作状态机骨架。
+- **偏离**：API aggregation（APIService 转发外部 apiserver）仅作 P0 进程外论证引用，不复制其 TLS/discovery 全栈。
+
+### 2.3 Pact / Provider Verification — 活体 conformance（→ US17/US18）
+
+- **对活体黑盒验契约**（`providerBaseUrl`，验兑现非测代码）；`stateHandlers` 的 setup/teardown 配对（测试数据进出对称）；`requestFilter` 注入瞬态凭据（token 不落契约）。
+- **can-i-deploy 矩阵**：无 successful verification 不准 deploy → GoCell `probing→conformant` 晋级 = conformance result 通过；result 是带 provider 版本的不可变记录。
+- **采纳**：活体握手范式；setup/teardown sealed 配对（缺 teardown 校验/编译错，强于 Pact 运行时约定，AI-robust Hard）；凭据注入不入契约；result append-only。
+- **偏离**：bi-directional pact（消费者期望↔提供者验证）不适用——GoCell 是「中心声明→活体验证兑现」单向。
+
+### 2.4 Envoy xDS — 控制面/数据面分离（→ US1/US11）
+
+- **DiscoveryRequest/Response + version_info + nonce + ACK/NACK**：NACK 时 client 填 error_detail、**保留上一个 good version**（坏配置永不生效，last-good 在线）；ADS make-before-break 排序（依赖资源先于引用方）。
+- **采纳**：控制面声明→数据面无重启加载（P0 论证主骨架）；NACK 保留 last-good（坏契约不应用）；version_info ≈ fencing epoch，收敛复用 reconcile。
+- **偏离**：单 gRPC 长流多路复用 → GoCell 走 L2 outbox 事件（`contract-activated`），不建 xDS 长流。
+
+## 3. 数据面对标（→ P4：US9/US10/US11/US12）
+
+### 3.1 watermill `message/router.go` — 动态 handler（最高优先）
+
+- `Router.handlers map[string]*handler` + `handlersLock *sync.RWMutex`；`AddHandler` 后可 `RunHandlers()`（docstring 显式支持运行时增）；`handlerAdded chan struct{}` 信号；`h.started` 标志保证 RunHandlers 幂等；每 handler 独立 `h.stopFn = cancel`（per-handler ctx）；handler 退出 defer 内 `delete(r.handlers, name)` 自删 + `close(h.stopped)`；在途 message 由 `runningHandlersWg.Wait()` drain。
+- **GoCell 缺失**：Run 后冻结 slice、全局单 cancel、无单 handler stop、slice 无删除、只有全局 Running()。
+- **采纳**：slice→`map[topic+group]`；per-handler 子 ctx + stopFn；退出自删 map；started 幂等。**偏离**：watermill `AddHandler` 带 publish-side（GoCell 经 outbox.Writer 发布，Router 只订阅）；重名 panic→返回 error（治理禁生产 panic）。
+
+### 3.2 go-control-plane `SnapshotCache` — 原子版本化推送
+
+- `SetSnapshot` 在 `mu` 内整体替换 `snapshots[node]` + 触发 watch；每 typeURL opaque version，version 未变不重推；ADS `orderResponseWatches()` 强制排序。
+- **采纳**：`RegistrySnapshot` 单调 version + diff（仅对变化订阅 add/remove，避免全 Router 重建）；版本回退 fail-closed。**偏离**：GoCell 是 push 式 reconcile 单点增删，不引 per-node SnapshotCache 全套（订阅是有状态 goroutine，整份替换=全重建代价高）。
+
+### 3.3 controller-runtime `source.go` — ctx-per-source 生命周期
+
+- `TypedSource.Start(ctx, queue)` 绑定 ctx，cancel→watch goroutine 退出；`TypedSyncingSource.WaitForSync(ctx)` 就绪屏障（对标 GoCell `Subscriber.Ready`）。
+- **采纳**：每个动态订阅 = ctx-scoped runnable，与 reconcile/leader-elect「丢 lease 取消 lease-scoped ctx」同构；WaitForSync ≈ 复刻现有 Phase3 单 handler 版。**偏离**：不引 informer/workqueue；leader gating 由 composition root 决定（与 saga-projection locker 一致），Router 不自建 leader gate。
+
+### 3.4 Istio Pilot `discovery.go` — debounce 批量
+
+- `DebounceOptions{DebounceAfter, debounceMax}` 双触发（静默 + 上限保底）+ `PushRequest.Merge` 合并窗口内多次变更。
+- **采纳**：`contract-activated` 消费侧 debounce 合并多激活为一次 diff reconcile；累积 toAdd/toRemove 集窗口末一次 apply。**偏离**：GoCell 数据面天然增量（add/remove 单 handler），debounce 只合并触发频率，不做全量 vs 增量传输决策。
+
+## 4. P4 改造清单（数据面 agent 给出，→ US9-US12 拆分依据）
+
+| PR | 范围 | 对标 | US |
+|----|------|------|----|
+| A | `handlers []` → `map[handlerKey]*runningHandler` + 重名返 error（行为等价地基） | watermill map | US9 |
+| B | `runRootCtx` 提升 + per-handler 子 ctx + `AddRunningHandler`/`RemoveHandler`（fail-closed 半启动清理）；与 `runGuard sync.Once` 兼容（Run 仍一次，增删仅 started 后） | watermill stopFn + controller-runtime ctx-per-source | US10 |
+| C | `RegistrySnapshot` 版本化 + diff `Reconcile` + `contract-activated` debounce + archtest 守卫（子 ctx 挂树 / fail 必 hcancel） | go-control-plane + istio | US11 |
+| D | HTTP Router 一次性 drain → 运行时 add/remove route（不绕 auth） | net/http 包装 mux | US12 |
+
+> `Close` 三阶段 drain **零改动复用**：Phase2 全局 cancel `runRootCtx` 整棵树 → 动态 handler 子 ctx 随之取消；Phase3 `wg.Wait()` 自然等动态 handler 退出。这是 GoCell 优于直接照搬 watermill 之处（watermill auto-close 逻辑 GoCell 不需要）。
+
+## 5. 综合裁决（GoCell 取舍）
+
+| 维度 | 取舍 |
+|------|------|
+| 注册 API | REST `submit` + `:check`(dry-run) 共用 `governance.Validator`；契约元数据非 schema 字节 |
+| 校验门 | 静态 governance gate 同步（不过不进 submitted）+ 活体 conformance 异步（probing→conformant，reconcile 收敛）——K8s 分层 |
+| 审批 | 机器门(gate+conformance) → admin 人审(saga 有限步) → active；四系统均无人审，人审是 zero-trust 增量需自研 |
+| 命名空间 | `(kind,domain-path,version,owner)` 四元组 + `_framework` sentinel 单列（对标 NamesAccepted） |
+| conformance 副作用 | Pact setup/teardown 配对（sealed 强制，Hard）+ K8s dryRun 抑制 + 凭据注入不入契约；彻底档合成租户 hard-depend #1337 |
+| 控制面/数据面 | xDS NACK 保 last-good + CRD 不重启加载 + ADS 依赖序；收敛复用 reconcile + fencing epoch；append-only 状态（载体 PG outbox） |
+| 数据面增删 | watermill map + per-handler ctx + 退出自删；go-control-plane 版本化 diff；istio debounce 合并；controller-runtime WaitForSync 屏障 |
+
+## 6. 引用（供 PR/commit）
+
+```
+ref: confluentinc/schema-registry core/.../storage/KafkaSchemaRegistry.java + rest/resources/SubjectVersionsResource.java@master
+ref: kubernetes/api admission/v1/types.go + admissionregistration/v1/types.go@master；apiextensions-apiserver pkg/apis/apiextensions/v1/types.go@master
+ref: pact-foundation/pact-js docs/provider.md@master；docs.pact.io/pact_broker/can_i_deploy
+ref: envoyproxy/envoy xds_protocol（官方 docs）
+ref: ThreeDotsLabs/watermill message/router.go@master — AddHandler/RunHandlers/handlerAdded/stopFn/delete-on-exit
+ref: envoyproxy/go-control-plane pkg/cache/v3/simple.go@main — SnapshotCache.SetSnapshot atomic + per-typeURL version + watch diff
+ref: kubernetes-sigs/controller-runtime pkg/source/source.go@main — TypedSource.Start(ctx,queue) + WaitForSync
+ref: istio/istio pilot/pkg/xds/discovery.go@master — debounce DebounceAfter/debounceMax + PushRequest.Merge
+GoCell 现状: framework/kernel/registry/contract.go、framework/runtime/eventrouter/router.go、framework/kernel/governance/validate.go
+```

--- a/specs/070-runtime-contract-registry/spec.md
+++ b/specs/070-runtime-contract-registry/spec.md
@@ -10,7 +10,7 @@
 - **架构形态已定（进程外控制面）**：外部 cell 是独立进程；注册中心管理其**契约元数据 + 订阅意图 + 端点地址**。框架退化为「契约控制面 + 事件/HTTP 数据面转发」；in-tree 二进制保持完全静态可验证。范式对标 K8s CRD + API aggregation / Envoy xDS / Confluent Schema Registry。
 - **dual-track（必须诚实对齐宪法）**：In-tree cells 现有编译期静态治理（cellgen / archtest 扇出闭环 / `gocell validate`）**全部保留不变**，仍是 trust root；Out-of-tree cells 编译期治理结构性不可达 → 由 **runtime governance gate 补偿**（注册时跑同一套 `kernel/governance.Validator` + 自动 conformance + admin 审批 + 审计落账）。这是 out-of-tree 契约在 Go 下的天花板，**AI-robust 评级 = Medium（runtime guard + 人审），不得伪装成 Hard**。
 - **现状证据（已读源码）**：`kernel/registry.ContractRegistry` 当前**完全只读**（`NewContractRegistry(project)` 一次性构建 map + 读时 deepCopy，无 mutation API）；`runtime/eventrouter.Router` 是「声明 then `Run`-once」（`Run MUST be called at most once`，无运行时增删 handler）；`kernel/governance.Validator` 是纯 Go 校验器，今天只被 `gocell validate` CLI 调用。对标与采纳/偏离详见同目录 `research.md`。
-- **状态机**：`submitted → probing → (conformant → pending-approval → approved | rejected) → active → retired`。
+- **状态机**（分支式，避免「rejected→active」误读）：主路径 `submitted → probing → conformant → pending-approval → approved → active → retired`；**终态分支** `rejected`（由 `probing` conformance 失败 或 `pending-approval` admin 拒绝进入，**无 →active 迁移**）。
 - **边界划清**（非重复造轮子）：
   - **#1081 / #1090（M9）= Tier-1**（编译期外部 cell：源码编译进二进制）；本 epic = **Tier-2**（运行时注册，进程外）。#1090 明确不做中心运行时 registry → 归本 epic。两者互补、非二选一。
   - **#1046（D5/W5 Schema Registry runtime）= codegen-time schema hash/compat**，与本 epic 的 runtime **契约**注册不同层，非重复。
@@ -67,12 +67,13 @@
 1. **Given** 一个 wire 合规但有非阻断告警的契约，**When** 调 `:check`，**Then** 返回 `{allowed:true, warnings:[…]}`，不落库。
 2. **Given** 一个违反 governance 规则的契约，**When** 调 `submit`，**Then** 落库前同步拒绝（无「submitted 但 invalid」中间态），错误带可机读 reason。
 3. **Given** Validator/依赖不可达，**When** 注册请求到达，**Then** fail-closed（deny），绝不 fail-open。
+4. **Given** 一个缺 publisher/subscriber/owner 的运行时契约（in-tree 由扇出 archtest 静态保证、runtime 不可达），**When** submit 经 gate，**Then** gate 跑 runtime 扇出完整性校验（publisher/subscriber/owner 齐全）并对缺失 fail-closed——这是 ADR「扇出 archtest 对 runtime 契约 vacuous」的等价 runtime 补偿。
 
 ---
 
 ### User Story 4 - registrycore cell 骨架 + submit/list 契约声明（Priority: P1）
 
-新增平台 cell `registrycore`（与 accesscore/auditcore/configcore 并列，吃自己的狗粮）：`cell.yaml` + slices + `http.registry.contract.submit.v1` / `http.registry.contract.list.v1` 契约声明，经 cellgen 从 metadata 单源派生注册代码。
+新增平台 cell `registrycore`（与 accesscore/auditcore/configcore 并列，吃自己的狗粮）：`cell.yaml` + slices + `http.registry.contract.submit.v1` / `http.registry.contract.list.v1` 契约声明，经 cellgen 从 metadata 单源派生注册代码。list 契约 MUST 声明强制分页（`limit`≤500 + `data`/`nextCursor`/`hasMore` 响应 envelope，per `go-standards.md` 列表约定），不返回无界全集。
 
 **Why this priority**: 注册中心的承载 cell；submit/list 是外部 cell 接入的最小可用面。
 
@@ -106,18 +107,19 @@ submit/list handler（typed response envelope 表达业务状态码）+ applicat
 
 **Why this priority**: 把 US2-US5 串成「外部 cell 能 submit 一个契约并 list 看到 pending」的端到端最小闭环（epic MVP 的提交面）。
 
-**Independent Test**: httptest 覆盖 submit（合法→pending / 非法→4xx）+ list（按 state 过滤）；contract 测试断言 error envelope 合规。
+**Independent Test**: httptest 覆盖 submit（合法→pending / 非法→4xx）+ list（按 state 过滤 + 分页翻页）；contract 测试断言 error envelope 合规。
 
 **Acceptance Scenarios**:
 
 1. **Given** 合法契约 payload，**When** POST submit，**Then** 经 gate → 落库 → 返回 201 + registration id，state=submitted/probing。
 2. **Given** 非法 payload，**When** POST submit，**Then** 返回声明的 4xx + shared error schema（`{error:{code,message,details,requestId}}`）。
+3. **Given** 超过一页的注册集，**When** GET list（带 `limit`≤500，超限截断到 500），**Then** 返回 `data`/`nextCursor`/`hasMore` envelope，`nextCursor` 可稳定翻页（per `go-standards.md` 列表分页约定）。
 
 ---
 
-### User Story 7 - Admin 审批工作流：approve/reject + RBAC（Priority: P2）
+### User Story 7 - Admin 审批工作流：approve/reject/retire + RBAC（Priority: P2）
 
-`http.registry.contract.approve.v1` / `reject.v1` 契约 + handler + 路由门禁经 `auth.RequirePermission(authz.Permission)` 接 accesscore admin 决策（PDP，非硬编 role 字面量）+ 状态机不变式（approved 才能 active；reject 不可激活）。
+`http.registry.contract.approve.v1` / `reject.v1` / `retire.v1` 契约 + handler + 路由门禁经 `auth.RequirePermission(authz.Permission)` 接 accesscore admin 决策（PDP，非硬编 role 字面量）+ 状态机不变式（approved 才能 active；reject 不可激活；retire 是 `active→retired` 终态迁移，触发数据面 remove 该契约的订阅/路由）。retire 与 approve/reject 同走 PDP admin + 审计（US8）+ `contract-retired` 事件（FR-001 闭合：submit/list/approve/reject/retire 五端点全覆盖）。
 
 **Why this priority**: 替代编译期 CI gate 的人工补偿控制；审批是产品硬需求。
 
@@ -128,6 +130,7 @@ submit/list handler（typed response envelope 表达业务状态码）+ applicat
 1. **Given** 非 admin principal，**When** 调 approve，**Then** PDP deny（路由门禁），不触碰状态机。
 2. **Given** admin 对 conformant 契约 approve，**When** 状态机推进，**Then** approved，可被 US11 数据面加载。
 3. **Given** 一个 rejected 契约，**When** 请求 activate，**Then** 状态机拒绝。
+4. **Given** admin 对一个 active 契约 retire，**When** `retire.v1` 调用，**Then** 状态机迁 `active→retired`、发 `contract-retired` 事件、触发数据面 remove 该订阅/路由（US11/US12 消费）；非 admin retire → PDP deny（fail-closed）。
 
 ---
 
@@ -225,7 +228,7 @@ HTTP 数据面从「启动期一次性 drain 注册」升级为运行时 add/rem
 
 ### User Story 14 - 端点注册 + 数据面转发（依赖 #1423/#1966）（Priority: P2，特殊可超 2000 行）
 
-进程外模型下的端点地址登记 + 框架把 topic 事件 / HTTP 请求转发到外部 cell 网络端点：复用 #1423/#1966 的 `CellTransport` remote 实现 + Resolver（cellID→endpoint）+ service token 出站签名 + principal/tenant 跨进程传播，不另造转发栈。
+进程外模型下的端点地址登记 + 框架把 topic 事件 / HTTP 请求转发到外部 cell 网络端点：复用 #1423/#1966 的 `CellTransport` remote 实现 + Resolver（cellID→endpoint）+ service token 出站签名 + principal/tenant 跨进程传播，不另造转发栈。**ExternalEndpoint 注册与数据面转发目标 MUST 经与 conformance 探测同一 endpoint egress allowlist admission（US16）**——框架带 service token + principal/tenant 转发前，目标端点须已 admitted，禁向非 allowlist / 内网 metadata 地址转发（SSRF/身份外泄边界）。
 
 **Why this priority**: epic 验收信号「框架不重启即转发该 topic 事件给该外部端点」的转发落地面；因复用 #1423 故 gated 在其 remote transport 就位之后。
 
@@ -233,8 +236,9 @@ HTTP 数据面从「启动期一次性 drain 注册」升级为运行时 add/rem
 
 **Acceptance Scenarios**:
 
-1. **Given** 一个已 active 的外部 event 契约 + 登记端点，**When** 框架收到该 topic 事件，**Then** 经 remote transport 转发到外部端点，带 service token + principal/tenant 传播头。
+1. **Given** 一个已 active 的外部 event 契约 + 已 admitted 端点，**When** 框架收到该 topic 事件，**Then** 经 remote transport 转发到外部端点，带 service token + principal/tenant 传播头。
 2. **Given** 外部端点不可达，**When** 转发，**Then** 返回 upstream-cell-unavailable 类 errcode（复用 #1423 FR-007 投影约束），可区分本地依赖缺失。
+3. **Given** 登记/转发目标是非 allowlist 或内网 metadata 地址，**When** 注册端点或框架准备转发，**Then** endpoint egress admission（US16）fail-closed 拒绝，不携 token/租户身份外发。
 
 ---
 
@@ -253,18 +257,18 @@ HTTP 数据面从「启动期一次性 drain 注册」升级为运行时 add/rem
 
 ---
 
-### User Story 16 - 恶意注册防护 + 限流 + conformance egress allowlist（Priority: P2）
+### User Story 16 - 恶意注册防护 + 限流 + endpoint egress allowlist（Priority: P2）
 
-注册端点鉴权 + 限流（防重复/恶意注册）+ conformance 探测 SSRF 防护：框架向「提交方声明的任意端点」发请求前过 egress allowlist + 鉴权 + 限流，禁裸打（威胁矩阵 conformance SSRF/出站攻击面）。
+注册端点鉴权 + 限流（防重复/恶意注册）+ **统一 endpoint egress allowlist admission**：框架一切向「提交方声明的端点」的出站——conformance 探测（US17）**与** US14 数据面转发 **与** ExternalEndpoint 注册——前都过同一 egress allowlist + 鉴权 + 限流，禁裸打任意地址（威胁矩阵 SSRF/身份外泄/出站攻击面）。单一 admission seam，数据面只消费 admitted endpoint。
 
-**Why this priority**: 进程外控制面对外发请求的攻击面收敛；zero-trust 边界硬需求。
+**Why this priority**: 进程外控制面对外发请求的攻击面收敛；zero-trust 边界硬需求；conformance 与数据面转发共用一条 endpoint admission 边界，避免「探测过门、转发裸打」的不一致缺口。
 
-**Independent Test**: 超频注册被限流；conformance 探测目标不在 allowlist → 拒绝；未授权 submit → 401/403。
+**Independent Test**: 超频注册被限流；conformance 探测**或** US14 转发目标不在 allowlist / 是内网 metadata 地址 → 拒绝；未授权 submit → 401/403。
 
 **Acceptance Scenarios**:
 
 1. **Given** 短时间大量注册请求，**When** 超过预算，**Then** 限流拒绝（429 / 稳定 errcode）。
-2. **Given** conformance 探测目标端点不在 egress allowlist，**When** 框架准备发探测请求，**Then** 拒绝（不裸打任意地址）。
+2. **Given** conformance 探测目标 **或** US14 数据面转发目标端点不在 egress allowlist（或为内网 metadata 地址），**When** 框架准备出站（探测 / 转发），**Then** 同一 admission fail-closed 拒绝（不裸打任意地址、不携 token/租户身份外发）。
 
 ---
 
@@ -281,7 +285,7 @@ HTTP 数据面从「启动期一次性 drain 注册」升级为运行时 add/rem
 1. **Given** 一个声明 HTTP-provider 契约的活体外部 cell，**When** 框架在隔离窗口跑读/幂等面 conformance，**Then** 通过则晋级 conformant 并写 result record，失败则停 probing。
 2. **Given** 一个声明了 setup 但缺 teardown 的 conformance 用例，**When** 校验，**Then** sealed 类型不可表达（编译/校验错）。
 
-**Trigger**: 随 US7（Admin 审批，P2）落地后启动；首档不 hard-depend 多租户。
+**Trigger**: blocked-by US7（Admin 审批，P2）+ **US16（endpoint egress allowlist）**——探测向活体端点出站前 egress admission 必须先就位，避免可部署 probe 裸打外部端点；首档不 hard-depend 多租户。
 
 ---
 
@@ -310,7 +314,7 @@ HTTP 数据面从「启动期一次性 drain 注册」升级为运行时 add/rem
 - 数据面动态 add/remove 与正在消费的 goroutine 竞争 → per-handler 子 ctx 隔离 + map 锁 + drain。
 - 外部端点在 active 后下线 → 转发失败映射 errcode；不影响 in-tree 契约转发。
 - in-tree 静态扇出 archtest 对 runtime 注册契约 vacuous → 设计预期，P0 ADR 显式声明 scope 边界，并为 out-of-tree 提供等价 runtime 扇出校验（注册时验 publisher/subscriber/owner 完整性）。
-- conformance 探测目标声明为内网/元数据地址（SSRF）→ egress allowlist 拒绝。
+- conformance 探测**或** US14 数据面转发目标声明为内网/元数据地址（SSRF）→ 同一 endpoint egress allowlist admission 拒绝（探测与转发不得有「探测过门、转发裸打」的边界不一致）。
 
 ## Requirements *(mandatory)*
 
@@ -318,14 +322,14 @@ HTTP 数据面从「启动期一次性 drain 注册」升级为运行时 add/rem
 
 - **FR-001**: 框架 MUST 提供运行时契约注册 API（submit/list/approve/reject/retire），外部 cell 经 API 注册，**无需重编译/部署框架**。
 - **FR-002**: 注册时 MUST 经 governance gate（复用 `governance.Validator`）同步校验，校验不过的契约不进 submitted；gate fail-closed（校验器/租户/store 不可用 → deny）。
-- **FR-003**: 契约状态机 MUST 为 sealed `submitted→probing→(conformant→pending-approval→approved|rejected)→active→retired`，不变式「approved 才能 active」「reject 不可激活」由状态机强制，包外不可伪造状态。
+- **FR-003**: 契约状态机 MUST 为 sealed，合法迁移：主路径 `submitted→probing→conformant→pending-approval→approved→active→retired`；终态分支 `probing→rejected`（conformance 失败）与 `pending-approval→rejected`（admin 拒绝）——`rejected` 为终态、**无 →active 迁移**。不变式「approved 才能 active」「reject 不可激活」由迁移表强制，包外不可伪造状态。
 - **FR-004**: in-tree 编译期静态治理（cellgen / archtest 扇出闭环 / `gocell validate`）MUST 零回归；其对 runtime 注册契约 vacuous 是设计预期，由 P0 ADR 显式声明。
-- **FR-005**: approve/reject MUST 经 PDP（`auth.RequirePermission`）接 accesscore admin 决策，不硬编 role 字面量；缺 Authorizer fail-closed。
+- **FR-005**: approve/reject/retire MUST 经 PDP（`auth.RequirePermission`）接 accesscore admin 决策，不硬编 role 字面量；缺 Authorizer fail-closed。retire 是 `active→retired` 终态迁移，触发数据面 remove。
 - **FR-006**: submit/approve/reject/retire MUST 经 auditcore hash chain 落账（replayable PII hash/redaction）；激活/退役 MUST 发 L2 OutboxFact 事件。
 - **FR-007**: EventRouter MUST 支持运行时 add/remove subscription（per-handler 子 ctx 生命周期，fail-closed 无半启动），消费 contract-activated 动态加载；HTTP Router MUST 支持运行时 add/remove route（不绕过 auth chain）。
 - **FR-008**: 数据面加载 MUST 版本化 + 版本回退 fail-closed（保留 last-good）+ 激活事件 debounce 批量合并。
 - **FR-009**: 注册 MUST 唯一性校验 `(kind,domain-path,version,owner)` 四元组 + 外部契约命名空间前缀；consistency 越权 fail-closed。
-- **FR-010**: 注册端点 MUST 鉴权 + 限流；conformance 探测 MUST 过 egress allowlist（SSRF 防护），禁裸打任意端点。
+- **FR-010**: 注册端点 MUST 鉴权 + 限流；一切向提交方声明端点的出站——conformance 探测（US17）+ US14 数据面转发 + ExternalEndpoint 注册——MUST 过**同一 endpoint egress allowlist admission**（SSRF/身份外泄防护），禁裸打任意端点；数据面只消费 admitted endpoint。
 - **FR-011**: `probing` conformance 首档 MUST 验活体读/幂等面（schema/status/disposition/error envelope）+ setup/teardown sealed 配对；彻底档（写面 + 合成租户 + egress-suppression）hard-depend 多租户 GA（#1337）。
 - **FR-012**: 端点注册 + 数据面转发 MUST 复用 #1423/#1966 的 remote transport（Resolver + service token + principal/tenant 传播），不另造转发栈。
 - **FR-013**: 本 epic 引入的 runtime governance gate AI-robust 评级 MUST 标注为 **Medium**（runtime guard + 人审），在 ADR 威胁矩阵显式记录，不伪装成 Hard。
@@ -337,7 +341,7 @@ HTTP 数据面从「启动期一次性 drain 注册」升级为运行时 add/rem
 - **GovernanceGateResult**: `{allowed, result, warnings}`（AdmissionResponse 式）；`:check`/`submit` 双入口共用 Validator。
 - **RegistrySnapshot（数据面快照）**: 单调 Version + 订阅/路由意图集；diff reconcile 的 desired 源。
 - **ConformanceProbe**: 活体握手用例 + sealed setup/teardown 配对 + egress allowlist；result record append-only。
-- **ExternalEndpoint**: cellID→endpoint 地址登记；转发经 #1423 Resolver/CellTransport remote。
+- **ExternalEndpoint**: cellID→endpoint 地址登记；注册与转发前经 endpoint egress allowlist admission（与 conformance 同一边界，US16）；转发经 #1423 Resolver/CellTransport remote，数据面只消费 admitted endpoint。
 
 ## Success Criteria *(mandatory)*
 

--- a/specs/070-runtime-contract-registry/spec.md
+++ b/specs/070-runtime-contract-registry/spec.md
@@ -1,0 +1,360 @@
+# Feature Specification: 运行时契约注册中心（Runtime Contract Registry + Admin 审批）
+
+**Feature Branch**: `070-runtime-contract-registry`（规格分解阶段未建分支，实施期按子 issue 各自走 worktree，对齐 069 先例）
+**Created**: 2026-06-16
+**Status**: Draft（epic #303 任务分解产物）
+**Input**: Epic #303 — 框架上线后持续运行，外部 cell（独立进程/服务）经 API 随时提交契约注册，framework admin 审批通过后契约即上线生效，**无需重新编译/部署框架二进制**。
+
+## 范围基线（2026-06-16 探索结论）
+
+- **架构形态已定（进程外控制面）**：外部 cell 是独立进程；注册中心管理其**契约元数据 + 订阅意图 + 端点地址**。框架退化为「契约控制面 + 事件/HTTP 数据面转发」；in-tree 二进制保持完全静态可验证。范式对标 K8s CRD + API aggregation / Envoy xDS / Confluent Schema Registry。
+- **dual-track（必须诚实对齐宪法）**：In-tree cells 现有编译期静态治理（cellgen / archtest 扇出闭环 / `gocell validate`）**全部保留不变**，仍是 trust root；Out-of-tree cells 编译期治理结构性不可达 → 由 **runtime governance gate 补偿**（注册时跑同一套 `kernel/governance.Validator` + 自动 conformance + admin 审批 + 审计落账）。这是 out-of-tree 契约在 Go 下的天花板，**AI-robust 评级 = Medium（runtime guard + 人审），不得伪装成 Hard**。
+- **现状证据（已读源码）**：`kernel/registry.ContractRegistry` 当前**完全只读**（`NewContractRegistry(project)` 一次性构建 map + 读时 deepCopy，无 mutation API）；`runtime/eventrouter.Router` 是「声明 then `Run`-once」（`Run MUST be called at most once`，无运行时增删 handler）；`kernel/governance.Validator` 是纯 Go 校验器，今天只被 `gocell validate` CLI 调用。对标与采纳/偏离详见同目录 `research.md`。
+- **状态机**：`submitted → probing → (conformant → pending-approval → approved | rejected) → active → retired`。
+- **边界划清**（非重复造轮子）：
+  - **#1081 / #1090（M9）= Tier-1**（编译期外部 cell：源码编译进二进制）；本 epic = **Tier-2**（运行时注册，进程外）。#1090 明确不做中心运行时 registry → 归本 epic。两者互补、非二选一。
+  - **#1046（D5/W5 Schema Registry runtime）= codegen-time schema hash/compat**，与本 epic 的 runtime **契约**注册不同层，非重复。
+  - **#1423 / #1966（location-transparent remote transport）= 数据面转发的真实前置**：US14（端点注册 + 转发）复用其 `CellTransport` remote 实现与 Resolver，不另造。
+  - **#659（CELL-CONSUMER-EXTRA-TOPICS-OPTION-01）= #303 原始 `WithExtraTopics` 诉求**，已被本 epic 取代，分解落地后 close as superseded。
+  - **#1337（多租户/ABAC）= US18 彻底档 conformance 的硬依赖**。
+
+## User Scenarios & Testing *(mandatory)*
+
+> 每个 user story = 一个 GitHub backlog issue = 一个（或一簇）PR，净增删 ≤2000 行（US14/US18 标记特殊可超）。优先级 P1=关键路径地基，P2=主体能力，P3=深度 gated。
+
+### User Story 1 - 方向 ADR：dual-track + 进程外控制面/数据面转发裁决（Priority: P1）
+
+平台维护者需要一份方向 ADR，论证 dual-track reconciliation（in-tree Hard trust root 不动摇 / out-of-tree runtime governance gate = Medium）、进程外控制面 + 数据面转发设计、完整威胁矩阵，并显式声明现有扇出 archtest（`DEAD-CONTRACT-01` / `IMPL-DECL-COVER-01` / `EMIT-DECL-COVER-01` / `DEAD-CODE-01`）对 runtime 注册契约的 vacuous 边界（设计预期，非缺陷）。
+
+**Why this priority**: cheap 决策、最高杠杆——裁决结果 reshape 下游所有 story 形态（状态机载体、governance gate 同步/异步、数据面加载一致性模型、conformance 副作用方案）。
+
+**Independent Test**: ADR 文档合入即交付；下游 story 可直接引用其裁决条款开工。
+
+**Acceptance Scenarios**:
+
+1. **Given** 宪法「AI-robust = 违反不可表达」与 runtime 注册的结构性张力，**When** ADR 合入，**Then** dual-track 论证完整：in-tree 轨道列出保留不变的编译期机器，out-of-tree 轨道明确 governance gate 的 Medium 评级 + 人审补偿，**不伪装成 Hard**。
+2. **Given** 威胁矩阵（恶意注册 / 命名空间冲突 / consistency 越权 / 数据面并发 / 审批旁路 / conformance SSRF / 合成租户副作用泄漏 / AI-robust 降级），**When** ADR 合入，**Then** 每行有对应补偿措施 + 落地 story 指针。
+3. **Given** 与 #1081/#1090/#1046/#1423 的关系，**When** ADR 合入，**Then** 显式划清「两层模型 + 外部团队何时选 Tier-1 vs Tier-2」+ 数据面转发复用 #1423 remote transport 的边界，并与 #1081 方向 ADR 对齐。
+
+---
+
+### User Story 2 - Runtime ContractRegistry 可变化：只读 → 状态机（Priority: P1）
+
+`kernel/registry.ContractRegistry` 从一次性只读升级为带 sealed 状态机的可注册中心：`register / approve / activate / retire` 迁移 + sealed `RegistrationState`（submitted…retired）+ append-only 事件溯源底模 + 投影出 in-mem 索引（保留现有 deepCopy serving 读路径）。
+
+**Why this priority**: 所有运行时注册能力的内核地基；状态迁移不变式（只有 approved 才能 active）是审批旁路防护的根。
+
+**Independent Test**: 单元测试（kernel ≥90%）覆盖每条合法/非法状态迁移；非法迁移 fail-closed；投影索引与 append-only 事件一致。
+
+**Acceptance Scenarios**:
+
+1. **Given** 一个 submitted 契约，**When** 未经 approved 直接请求 activate，**Then** 状态机拒绝（不变式：approved 才能 active），返回 typed 错误。
+2. **Given** sealed `RegistrationState`，**When** 包外尝试构造任意状态值或跳变，**Then** 编译期不可表达（sealed 构造）；状态值集冻结。
+3. **Given** append-only 迁移事件流，**When** 重建投影索引，**Then** 当前态与事件流一致，且现有 in-tree 只读读路径（`Get`/`ByKind`/`ByOwner`/`Provider`/`Consumers`）零回归。
+
+---
+
+### User Story 3 - 注册时 governance gate（复用 Validator + dry-run/submit 双入口）（Priority: P1）
+
+把现有 `kernel/governance.Validator`（今天只 CLI 调）包成 K8s AdmissionResponse 式 `{allowed, result, warnings}`，提供 `:check`（dry-run，不落库）+ `submit`（落库前同步校验）两入口共用一套校验逻辑（对标 Confluent SR 的 `/compatibility/*` vs `/versions`）；`FailurePolicy=Fail` fail-closed（校验器不可达/缺租户/store 不可用 → deny）。
+
+**Why this priority**: 「把 `gocell validate` 从 CI 搬到注册端点」是 dual-track 的核心补偿机制；最小改动最高杠杆（Validator 已存在）。
+
+**Independent Test**: 合法契约经 `:check` 返回 allowed+warnings；非法契约连 submitted 都不进（静态门同步拒绝）；校验器不可达时 fail-closed。
+
+**Acceptance Scenarios**:
+
+1. **Given** 一个 wire 合规但有非阻断告警的契约，**When** 调 `:check`，**Then** 返回 `{allowed:true, warnings:[…]}`，不落库。
+2. **Given** 一个违反 governance 规则的契约，**When** 调 `submit`，**Then** 落库前同步拒绝（无「submitted 但 invalid」中间态），错误带可机读 reason。
+3. **Given** Validator/依赖不可达，**When** 注册请求到达，**Then** fail-closed（deny），绝不 fail-open。
+
+---
+
+### User Story 4 - registrycore cell 骨架 + submit/list 契约声明（Priority: P1）
+
+新增平台 cell `registrycore`（与 accesscore/auditcore/configcore 并列，吃自己的狗粮）：`cell.yaml` + slices + `http.registry.contract.submit.v1` / `http.registry.contract.list.v1` 契约声明，经 cellgen 从 metadata 单源派生注册代码。
+
+**Why this priority**: 注册中心的承载 cell；submit/list 是外部 cell 接入的最小可用面。
+
+**Independent Test**: `gocell validate` 接受新 cell + 契约；cellgen 派生的 `cell_gen.go` 与 golden 一致；契约级测试覆盖正常响应 schema。
+
+**Acceptance Scenarios**:
+
+1. **Given** registrycore cell.yaml + slice.yaml（含 contractUsages），**When** `gocell validate` 与 cellgen 运行，**Then** 校验通过、派生代码与 golden 字节一致。
+2. **Given** submit/list HTTP 契约，**When** 契约级测试运行，**Then** 正常响应 schema / 参数错误码 / 鉴权边界 / path 参数校验全覆盖。
+
+---
+
+### User Story 5 - contract_registrations 表 + PG store（Priority: P1）
+
+`contract_registrations` 表 migration（id / submitter / kind / payload-schema / state / approver / timestamps）+ PG store + repository（`internal/ports` 接口 + `internal/mem` + PG 实现）；状态迁移走 L1 本地事务；append-only 迁移历史（对标 SR/Pact 不可变 verification record）。
+
+**Why this priority**: 注册态的持久化真源；US2 状态机的落地存储面。
+
+**Independent Test**: repository 事务完整性测试（L1）；迁移历史 append-only；RLS/owner 形态符合 schema guard。
+
+**Acceptance Scenarios**:
+
+1. **Given** 一次状态迁移，**When** 写入失败回滚，**Then** 不留半态（L1 事务原子性）。
+2. **Given** 已提交 migration，**When** 新增字段，**Then** 有默认值或允许 NULL（只增不改，命名 `{序号}_{动词}_{对象}.sql`）。
+
+---
+
+### User Story 6 - submit/list handlers + service 接线 + 契约测试（Priority: P1）
+
+submit/list handler（typed response envelope 表达业务状态码）+ application service（必填依赖 `gocell:"required"`）+ 接 US2 状态机 / US3 gate / US5 store，contract-level 测试闭环。
+
+**Why this priority**: 把 US2-US5 串成「外部 cell 能 submit 一个契约并 list 看到 pending」的端到端最小闭环（epic MVP 的提交面）。
+
+**Independent Test**: httptest 覆盖 submit（合法→pending / 非法→4xx）+ list（按 state 过滤）；contract 测试断言 error envelope 合规。
+
+**Acceptance Scenarios**:
+
+1. **Given** 合法契约 payload，**When** POST submit，**Then** 经 gate → 落库 → 返回 201 + registration id，state=submitted/probing。
+2. **Given** 非法 payload，**When** POST submit，**Then** 返回声明的 4xx + shared error schema（`{error:{code,message,details,requestId}}`）。
+
+---
+
+### User Story 7 - Admin 审批工作流：approve/reject + RBAC（Priority: P2）
+
+`http.registry.contract.approve.v1` / `reject.v1` 契约 + handler + 路由门禁经 `auth.RequirePermission(authz.Permission)` 接 accesscore admin 决策（PDP，非硬编 role 字面量）+ 状态机不变式（approved 才能 active；reject 不可激活）。
+
+**Why this priority**: 替代编译期 CI gate 的人工补偿控制；审批是产品硬需求。
+
+**Independent Test**: 非 admin 调 approve → PDP deny（fail-closed）；approve 后状态机推进 pending-approval→approved；reject 后契约不可 activate。
+
+**Acceptance Scenarios**:
+
+1. **Given** 非 admin principal，**When** 调 approve，**Then** PDP deny（路由门禁），不触碰状态机。
+2. **Given** admin 对 conformant 契约 approve，**When** 状态机推进，**Then** approved，可被 US11 数据面加载。
+3. **Given** 一个 rejected 契约，**When** 请求 activate，**Then** 状态机拒绝。
+
+---
+
+### User Story 8 - 审批审计落账 + 激活/退役事件（Priority: P2）
+
+submit/approve/reject/retire 每次经 auditcore hash chain 落账（审批可追溯硬需求，PII hash/redaction）+ `event.registry.contract-activated.v1` / `contract-retired.v1`（L2 OutboxFact，envelope 字段由 `outbox.NewEntry` 注入，不伪造 reserved key）。
+
+**Why this priority**: 审批旁路防护的留痕面 + 数据面动态加载的事件源（US11 消费）。
+
+**Independent Test**: L2 outbox 原子性 + consumer 幂等测试；审计链含 submit/approve/activate；replayable PII 已 hash。
+
+**Acceptance Scenarios**:
+
+1. **Given** 一次 approve，**When** 事务提交，**Then** 审计 hash chain 追加一条 + `contract-activated` 事件原子入 outbox（同事务）。
+2. **Given** 审计 payload 含 submitter 标识，**When** 落账，**Then** replayable PII 经 hash/redaction，不明文留存。
+
+---
+
+### User Story 9 - EventRouter handlers 容器 slice→map（地基重构）（Priority: P1）
+
+`eventrouter.Router` 的 `handlers []handlerConfig` 改为 `map[handlerKey]*runningHandler`（key=topic+consumerGroup），新增 `runningHandler` 结构（持 cfg + cancel + started + done channel）；`Run` 4 阶段 / `HandlerCount` / `AddContractHandler` 同步改 map；重名返回 error（不 panic）。**行为等价、零功能变更**。
+
+**Why this priority**: US10 运行时增删的数据结构前提；先做无行为变更的地基重构降低 US10 风险（对标 watermill `map[string]*handler`）。
+
+**Independent Test**: 现有 eventrouter 测试全过（行为等价）；重名 key 返回 error。
+
+**Acceptance Scenarios**:
+
+1. **Given** 多个声明式 handler（pre-Run），**When** `Run` 遍历 map 执行 4 阶段，**Then** 与改造前 slice 行为一致，现有测试零回归。
+2. **Given** 同 key（topic+group）重复 add，**When** 第二次 add，**Then** 返回 error（不 panic，对齐 error-handling.md）。
+
+---
+
+### User Story 10 - 数据面运行时增删订阅：per-handler ctx + Add/Remove（Priority: P1）
+
+`runRootCtx` 字段提升（现为 `Run` 局部变量）+ 新增 `AddRunningHandler(ctx, spec, handler, group, owner, opts)` / `RemoveHandler(topic, group)`：每个动态 handler 挂 `context.WithCancel(runRootCtx)` 子 ctx；Add 复刻 Setup→Subscribe→await Ready（fail-closed：任一步失败 hcancel + 不入 map + 不 Inc）；Remove 取消子 ctx + 等 drain + DecActive；与 `runGuard sync.Once` 兼容（Run 仍一次，动态增删只在 started 后合法）；`Close` 三阶段 drain 零改动复用。
+
+**Why this priority**: P4 数据面最大改造、epic 验收信号「框架不重启即转发新 topic 事件」的核心；goroutine 生命周期 + 并发安全是难点（对标 watermill per-handler `stopFn` + controller-runtime ctx-per-source）。
+
+**Independent Test**: Run 后 AddRunningHandler 成功消费新 topic；RemoveHandler 后该订阅 goroutine 退出、不影响其他 handler；Add 中途失败无半启动泄漏；Close 仍能停掉动态 handler。
+
+**Acceptance Scenarios**:
+
+1. **Given** Router 已 Run，**When** AddRunningHandler 注册一个新 topic，**Then** 经 Setup→Subscribe→Ready 后开始消费，IncSubscriptionActive，其他 handler 不受影响。
+2. **Given** 一个运行中的动态 handler，**When** RemoveHandler，**Then** 仅该 handler 子 ctx 取消、drain 后从 map 删除并 DecActive。
+3. **Given** AddRunningHandler 在 Ready 等待超时/失败，**When** 失败返回，**Then** hcancel 调用、不入 map、不 Inc（fail-closed，无半启动）。
+
+---
+
+### User Story 11 - Snapshot 版本化 diff Reconcile + 激活事件 debounce（Priority: P2）
+
+`RegistrySnapshot` 加单调 `Version`；新增 `Reconcile(snapshot)`：与当前 map diff 算 toAdd/toRemove 分别调 Add/RemoveRunningHandler，版本回退 fail-closed（对标 go-control-plane 版本化 + xDS NACK 保留 last-good）；`event.registry.contract-activated` 消费侧 debounce（对标 istio `DebounceAfter`+`debounceMax`，窗口内多激活 merge 成一次 reconcile）；archtest 守卫（动态 handler 子 ctx 必须挂 runRootCtx、Add fail 必 hcancel）同 PR 落地。
+
+**Why this priority**: 把 US10 的单点增删升级为「控制面事件 → 数据面收敛」的原子/批量加载；避免逐事件全 Router 重建；闭合 AI-robust 守卫（同 PR 自证）。
+
+**Independent Test**: 多个 activated 事件经 debounce 合并为一次 diff reconcile；版本回退被拒；archtest synthetic red case（裸 ctx / 漏 hcancel）红、修复后绿。
+
+**Acceptance Scenarios**:
+
+1. **Given** 窗口内 N 个 contract-activated 事件，**When** debounce 触发，**Then** 一次 Reconcile 应用 N 条 diff（非 N 次全量重建）。
+2. **Given** 一个版本号回退的 snapshot，**When** Reconcile，**Then** fail-closed 拒绝，保留 last-good。
+3. **Given** 违反「子 ctx 挂 runRootCtx」的 synthetic 代码，**When** archtest 运行，**Then** 规则红；修复后绿（anti-vacuity）。
+
+---
+
+### User Story 12 - HTTP Router 运行时动态 route（Priority: P2）
+
+HTTP 数据面从「启动期一次性 drain 注册」升级为运行时 add/remove route（`net/http.ServeMux` 不支持运行时改 → 引入可替换/包装的动态 mux），消费 contract-activated 给外部 cell 端点登记路由；与 FinalizeAuth / listener auth plan 兼容（动态 route 仍过最终 matcher，不绕过 auth）。
+
+**Why this priority**: HTTP 维度的数据面动态加载，与 US10/US11 的 event 维度对称；进程外 HTTP 契约转发的前提。
+
+**Independent Test**: Run 后动态注册一条 route 可被请求命中、过 auth chain；移除后 404；并发 add/remove 无竞争。
+
+**Acceptance Scenarios**:
+
+1. **Given** 框架已起，**When** 动态注册一条外部 cell 的 HTTP route，**Then** 请求命中且 listener auth plan 照常生效（不因动态注册绕过）。
+2. **Given** 已注册的动态 route，**When** 移除，**Then** 后续请求 404，无在途请求被腰斩。
+
+---
+
+### User Story 13 - 外部 cell 注册客户端 / SDK（Priority: P2）
+
+外部 cell（进程外）如何声明契约、上传 payload schema、调注册 API 的 client/SDK：契约声明 helper + schema 上传 + submit/poll-status client（对标 SR client RegisterSchemaRequest）。
+
+**Why this priority**: 外部团队接入的开发者体验面；把 US6 的服务端 submit 面补成可用的客户端。
+
+**Independent Test**: SDK 构造一个 event 契约声明 → submit → poll 到 state 变迁；错误响应可区分（no-mapping / invalid / unavailable）。
+
+**Acceptance Scenarios**:
+
+1. **Given** 外部 cell 用 SDK 声明一个 event 契约，**When** 调 submit，**Then** 拿到 registration id 并可 poll 到 submitted→probing→pending-approval。
+2. **Given** 注册被 gate 拒，**When** SDK 收到响应，**Then** 错误机读可区分（typed reason），非英文文本解析。
+
+---
+
+### User Story 14 - 端点注册 + 数据面转发（依赖 #1423/#1966）（Priority: P2，特殊可超 2000 行）
+
+进程外模型下的端点地址登记 + 框架把 topic 事件 / HTTP 请求转发到外部 cell 网络端点：复用 #1423/#1966 的 `CellTransport` remote 实现 + Resolver（cellID→endpoint）+ service token 出站签名 + principal/tenant 跨进程传播，不另造转发栈。
+
+**Why this priority**: epic 验收信号「框架不重启即转发该 topic 事件给该外部端点」的转发落地面；因复用 #1423 故 gated 在其 remote transport 就位之后。
+
+**Independent Test**: 双进程 fixture 下，approve 后框架把合成事件转发到外部 cell 端点，principal/tenant 正确重建；端点不可达映射为专属 errcode。
+
+**Acceptance Scenarios**:
+
+1. **Given** 一个已 active 的外部 event 契约 + 登记端点，**When** 框架收到该 topic 事件，**Then** 经 remote transport 转发到外部端点，带 service token + principal/tenant 传播头。
+2. **Given** 外部端点不可达，**When** 转发，**Then** 返回 upstream-cell-unavailable 类 errcode（复用 #1423 FR-007 投影约束），可区分本地依赖缺失。
+
+---
+
+### User Story 15 - 命名空间防冲突 + consistency ceiling（Priority: P2）
+
+注册时唯一性校验 `(kind, domain-path, version, owner)` 四元组（对标 K8s CRD NamesAccepted condition）+ 外部契约强制命名空间前缀；consistency 越权防护：runtime cell 声明的一致性级别经 actors.yaml `maxConsistencyLevel` 语义的 runtime 形态裁决。
+
+**Why this priority**: 威胁矩阵「topic/路由命名空间冲突」+「consistency 越权」的补偿；in-tree 与 out-of-tree 契约 ID/topic/path 撞车的硬防护。
+
+**Independent Test**: 注册与 in-tree 契约 ID/topic 撞车 → 拒绝；声明超出 ceiling 的一致性级别 → 拒绝。
+
+**Acceptance Scenarios**:
+
+1. **Given** 一个与已有 in-tree 契约同 `(kind,domain,version,owner)` 的注册，**When** submit，**Then** 唯一性校验拒绝。
+2. **Given** 外部 cell 声明超出其 actor ceiling 的 consistency level，**When** 注册，**Then** fail-closed 拒绝。
+
+---
+
+### User Story 16 - 恶意注册防护 + 限流 + conformance egress allowlist（Priority: P2）
+
+注册端点鉴权 + 限流（防重复/恶意注册）+ conformance 探测 SSRF 防护：框架向「提交方声明的任意端点」发请求前过 egress allowlist + 鉴权 + 限流，禁裸打（威胁矩阵 conformance SSRF/出站攻击面）。
+
+**Why this priority**: 进程外控制面对外发请求的攻击面收敛；zero-trust 边界硬需求。
+
+**Independent Test**: 超频注册被限流；conformance 探测目标不在 allowlist → 拒绝；未授权 submit → 401/403。
+
+**Acceptance Scenarios**:
+
+1. **Given** 短时间大量注册请求，**When** 超过预算，**Then** 限流拒绝（429 / 稳定 errcode）。
+2. **Given** conformance 探测目标端点不在 egress allowlist，**When** 框架准备发探测请求，**Then** 拒绝（不裸打任意地址）。
+
+---
+
+### User Story 17 - 注册 conformance 自动测试（首档：读/幂等面 + setup/teardown）（Priority: P2，flag-cond）
+
+`probing` 态机器门：框架扮合成 consumer，按契约 request schema 造请求打活体外部 cell 端点（读/幂等面），断言 successStatus + 响应 schema + 声明 4xx/5xx 可达 + error envelope 合规（对标 Pact provider verification）；副作用隔离用 setup/teardown 配对（sealed 类型强制配对，缺 teardown 校验错，强于 Pact 运行时约定）；conformance 结果落 append-only record，admin 据此审批。
+
+**Why this priority**: admin 人审前的机器门（验活体黑盒兑现契约）；首档不依赖多租户，随 P3 可早上。
+
+**Independent Test**: 活体端点 conformance 握手通过 → 晋级 conformant；schema 不符 → 停在 probing；setup 必配 teardown（缺则校验/编译错）。
+
+**Acceptance Scenarios**:
+
+1. **Given** 一个声明 HTTP-provider 契约的活体外部 cell，**When** 框架在隔离窗口跑读/幂等面 conformance，**Then** 通过则晋级 conformant 并写 result record，失败则停 probing。
+2. **Given** 一个声明了 setup 但缺 teardown 的 conformance 用例，**When** 校验，**Then** sealed 类型不可表达（编译/校验错）。
+
+**Trigger**: 随 US7（P3a Admin 审批）落地后启动；首档不 hard-depend 多租户。
+
+---
+
+### User Story 18 - 注册 conformance 彻底档（合成租户写面 + egress-suppression，hard-depend #1337）（Priority: P3，flag-cond）
+
+彻底档 conformance：用一次性**合成租户**跑真实写路径（复用 tenant 隔离边界，不发明 conformance 专用旁路），测完整租户清除 + event-consumer 写面深测；合成租户附 **egress-suppression** 标记（禁真实外发：事件/外部系统/邮件）；非多租户 cell 退回首档 (c)+admin 签字（混合形态）。
+
+**Why this priority**: conformance 最彻底形态，但其安全保证完全建立在 tenant 隔离边界为真之上 → 结构性 block 在多租户 GA 之后。
+
+**Independent Test**: 多租户 GA 后，合成租户跑写路径 conformance，测完整租户可清除、无数据泄漏进共享态；egress-suppression 下合成请求不触发真实外发。
+
+**Acceptance Scenarios**:
+
+1. **Given** 多租户 GA + 一个 tenant-aware 外部 cell，**When** 合成租户跑写面 conformance，**Then** 真实 handler/真落库执行、测完整租户清除、无跨租户泄漏。
+2. **Given** 合成租户请求触发 handler 对外发事件，**When** egress-suppression 生效，**Then** 真实外发被抑制。
+
+**Trigger**: hard-depend 多租户/ABAC epic #1337 GA；US10/US17 就位后。
+
+---
+
+### Edge Cases
+
+- 注册端点收到空/畸形 payload → 同步 gate 拒绝，不进 submitted（无 invalid 中间态）。
+- 同一契约重复 submit（幂等）→ 按 `(kind,domain,version,owner)` 去重，返回既有 registration 而非新建。
+- approve 一个非 conformant（probing 未过）契约 → 状态机拒绝（必须 conformant 才能 pending-approval→approved）。
+- 数据面动态 add/remove 与正在消费的 goroutine 竞争 → per-handler 子 ctx 隔离 + map 锁 + drain。
+- 外部端点在 active 后下线 → 转发失败映射 errcode；不影响 in-tree 契约转发。
+- in-tree 静态扇出 archtest 对 runtime 注册契约 vacuous → 设计预期，P0 ADR 显式声明 scope 边界，并为 out-of-tree 提供等价 runtime 扇出校验（注册时验 publisher/subscriber/owner 完整性）。
+- conformance 探测目标声明为内网/元数据地址（SSRF）→ egress allowlist 拒绝。
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 框架 MUST 提供运行时契约注册 API（submit/list/approve/reject/retire），外部 cell 经 API 注册，**无需重编译/部署框架**。
+- **FR-002**: 注册时 MUST 经 governance gate（复用 `governance.Validator`）同步校验，校验不过的契约不进 submitted；gate fail-closed（校验器/租户/store 不可用 → deny）。
+- **FR-003**: 契约状态机 MUST 为 sealed `submitted→probing→(conformant→pending-approval→approved|rejected)→active→retired`，不变式「approved 才能 active」「reject 不可激活」由状态机强制，包外不可伪造状态。
+- **FR-004**: in-tree 编译期静态治理（cellgen / archtest 扇出闭环 / `gocell validate`）MUST 零回归；其对 runtime 注册契约 vacuous 是设计预期，由 P0 ADR 显式声明。
+- **FR-005**: approve/reject MUST 经 PDP（`auth.RequirePermission`）接 accesscore admin 决策，不硬编 role 字面量；缺 Authorizer fail-closed。
+- **FR-006**: submit/approve/reject/retire MUST 经 auditcore hash chain 落账（replayable PII hash/redaction）；激活/退役 MUST 发 L2 OutboxFact 事件。
+- **FR-007**: EventRouter MUST 支持运行时 add/remove subscription（per-handler 子 ctx 生命周期，fail-closed 无半启动），消费 contract-activated 动态加载；HTTP Router MUST 支持运行时 add/remove route（不绕过 auth chain）。
+- **FR-008**: 数据面加载 MUST 版本化 + 版本回退 fail-closed（保留 last-good）+ 激活事件 debounce 批量合并。
+- **FR-009**: 注册 MUST 唯一性校验 `(kind,domain-path,version,owner)` 四元组 + 外部契约命名空间前缀；consistency 越权 fail-closed。
+- **FR-010**: 注册端点 MUST 鉴权 + 限流；conformance 探测 MUST 过 egress allowlist（SSRF 防护），禁裸打任意端点。
+- **FR-011**: `probing` conformance 首档 MUST 验活体读/幂等面（schema/status/disposition/error envelope）+ setup/teardown sealed 配对；彻底档（写面 + 合成租户 + egress-suppression）hard-depend 多租户 GA（#1337）。
+- **FR-012**: 端点注册 + 数据面转发 MUST 复用 #1423/#1966 的 remote transport（Resolver + service token + principal/tenant 传播），不另造转发栈。
+- **FR-013**: 本 epic 引入的 runtime governance gate AI-robust 评级 MUST 标注为 **Medium**（runtime guard + 人审），在 ADR 威胁矩阵显式记录，不伪装成 Hard。
+
+### Key Entities
+
+- **ContractRegistration（注册条目）**: id / submitter / kind / payload-schema / sealed state / approver / timestamps；状态机驱动；append-only 迁移历史。
+- **RegistrationState（sealed 状态）**: submitted / probing / conformant / pending-approval / approved / rejected / active / retired；包外不可构造，值集冻结。
+- **GovernanceGateResult**: `{allowed, result, warnings}`（AdmissionResponse 式）；`:check`/`submit` 双入口共用 Validator。
+- **RegistrySnapshot（数据面快照）**: 单调 Version + 订阅/路由意图集；diff reconcile 的 desired 源。
+- **ConformanceProbe**: 活体握手用例 + sealed setup/teardown 配对 + egress allowlist；result record append-only。
+- **ExternalEndpoint**: cellID→endpoint 地址登记；转发经 #1423 Resolver/CellTransport remote。
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 外部 cell（进程外）submit 一个 event 契约 → 自动 conformance 通过 → admin approve → 框架**不重启**即开始转发该 topic 事件给外部端点（双进程 journey 验收）。
+- **SC-002**: 未审批 / conformance 失败 / reject 的契约 100% 不可激活（状态机不变式 + 审计强制落账）。
+- **SC-003**: 全程审计可追溯（auditcore hash chain 含 submit/approve/activate）；replayable PII 0 明文。
+- **SC-004**: in-tree 静态治理（archtest 扇出闭环 + `gocell validate`）零回归。
+- **SC-005**: 恶意注册 / 命名空间冲突 / consistency 越权 / 审批旁路 / conformance SSRF 各有补偿措施，威胁矩阵逐行有落地 story。
+- **SC-006**: 每个 PR 净增删 ≤2000 行（US14/US18 特殊可超，PR 说明动机）。
+
+## Assumptions
+
+- 架构形态「进程外控制面」已定，本分解不再论证替代形态（in-process 由 #1081 Tier-1 承载）。
+- `governance.Validator` / `ContractRegistry` / `eventrouter.Router` 现状如范围基线所述（已读源码确认）。
+- 数据面转发（US14）复用 #1423/#1966 remote transport，故 gated 在其 remote 实现就位之后；本 epic 不另造跨进程同步栈。
+- conformance 彻底档（US18）hard-depend 多租户/ABAC epic #1337 GA；首档（US17）不依赖多租户，随 P3 可上。
+- 与 #1081/#1090/#1046 边界如范围基线所述（互补/不同层，非重复造中心 registry）。
+- #659 是被本 epic 取代的原始诉求，分解落地后 close as superseded by #303。

--- a/specs/070-runtime-contract-registry/spec.md
+++ b/specs/070-runtime-contract-registry/spec.md
@@ -281,7 +281,7 @@ HTTP 数据面从「启动期一次性 drain 注册」升级为运行时 add/rem
 1. **Given** 一个声明 HTTP-provider 契约的活体外部 cell，**When** 框架在隔离窗口跑读/幂等面 conformance，**Then** 通过则晋级 conformant 并写 result record，失败则停 probing。
 2. **Given** 一个声明了 setup 但缺 teardown 的 conformance 用例，**When** 校验，**Then** sealed 类型不可表达（编译/校验错）。
 
-**Trigger**: 随 US7（P3a Admin 审批）落地后启动；首档不 hard-depend 多租户。
+**Trigger**: 随 US7（Admin 审批，P2）落地后启动；首档不 hard-depend 多租户。
 
 ---
 

--- a/specs/070-runtime-contract-registry/tasks.md
+++ b/specs/070-runtime-contract-registry/tasks.md
@@ -39,6 +39,7 @@
 
 - [ ] T030 [US3] 包 `governance.Validator` 为 `{allowed,result,warnings}`（AdmissionResponse 式）；`:check`(dry-run 不落库) + `submit`(落库前同步校验) 双入口共用校验逻辑
 - [ ] T031 [P] [US3] FailurePolicy=Fail fail-closed（校验器/租户/store 不可用 → deny）+ 测试
+- [ ] T032 [US3] **runtime 扇出完整性校验**（ADR 承诺的等价 runtime 补偿）：注册时验 publisher/subscriber/owner 齐全（扇出 archtest 对 runtime 契约 vacuous 的 register-time 补偿）+ 缺 publisher/subscriber/owner 的 fail-closed 测试（与 US15 命名空间/ceiling 校验同走 gate）
 
 ### US4 — registrycore cell 骨架 + submit/list 契约声明（P1）→ #2235
 
@@ -56,15 +57,16 @@
 
 ### US6 — submit/list handlers + service 接线 + 契约测试（P1）→ #2237
 
-- [ ] T060 [US6] submit/list handler（typed response envelope）+ application service（`gocell:"required"` 依赖）接 US2 状态机 / US3 gate / US5 store
-- [ ] T061 [P] [US6] httptest：submit（合法→pending / 非法→4xx shared error schema）+ list（按 state 过滤）端到端闭环
+- [ ] T060 [US6] submit/list handler（typed response envelope）+ application service（`gocell:"required"` 依赖）接 US2 状态机 / US3 gate / US5 store；list 强制分页（`limit`≤500 截断 + `data`/`nextCursor`/`hasMore` envelope，per go-standards；复用现有 query pagination helper）
+- [ ] T061 [P] [US6] httptest：submit（合法→pending / 非法→4xx shared error schema）+ list（按 state 过滤 + cursor 翻页 + limit 上限截断）端到端闭环
 
 ## Phase 5: 审批 + 审计/事件（Wave 5，blocked-by US6）
 
-### US7 — Admin 审批 approve/reject + RBAC（P2）→ #2238
+### US7 — Admin 审批 approve/reject/retire + RBAC（P2）→ #2238
 
-- [ ] T070 [US7] `approve.v1`/`reject.v1` 契约 + handler；路由门禁 `auth.RequirePermission(authz.Permission)` 接 accesscore admin（PDP，不硬编 role）
-- [ ] T071 [P] [US7] 状态机不变式（conformant→pending-approval→approved；reject 不可激活）+ 非 admin fail-closed 测试
+- [ ] T070 [US7] `approve.v1`/`reject.v1`/`retire.v1` 契约 + handler；路由门禁 `auth.RequirePermission(authz.Permission)` 接 accesscore admin（PDP，不硬编 role）
+- [ ] T071 [P] [US7] 状态机不变式（conformant→pending-approval→approved；reject 不可激活；active→retired 终态）+ 非 admin fail-closed 测试（approve/reject/retire 三端点对称）
+- [ ] T072 [US7] retire：`active→retired` 迁移 + 审计（US8）+ `contract-retired` 事件 + 触发数据面 remove（US11/US12 消费）；contract test 覆盖 retire handler + 非 admin deny（FR-001 五端点闭合）
 
 ### US8 — 审批审计落账 + 激活/退役事件（P2）→ #2239
 
@@ -110,15 +112,15 @@
 - [ ] T150 [US15] 注册唯一性 `(kind,domain-path,version,owner)` 四元组（对标 CRD NamesAccepted）+ 外部契约命名空间前缀；与 in-tree 契约撞车拒绝
 - [ ] T151 [P] [US15] consistency 越权：runtime cell 声明级别经 actors.yaml `maxConsistencyLevel` runtime 形态裁决，超限 fail-closed
 
-### US16 — 恶意注册防护 + 限流 + conformance egress allowlist（P2）→ #2246
+### US16 — 恶意注册防护 + 限流 + endpoint egress allowlist（P2）→ #2246
 
 - [ ] T160 [US16] 注册端点鉴权 + 限流（防重复/恶意注册，429/稳定 errcode）
-- [ ] T161 [US16] conformance 探测 SSRF 防护：egress allowlist + 鉴权 + 限流，禁裸打任意端点
-- [ ] T162 [P] [US16] 测试：超频限流 / 非 allowlist 目标拒绝 / 未授权 submit 拒绝
+- [ ] T161 [US16] **统一 endpoint egress allowlist admission**：一切向提交方端点的出站——conformance 探测（US17）+ US14 数据面转发 + ExternalEndpoint 注册——同走一条 admission（egress allowlist + 鉴权 + 限流，禁裸打/内网 metadata 地址）；数据面只消费 admitted endpoint
+- [ ] T162 [P] [US16] 测试：超频限流 / conformance 或 US14 转发非 allowlist 目标拒绝 / 内网 metadata 地址拒绝 / 未授权 submit 拒绝
 
 ## Phase 9: 注册 conformance 自动测试（flag-cond，分档）
 
-### US17 — conformance 首档：读/幂等面 + setup/teardown（P2，flag-cond，blocked-by US7）→ #2247
+### US17 — conformance 首档：读/幂等面 + setup/teardown（P2，flag-cond，blocked-by US7 + US16）→ #2247
 
 - [ ] T170 [US17] `probing` 态机器门：合成 consumer 按契约 request schema 打活体端点（读/幂等面），断言 successStatus+响应 schema+声明 4xx/5xx 可达+error envelope 合规
 - [ ] T171 [US17] setup/teardown sealed 配对（缺 teardown 校验/编译错，AI-robust Hard）+ 凭据注入不入契约
@@ -136,9 +138,9 @@ US1(ADR) ─┬─ US2(SM) ─┬─ US3(gate) ─┐
           │           └─ US4(cell) ─┴─ US5(store) ─ US6(submit闭环) ─┬─ US7(approve) ─ US8(audit/event) ─┐
 US9(map) ──── US10(add/remove) ───────────────────────────────────── US11(reconcile) ←──────────────────┘
           └─ US12(http route)                                         │
-                                              US6 ─┬─ US13(SDK) ─ US14(转发) ←── #1423/#1966
-                                                   ├─ US15(namespace/ceiling) ─ US16(防护/egress)
-                                                   └─ US7 ─ US17(conformance 首档, flag-cond)
+                                              US6 ─┬─ US13(SDK) ─ US14(转发) ←── #1423/#1966 + US16(endpoint egress admission)
+                                                   ├─ US15(namespace/ceiling) ─ US16(防护/endpoint egress)
+                                                   └─ US7 ─┬─ US17(conformance 首档, flag-cond) ←── US16
                                               #1337 + US14 + US17 ─ US18(conformance 彻底档, flag-cond)
 ```
 

--- a/specs/070-runtime-contract-registry/tasks.md
+++ b/specs/070-runtime-contract-registry/tasks.md
@@ -1,0 +1,162 @@
+# Tasks: 运行时契约注册中心（Epic #303 分解）
+
+**Input**: `specs/070-runtime-contract-registry/spec.md` + `research.md`
+**Prerequisites**: 探索结论（research.md）已确认 GoCell 现状（ContractRegistry 只读 / eventrouter Run-once / governance.Validator 纯 Go）。
+**Organization**: 按 user story 分组；每个 story = 一个 GitHub backlog issue = 一个（或一簇）PR，净增删 ≤2000 行（US14/US18 特殊可超）。issue 号在登记后回填。
+**Tests**: 本仓约束（TDD、kernel ≥90% / 其余 ≥80%、archtest synthetic red case、contract-level 测试）对每个 story 默认生效。
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: 与同 phase 其它任务无文件交叉、可并行
+- 路径为当前锚点，实施期以 US1 ADR 裁决为准
+
+## Phase 1: 方向裁决 + 数据面地基（Wave 1，无 blocker，立即可做）
+
+### US1 — 方向 ADR：dual-track + 进程外控制面/数据面转发（P1）→ #2230
+
+- [ ] T001 [US1] 写 ADR `docs/architecture/{ts}-303-adr-runtime-contract-registry.md`：dual-track reconciliation（in-tree Hard trust root 不动 / out-of-tree runtime governance gate = Medium，**不伪装 Hard**）+ 进程外控制面/数据面转发设计 + 完整威胁矩阵（每行配补偿 story 指针）
+- [ ] T002 [P] [US1] ADR 显式声明扇出 archtest（DEAD-CONTRACT-01 / IMPL-DECL-COVER-01 / EMIT-DECL-COVER-01 / DEAD-CODE-01）对 runtime 注册契约 vacuous = 设计预期 + out-of-tree 等价 runtime 扇出校验方向
+- [ ] T003 [P] [US1] 与 #1081/#1090（Tier-1）/#1046（codegen schema）/#1423（remote transport）边界划清 + 与 #1081 方向 ADR 对齐；AI-robust 章程：冲突段落同改
+
+### US9 — EventRouter handlers 容器 slice→map（地基重构，P1）→ #2231
+
+- [ ] T010 [US9] `framework/runtime/eventrouter/router.go`：`handlers []handlerConfig` → `map[handlerKey]*runningHandler`（key=topic+consumerGroup）+ `runningHandler` 结构（cfg/cancel/started/done）；`Run`/`HandlerCount`/`AddContractHandler` 改 map；重名返 error（不 panic）
+- [ ] T011 [P] [US9] 现有 eventrouter 测试零回归（行为等价）+ 重名 key error 用例
+
+**Checkpoint**: ADR 合入后下游形态锁定；US9 为 US10 的数据结构前提
+
+## Phase 2: 内核地基（Wave 2，blocked-by US1）
+
+### US2 — Runtime ContractRegistry 只读→状态机（P1）→ #2233
+
+- [ ] T020 [US2] `framework/kernel/registry/`：sealed `RegistrationState`（submitted…retired）+ 状态迁移 + 不变式（approved 才能 active；reject 不可激活）；包外不可构造状态
+- [ ] T021 [US2] append-only 迁移事件底模 + 投影 in-mem 索引；保留现有 deepCopy serving 读路径（Get/ByKind/ByOwner/Provider/Consumers 零回归）
+- [ ] T022 [P] [US2] kernel ≥90% table-driven：每条合法/非法迁移 + sealed 构造拒绝 + 投影一致性
+
+## Phase 3: 注册门 + cell 骨架（Wave 3，blocked-by US2）
+
+### US3 — 注册时 governance gate（复用 Validator + dry-run/submit 双入口，P1）→ #2234
+
+- [ ] T030 [US3] 包 `governance.Validator` 为 `{allowed,result,warnings}`（AdmissionResponse 式）；`:check`(dry-run 不落库) + `submit`(落库前同步校验) 双入口共用校验逻辑
+- [ ] T031 [P] [US3] FailurePolicy=Fail fail-closed（校验器/租户/store 不可用 → deny）+ 测试
+
+### US4 — registrycore cell 骨架 + submit/list 契约声明（P1）→ #2235
+
+- [ ] T040 [US4] `corecells/registrycore/` cell.yaml + slices + `http.registry.contract.submit.v1`/`list.v1` 契约声明（contracts/）+ contractUsages
+- [ ] T041 [US4] cellgen 派生 `cell_gen.go` + golden；`gocell validate` 通过
+- [ ] T042 [P] [US4] 契约级测试：正常响应 schema / 参数错误码 / 鉴权边界 / path 参数校验
+
+## Phase 4: 持久化 + 提交闭环（Wave 4，blocked-by US3+US4）
+
+### US5 — contract_registrations 表 + PG store（P1）→ #2236
+
+- [ ] T050 [US5] migration `adapters/postgres/migrations/{序号}_create_contract_registrations.sql`（id/submitter/kind/payload-schema/state/approver/timestamps；RLS/owner 形态）
+- [ ] T051 [US5] repository：`internal/ports` 接口 + `internal/mem` + PG 实现；状态迁移 L1 事务 + append-only 历史
+- [ ] T052 [P] [US5] 事务完整性测试（L1 原子性 / 回滚不留半态）
+
+### US6 — submit/list handlers + service 接线 + 契约测试（P1）→ #2237
+
+- [ ] T060 [US6] submit/list handler（typed response envelope）+ application service（`gocell:"required"` 依赖）接 US2 状态机 / US3 gate / US5 store
+- [ ] T061 [P] [US6] httptest：submit（合法→pending / 非法→4xx shared error schema）+ list（按 state 过滤）端到端闭环
+
+## Phase 5: 审批 + 审计/事件（Wave 5，blocked-by US6）
+
+### US7 — Admin 审批 approve/reject + RBAC（P2）→ #2238
+
+- [ ] T070 [US7] `approve.v1`/`reject.v1` 契约 + handler；路由门禁 `auth.RequirePermission(authz.Permission)` 接 accesscore admin（PDP，不硬编 role）
+- [ ] T071 [P] [US7] 状态机不变式（conformant→pending-approval→approved；reject 不可激活）+ 非 admin fail-closed 测试
+
+### US8 — 审批审计落账 + 激活/退役事件（P2）→ #2239
+
+- [ ] T080 [US8] submit/approve/reject/retire → auditcore hash chain（replayable PII hash/redaction）
+- [ ] T081 [US8] `event.registry.contract-activated.v1`/`contract-retired.v1`（L2 OutboxFact，envelope 经 outbox.NewEntry）
+- [ ] T082 [P] [US8] L2 outbox 原子性 + consumer 幂等测试
+
+## Phase 6: 数据面动态加载（Wave 5-6，event 维度 blocked-by US9，HTTP 独立）
+
+### US10 — 运行时增删订阅：per-handler ctx + Add/Remove（P1）→ #2240
+
+- [ ] T100 [US10] `runRootCtx` 字段提升 + `AddRunningHandler`/`RemoveHandler`：per-handler 子 ctx（挂 runRootCtx）、复刻 Setup→Subscribe→await Ready、fail-closed 半启动清理（hcancel+不入map+不Inc）
+- [ ] T101 [US10] 与 `runGuard sync.Once` 兼容（Run 仍一次；增删仅 started 后合法，否则 ErrNotRunning）；`Close` 三阶段 drain 复用
+- [ ] T102 [P] [US10] 测试：Run 后 add 新 topic 消费 / remove 单 handler 退出不影响他者 / Add 失败无半启动 / Close 停动态 handler
+
+### US11 — Snapshot 版本化 diff Reconcile + 激活事件 debounce + archtest（P2）→ #2241
+
+- [ ] T110 [US11] `RegistrySnapshot` 单调 Version + `Reconcile(snapshot)` diff（toAdd/toRemove）；版本回退 fail-closed 保 last-good
+- [ ] T111 [US11] `contract-activated` 消费侧 debounce（DebounceAfter+debounceMax，merge 窗口内多激活为一次 reconcile）
+- [ ] T112 [US11] archtest 守卫（动态 handler 子 ctx 挂 runRootCtx / Add fail 必 hcancel）+ synthetic red/green（同 PR 自证，constraint-self-close）
+
+### US12 — HTTP Router 运行时动态 route（P2）→ #2242
+
+- [ ] T120 [US12] HTTP 数据面：一次性 drain → 运行时 add/remove route（net/http ServeMux 包装/可替换 mux）；消费 contract-activated 登记外部 cell route
+- [ ] T121 [P] [US12] 与 FinalizeAuth/listener auth plan 兼容（动态 route 仍过最终 matcher，不绕 auth）+ 并发 add/remove 测试
+
+## Phase 7: 外部接入 + 转发（Wave 6+，blocked-by US6/#1423）
+
+### US13 — 外部 cell 注册客户端 / SDK（P2）→ #2243
+
+- [ ] T130 [US13] 契约声明 helper + payload schema 上传 + submit/poll-status client（对标 SR RegisterSchemaRequest）
+- [ ] T131 [P] [US13] 错误机读可区分（typed reason，非英文文本）+ 测试
+
+### US14 — 端点注册 + 数据面转发（P2，**依赖 #1423/#1966**，特殊可超 2000 行）→ #2244
+
+- [ ] T140 [US14] cellID→endpoint 地址登记 + 复用 #1423/#1966 `CellTransport` remote + Resolver 转发 topic 事件/HTTP 请求（service token 出站签名 + principal/tenant 传播）
+- [ ] T141 [P] [US14] 双进程 fixture：approve 后转发到外部端点 + principal/tenant 重建 + 端点不可达映射专属 errcode（复用 #1423 FR-007 投影约束）
+
+## Phase 8: 安全与隔离（Wave 6+，blocked-by US6）
+
+### US15 — 命名空间防冲突 + consistency ceiling（P2）→ #2245
+
+- [ ] T150 [US15] 注册唯一性 `(kind,domain-path,version,owner)` 四元组（对标 CRD NamesAccepted）+ 外部契约命名空间前缀；与 in-tree 契约撞车拒绝
+- [ ] T151 [P] [US15] consistency 越权：runtime cell 声明级别经 actors.yaml `maxConsistencyLevel` runtime 形态裁决，超限 fail-closed
+
+### US16 — 恶意注册防护 + 限流 + conformance egress allowlist（P2）→ #2246
+
+- [ ] T160 [US16] 注册端点鉴权 + 限流（防重复/恶意注册，429/稳定 errcode）
+- [ ] T161 [US16] conformance 探测 SSRF 防护：egress allowlist + 鉴权 + 限流，禁裸打任意端点
+- [ ] T162 [P] [US16] 测试：超频限流 / 非 allowlist 目标拒绝 / 未授权 submit 拒绝
+
+## Phase 9: 注册 conformance 自动测试（flag-cond，分档）
+
+### US17 — conformance 首档：读/幂等面 + setup/teardown（P2，flag-cond，blocked-by US7）→ #2247
+
+- [ ] T170 [US17] `probing` 态机器门：合成 consumer 按契约 request schema 打活体端点（读/幂等面），断言 successStatus+响应 schema+声明 4xx/5xx 可达+error envelope 合规
+- [ ] T171 [US17] setup/teardown sealed 配对（缺 teardown 校验/编译错，AI-robust Hard）+ 凭据注入不入契约
+- [ ] T172 [P] [US17] conformance result append-only record（admin 据此审批）+ 测试
+
+### US18 — conformance 彻底档：合成租户写面 + egress-suppression（P3，flag-cond，**hard-depend #1337**）→ #2248
+
+- [ ] T180 [US18] 合成租户跑真实写路径 conformance（复用 tenant 隔离边界）+ 测完整租户清除 + event-consumer 写面深测
+- [ ] T181 [US18] 合成租户 egress-suppression 标记（禁真实外发）；非多租户 cell 退回首档 (c)+admin 签字（混合形态）
+
+## Dependencies & Execution Order
+
+```
+US1(ADR) ─┬─ US2(SM) ─┬─ US3(gate) ─┐
+          │           └─ US4(cell) ─┴─ US5(store) ─ US6(submit闭环) ─┬─ US7(approve) ─ US8(audit/event) ─┐
+US9(map) ──── US10(add/remove) ───────────────────────────────────── US11(reconcile) ←──────────────────┘
+          └─ US12(http route)                                         │
+                                              US6 ─┬─ US13(SDK) ─ US14(转发) ←── #1423/#1966
+                                                   ├─ US15(namespace/ceiling) ─ US16(防护/egress)
+                                                   └─ US7 ─ US17(conformance 首档, flag-cond)
+                                              #1337 + US14 + US17 ─ US18(conformance 彻底档, flag-cond)
+```
+
+| 实施波次 | Story | 性质 |
+|------|-------|------|
+| W1 | US1（ADR）、US9（map 重构） | 裁决 + no-regret 地基，立即并行 |
+| W2 | US2（registry 状态机） | 内核地基，blocked-by US1 |
+| W3 | US3（gate）、US4（cell 骨架） | blocked-by US2，可并行 |
+| W4 | US5（store）、US10（add/remove）、US12（http route） | 持久化 + 数据面增删（US10/US12 blocked-by US9，可与 US5 并行） |
+| >W4（Project 超窗，暂不入 Wave 字段） | US6（提交闭环）、US7（approve）、US8（audit/event）、US11（reconcile）、US13（SDK）、US15（namespace）、US16（防护）、US17（conformance 首档 flag-cond） | 依赖链 >4，滚动前移；前置完成后自动入 Wave 字段 |
+| gated | US14（转发，gated #1423）、US18（conformance 彻底档，gated #1337） | 外部 epic 依赖 |
+
+> Project Wave 字段固定 Wave 1-4 四档（issues 技能 Part A 滚动写入；超窗 OPEN 不入字段、前置完成后自动前移）。本表是派生视图。
+
+## Notes
+
+- 每 story 一个 issue、一个（或一簇）PR，各自走 `/ship`（worktree + TDD + 内置 review）。
+- US14 数据面转发不重复造跨进程同步栈：复用 #1423/#1966 remote transport（blocked-by 其 remote 就位）。
+- US18 conformance 彻底档 hard-depend 多租户/ABAC epic #1337 GA；首档 US17 不依赖多租户。
+- runtime governance gate AI-robust = Medium（runtime guard + 人审），P0 ADR 威胁矩阵显式记录，不伪装 Hard。
+- 原始诉求 #659（WithExtraTopics）被本 epic 取代，分解落地后 close as superseded by #303。


### PR DESCRIPTION
## Summary

P0 方向 ADR（Epic #303, Wave-1 US1）+ speckit 分解产物：裁定运行时契约注册中心以 **dual-track 治理**（in-tree 编译期 Hard trust root 不动 / out-of-tree runtime governance gate = Medium，诚实不伪装 Hard）+ **进程外控制面/数据面转发** 形态，并锁定完整威胁矩阵（每行配补偿 sub-issue）。

## Why / 背景

#303 从「给消费 cell 加 `WithExtraTopics`」（前提已过时，订阅已 codegen 单源派生）升级为 Epic：框架上线后持续运行，外部进程外 cell 经 API 注册 + admin 审批上线，**不重编译/部署框架**。其与宪法「AI-robust = 违反不可表达」存在真实张力（runtime 注册对编译期静态治理结构性不可达），本 ADR 诚实 reconcile：dual-track + 进程外边界 + Medium 评级显式记录。本 PR 同时把 speckit 分解（18 user story / 两 agent 开源对标 / T-task DAG）落盘，作为下游 #2231-#2248 的规格底座。

## Refs

- Closes #2230（Epic #303, Wave-1 US1）
- 设计文档 `docs/plans/202605310313-047-runtime-contract-registry-epic.md`（本 ADR = 其 P0 产出）
- 相邻 ADR `docs/architecture/202606131142-1423-adr-cell-deployment-topology.md`（remote transport，#2244 复用）
- 边界：#1081/#1090（Tier-1）、#1046（codegen schema）、#1337（conformance 彻底档硬依赖）、#659（superseded）
- ref: confluentinc/schema-registry、kubernetes/api admission+apiextensions、pact-foundation/pact-js、envoyproxy/{envoy,go-control-plane}、kubernetes-sigs/controller-runtime、ThreeDotsLabs/watermill、istio/istio

## Risk / 兼容性

无。docs-only（1 ADR + 3 spec 文件，816 行），无 Go 改动、无 wire 契约影响、无 migration。ADR 命名遵循 `yyyyMMddHHmm-编号-功能.md`；与 #1423 ADR 互引、方向一致，不推翻任何已 Accepted ADR。

## Test plan

- [x] docs-only，无 Go 改动 → `go build`/`go test`/`golangci-lint` 不涉（无 .go 文件变更）
- [x] ADR 命名格式合规（`202606162119-303-adr-runtime-contract-registry.md`）
- [x] 威胁矩阵 T1-T10 每行有补偿 sub-issue 指针（#2233-#2248）
