### PR TITLE
feat(certlifecycle): runtime/certlifecycle 证书生命周期 reconciler [PR-7/#1895]

### DIFF
--- a/framework/runtime/certlifecycle/doc.go
+++ b/framework/runtime/certlifecycle/doc.go
@@ -1,0 +1,83 @@
+// Package certlifecycle is the reusable server-side certificate-lifecycle
+// reconcile.Reconciler. It periodically sweeps a cell's renewable device
+// certificates, and for each one due for renewal (k8s 70–90% jitter) it
+// Authorizes (fail-closed), re-signs the device's STORED CSR via the
+// certsigning.Signer seam, and persists the new generation through the reconcile
+// FencedWriter — the consumer's fenced write also lands the cert-issued L2 fact
+// atomically with the row.
+//
+// It REUSES kernel/reconcile.Loop (no new control loop) and generalizes the
+// iotdevice devicecertrenewal seed's loop shape, changing the action from
+// "enqueue a rotate-cert command (the device self-renews)" to server-side
+// signing. It is the L4 device-latent convergence archetype: a renewed cert is
+// persisted server-side; the device refetches it via the status endpoint (the
+// cert-issued event is metadata-only — no key material on the bus).
+//
+// # Layering
+//
+// runtime layer: depends on kernel (reconcile, clock), pkg (errcode, tenant,
+// validation), and the runtime/certsigning INTERFACES (Signer, Authorizer). It
+// does NOT depend on corecells or adapters, and in particular never imports a
+// concrete CA (adapters/softca) — it works only through the certsigning seam.
+// It deliberately does NOT import kernel/outbox or the generated contract types:
+// the cert-issued L2 fact is written transactionally inside the consumer's
+// ApplyFenced (see "cert-issued L2 emit" below), not by this package.
+//
+// # System identity / multi-tenant
+//
+// The reconcile Loop installs a tenantless system producer identity at its
+// chokepoint (#1821): actor/subject="system", tenant cleared. So this Reconciler
+// MUST source the tenant from each scanned Candidate row (Candidate.TenantID),
+// never from ctx. The package declares no tenancy stance — that is the
+// construction site's job: reconcile.New(r, reconcile.SingleTenant()) for a
+// single-tenant deployment, or reconcile.TenantScoped() for a multi-tenant one
+// (RECONCILE-TENANCY-DECLARED-01). Because the tenant rides on the row, a
+// multi-tenant sweep keeps tenants distinct without an ambient ctx tenant.
+//
+// # cert-issued L2 emit is atomic with the fenced persist (not a separate Emit)
+//
+// The Reconciler does NOT call outbox.Emit. L2 (local tx + outbox) requires the
+// certificate-row write and the cert-issued outbox entry to commit in ONE
+// transaction, and the only transaction is the consumer's. So the Reconciler's
+// single fenced write (IssuedMutation) carries every cert-issued field, and the
+// consumer's DeviceCertRepository.ApplyFenced persists the row AND writes the
+// cert-issued L2 outbox entry atomically. This is the FencedRepository-sanctioned
+// "device writes / command emission from inside Reconcile" via the single fenced
+// surface — and it is also forced by module topology: the framework module
+// cannot import the generated contract types (separate module). The Reconciler is
+// the emit DRIVER (it produces the data and triggers the fenced write); the
+// consumer cell is the L2 atomic EXECUTOR.
+//
+// # Enforced invariants
+//
+// CERTLIFECYCLE-SIGN-VIA-FUNNEL-01. This Reconciler obtains issued certificates
+// EXCLUSIVELY via certsigning.Signer.Sign — it never mints an IssuedCert nor
+// reaches into a concrete CA. The SECURITY PROPERTY is Hard by inheritance, no
+// new Hard mechanism required:
+//   - certsigning.IssuedCert has only unexported fields, so this package cannot
+//     forge one by composite literal (compile-time Hard,
+//     CERT-VALUE-SEALED-CONSTRUCTION-01);
+//   - the sole minter certsigning.NewIssuedCert is restricted by the existing
+//     CERT-SIGN-FUNNEL-01 caller-allowlist to {adapters/softca}, which excludes
+//     certlifecycle;
+//   - certlifecycle cannot import adapters/softca at all: softca is a separate Go
+//     module that requires the framework module, so the reverse import is a
+//     circular module dependency the build refuses (module-topology Hard).
+//
+// Together these make Signer.Sign the only compilable way for this package to
+// obtain an IssuedCert. The archtest of the same name is the Medium reverse
+// self-check / anti-vacuity (it asserts the package actually calls Signer.Sign,
+// does not call NewIssuedCert, and is absent from the mint allowlist) — see
+// tools/archtest/certlifecycle_invariants_test.go.
+//
+// RECONCILE-FENCED-WRITE-FUNNEL-01 (Hard, reused). The renewed certificate is
+// persisted EXCLUSIVELY through reconcile.FencedWriterFrom(ctx).Write; this
+// package never calls DeviceCertRepository.ApplyFenced directly. The fenced
+// writer's monotonic lease-epoch CAS is the cross-replica at-most-once guarantee.
+//
+// Why not runtime/command: the issue's "reuse runtime/command" is satisfied at
+// the reconcile-loop archetype level; the "queue active-uniqueness, at most one
+// valid signing" requirement is realized structurally by the fencing CAS, not a
+// command queue. softca signs synchronously (<10ms), so an async sign command
+// would only re-introduce the control loop this package is told not to build.
+package certlifecycle

--- a/framework/runtime/certlifecycle/doc.go
+++ b/framework/runtime/certlifecycle/doc.go
@@ -52,17 +52,21 @@
 //
 // A consuming cell wires this Reconciler by:
 //  1. implementing DeviceCertRepository — ListRenewalCandidates (scan State=active
-//     certs with NotAfter <= cutoff) and ApplyFenced (the monotonic-epoch CAS that
-//     persists the cert row AND writes the cert-issued L2 outbox entry in ONE
-//     transaction — see ApplyFenced's contract);
-//  2. NewReconciler(clk, repo, signer, authorizer, policy, logger);
+//     certs with NotAfter <= cutoff, capped at the limit = Policy.BatchSize) and
+//     ApplyFenced (the monotonic-epoch CAS that persists the cert row AND writes
+//     the cert-issued L2 outbox entry in ONE transaction — see ApplyFenced's
+//     contract);
+//  2. NewReconciler(clk, repo, signer, authorizer, policy, logger) — Policy
+//     requires a positive BatchSize (the per-sweep workload bound);
 //  3. binding it on a reconcile.Loop in the composition root:
 //     reconcile.New(rec, SingleTenant()|TenantScoped()).WithTrigger(
 //     reconcile.TickerTrigger(clk, interval)).WithLeader(le).WithFencedRepo(repo).
-//     WithoutDefaultRequeue().Build() — a TickerTrigger is the intended driver
-//     (this Reconciler always does a full bounded sweep; entity-specific Requests
-//     are ignored), and WithLeader+WithFencedRepo are REQUIRED (Reconcile fails
-//     closed without a fenced writer).
+//     WithoutDefaultRequeue().Build() — a TickerTrigger is the intended periodic
+//     driver (this Reconciler does a bounded full sweep; entity-specific Requests
+//     are ignored). WithoutDefaultRequeue is fine: when a sweep returns a FULL
+//     batch the Reconciler self-requeues (an explicit RequeueAfter, still honored)
+//     to drain the backlog faster than the tick. WithLeader+WithFencedRepo are
+//     REQUIRED (Reconcile fails closed without a fenced writer).
 //
 // The Signer / Authorizer are bound by the certsigning composition root (a later
 // epic PR). Specific-certificate lookup (by CertScope, never a bare serial — the

--- a/framework/runtime/certlifecycle/doc.go
+++ b/framework/runtime/certlifecycle/doc.go
@@ -48,6 +48,27 @@
 // the emit DRIVER (it produces the data and triggers the fenced write); the
 // consumer cell is the L2 atomic EXECUTOR.
 //
+// # Consumer wiring
+//
+// A consuming cell wires this Reconciler by:
+//  1. implementing DeviceCertRepository — ListRenewalCandidates (scan State=active
+//     certs with NotAfter <= cutoff) and ApplyFenced (the monotonic-epoch CAS that
+//     persists the cert row AND writes the cert-issued L2 outbox entry in ONE
+//     transaction — see ApplyFenced's contract);
+//  2. NewReconciler(clk, repo, signer, authorizer, policy, logger);
+//  3. binding it on a reconcile.Loop in the composition root:
+//     reconcile.New(rec, SingleTenant()|TenantScoped()).WithTrigger(
+//     reconcile.TickerTrigger(clk, interval)).WithLeader(le).WithFencedRepo(repo).
+//     WithoutDefaultRequeue().Build() — a TickerTrigger is the intended driver
+//     (this Reconciler always does a full bounded sweep; entity-specific Requests
+//     are ignored), and WithLeader+WithFencedRepo are REQUIRED (Reconcile fails
+//     closed without a fenced writer).
+//
+// The Signer / Authorizer are bound by the certsigning composition root (a later
+// epic PR). Specific-certificate lookup (by CertScope, never a bare serial — the
+// #1899 status-contract isolation invariant) is NOT part of this seam: it belongs
+// to the device status / EST endpoints (a later epic PR), not this renewal sweep.
+//
 // # Enforced invariants
 //
 // CERTLIFECYCLE-SIGN-VIA-FUNNEL-01. This Reconciler obtains issued certificates
@@ -55,8 +76,9 @@
 // reaches into a concrete CA. The SECURITY PROPERTY is Hard by inheritance, no
 // new Hard mechanism required:
 //   - certsigning.IssuedCert has only unexported fields, so this package cannot
-//     forge one by composite literal (compile-time Hard,
-//     CERT-VALUE-SEALED-CONSTRUCTION-01);
+//     forge a POPULATED IssuedCert by composite literal (the empty literal
+//     IssuedCert{} compiles but is the invalid zero value its consumers reject)
+//     (compile-time Hard, CERT-VALUE-SEALED-CONSTRUCTION-01);
 //   - the sole minter certsigning.NewIssuedCert is restricted by the existing
 //     CERT-SIGN-FUNNEL-01 caller-allowlist to {adapters/softca}, which excludes
 //     certlifecycle;
@@ -70,10 +92,14 @@
 // does not call NewIssuedCert, and is absent from the mint allowlist) — see
 // tools/archtest/certlifecycle_invariants_test.go.
 //
-// RECONCILE-FENCED-WRITE-FUNNEL-01 (Hard, reused). The renewed certificate is
+// RECONCILE-FENCED-WRITE-FUNNEL-01 (funnel, reused). The renewed certificate is
 // persisted EXCLUSIVELY through reconcile.FencedWriterFrom(ctx).Write; this
-// package never calls DeviceCertRepository.ApplyFenced directly. The fenced
-// writer's monotonic lease-epoch CAS is the cross-replica at-most-once guarantee.
+// package never calls DeviceCertRepository.ApplyFenced directly. The funnel is
+// upstream-Hard (FencedWriter's epoch field is unexported, so a writer with a
+// chosen epoch is uncompilable) and downstream-Medium (the ban on calling
+// ApplyFenced directly is the kernel archtest's caller-allowlist scan, which
+// covers this package). The fenced writer's monotonic lease-epoch CAS is the
+// cross-replica at-most-once guarantee.
 //
 // Why not runtime/command: the issue's "reuse runtime/command" is satisfied at
 // the reconcile-loop archetype level; the "queue active-uniqueness, at most one

--- a/framework/runtime/certlifecycle/jitter.go
+++ b/framework/runtime/certlifecycle/jitter.go
@@ -1,0 +1,58 @@
+package certlifecycle
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"time"
+)
+
+// Renewal-jitter model (k8s kubelet / cert-manager 70–90% lifetime): a
+// certificate becomes due for renewal at a DETERMINISTIC instant within 70–90%
+// of its validity window. The jitter fraction is derived from a hash of the
+// certificate identity (deviceID + serial), NOT from the clock or a random
+// source, so:
+//
+//   - the decision is identical on every reconcile tick and on every replica —
+//     a leader handoff mid-window does not shift the renewal instant (no
+//     flapping, no thundering herd from a fleet renewing at exactly the same %);
+//   - it is purely a function of its inputs, so it is fully table-testable.
+const (
+	// renewalLowerFraction / renewalUpperFraction bound the jittered renewal
+	// instant as a fraction of the certificate's (notAfter-notBefore) lifetime.
+	renewalLowerFraction = 0.70
+	renewalUpperFraction = 0.90
+)
+
+// renewalFraction returns the deterministic jitter fraction in
+// [renewalLowerFraction, renewalUpperFraction) for the given certificate
+// identity. The NUL separator between deviceID and serial makes the input
+// unambiguous, so ("ab","c") and ("a","bc") hash distinctly.
+func renewalFraction(deviceID, serial string) float64 {
+	h := sha256.Sum256([]byte(deviceID + "\x00" + serial))
+	u := binary.BigEndian.Uint64(h[:8])
+	// u / 2^64 is uniform in [0,1); scaling lands in [lower, upper).
+	frac := float64(u) / (float64(math.MaxUint64) + 1)
+	return renewalLowerFraction + frac*(renewalUpperFraction-renewalLowerFraction)
+}
+
+// renewalInstant returns the absolute time the certificate becomes due for
+// renewal: notBefore + lifetime*renewalFraction. A non-positive lifetime
+// (degenerate / malformed validity window) returns notBefore — immediately due —
+// rather than producing a time before notBefore.
+func renewalInstant(notBefore, notAfter time.Time, deviceID, serial string) time.Time {
+	lifetime := notAfter.Sub(notBefore)
+	if lifetime <= 0 {
+		return notBefore
+	}
+	offset := time.Duration(float64(lifetime) * renewalFraction(deviceID, serial))
+	return notBefore.Add(offset)
+}
+
+// dueForRenewal reports whether now has reached the certificate's jittered
+// renewal instant. A certificate already past notAfter is necessarily past its
+// renewal instant (notAfter > renewalInstant), so this also returns true for an
+// expired cert — the Reconciler re-signs it to recover (see reconciler.go).
+func dueForRenewal(now, notBefore, notAfter time.Time, deviceID, serial string) bool {
+	return !now.Before(renewalInstant(notBefore, notAfter, deviceID, serial))
+}

--- a/framework/runtime/certlifecycle/jitter_test.go
+++ b/framework/runtime/certlifecycle/jitter_test.go
@@ -1,0 +1,111 @@
+package certlifecycle
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRenewalFractionDeterministicAndBounded(t *testing.T) {
+	t.Parallel()
+	ids := []struct{ device, serial string }{
+		{"dev-1", "aa"},
+		{"dev-1", "bb"},
+		{"dev-2", "aa"},
+		{"00000000-0000-0000-0000-000000000001", "deadbeef"},
+		{"", ""},
+		{"x", ""},
+		{"", "x"},
+	}
+	for _, id := range ids {
+		f1 := renewalFraction(id.device, id.serial)
+		f2 := renewalFraction(id.device, id.serial)
+		if f1 != f2 {
+			t.Errorf("renewalFraction(%q,%q) not deterministic: %v != %v", id.device, id.serial, f1, f2)
+		}
+		if f1 < renewalLowerFraction || f1 >= renewalUpperFraction {
+			t.Errorf("renewalFraction(%q,%q) = %v, want [%v,%v)", id.device, id.serial,
+				f1, renewalLowerFraction, renewalUpperFraction)
+		}
+	}
+}
+
+func TestRenewalFractionSeparatorUnambiguous(t *testing.T) {
+	t.Parallel()
+	// The NUL separator must make ("ab","c") distinct from ("a","bc").
+	if renewalFraction("ab", "c") == renewalFraction("a", "bc") {
+		t.Error("renewalFraction collides across ambiguous concat boundary — separator missing")
+	}
+}
+
+func TestRenewalFractionSpread(t *testing.T) {
+	t.Parallel()
+	// Sanity: distinct identities spread across the band rather than clustering at
+	// a single value. Bucket 200 ids into 4 quartiles of [0.70,0.90); expect every
+	// quartile populated.
+	buckets := map[int]int{}
+	for i := 0; i < 200; i++ {
+		f := renewalFraction("device", string(rune('A'+i%26))+time.Duration(i).String())
+		q := int((f - renewalLowerFraction) / ((renewalUpperFraction - renewalLowerFraction) / 4))
+		if q == 4 { // f just under upper bound
+			q = 3
+		}
+		buckets[q]++
+	}
+	for q := 0; q < 4; q++ {
+		if buckets[q] == 0 {
+			t.Errorf("renewalFraction quartile %d empty — distribution clustered: %v", q, buckets)
+		}
+	}
+}
+
+func TestRenewalInstantAndDue(t *testing.T) {
+	t.Parallel()
+	notBefore := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	notAfter := notBefore.Add(100 * time.Hour)
+	const dev, serial = "dev", "ser"
+
+	lifetime := notAfter.Sub(notBefore) // runtime value: avoids constant float→Duration conversion
+	inst := renewalInstant(notBefore, notAfter, dev, serial)
+	frac := renewalFraction(dev, serial)
+	wantOffset := time.Duration(float64(lifetime) * frac)
+	if got := inst.Sub(notBefore); got != wantOffset {
+		t.Errorf("renewalInstant offset = %v, want %v", got, wantOffset)
+	}
+	// Instant must fall strictly inside the 70–90% window.
+	lo := notBefore.Add(time.Duration(float64(lifetime) * renewalLowerFraction))
+	hi := notBefore.Add(time.Duration(float64(lifetime) * renewalUpperFraction))
+	if inst.Before(lo) || !inst.Before(hi) {
+		t.Errorf("renewalInstant %v outside [%v,%v)", inst, lo, hi)
+	}
+
+	cases := []struct {
+		name string
+		now  time.Time
+		want bool
+	}{
+		{"before instant", inst.Add(-time.Nanosecond), false},
+		{"exactly at instant", inst, true},
+		{"after instant", inst.Add(time.Hour), true},
+		{"past notAfter (expired)", notAfter.Add(time.Hour), true},
+		{"at notBefore", notBefore, false},
+	}
+	for _, tc := range cases {
+		if got := dueForRenewal(tc.now, notBefore, notAfter, dev, serial); got != tc.want {
+			t.Errorf("%s: dueForRenewal = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestRenewalInstantDegenerateLifetime(t *testing.T) {
+	t.Parallel()
+	nb := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// notAfter <= notBefore → immediately due, instant == notBefore.
+	for _, na := range []time.Time{nb, nb.Add(-time.Hour)} {
+		if got := renewalInstant(nb, na, "d", "s"); !got.Equal(nb) {
+			t.Errorf("renewalInstant(degenerate na=%v) = %v, want notBefore %v", na, got, nb)
+		}
+		if !dueForRenewal(nb, nb, na, "d", "s") {
+			t.Errorf("dueForRenewal(degenerate na=%v) = false, want true", na)
+		}
+	}
+}

--- a/framework/runtime/certlifecycle/jitter_test.go
+++ b/framework/runtime/certlifecycle/jitter_test.go
@@ -5,6 +5,10 @@ import (
 	"time"
 )
 
+// jitterTestLifetime is the cert validity span used by the renewal-instant tests
+// (TEST-TIME-LITERAL-01: no inline test-time literals).
+const jitterTestLifetime = 100 * time.Hour
+
 func TestRenewalFractionDeterministicAndBounded(t *testing.T) {
 	t.Parallel()
 	ids := []struct{ device, serial string }{
@@ -61,7 +65,7 @@ func TestRenewalFractionSpread(t *testing.T) {
 func TestRenewalInstantAndDue(t *testing.T) {
 	t.Parallel()
 	notBefore := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	notAfter := notBefore.Add(100 * time.Hour)
+	notAfter := notBefore.Add(jitterTestLifetime)
 	const dev, serial = "dev", "ser"
 
 	lifetime := notAfter.Sub(notBefore) // runtime value: avoids constant float→Duration conversion

--- a/framework/runtime/certlifecycle/reconciler.go
+++ b/framework/runtime/certlifecycle/reconciler.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/clock"
 	"github.com/ghbvf/gocell/framework/kernel/reconcile"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
-	"github.com/ghbvf/gocell/framework/pkg/tenant"
 	"github.com/ghbvf/gocell/framework/pkg/validation"
 	"github.com/ghbvf/gocell/framework/runtime/certsigning"
 )
@@ -133,28 +132,52 @@ func NewReconciler(
 func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
 	// Fail-closed BEFORE any work: the renewal persist MUST be fenced. A Loop wired
 	// without WithFencedRepo+WithLeader has no lease-scoped write surface, so
-	// persisting would be unfenced — refuse rather than scan and then write unsafely.
+	// persisting would be unfenced. This is a wiring misconfiguration that every
+	// tick would hit identically, so mark it PermanentError — the Loop dead-letters
+	// it rather than burning indefinite transient backoff (fail-fast on misconfig).
 	fw, ok := reconcile.FencedWriterFrom(ctx)
 	if !ok {
-		return reconcile.Result{}, errcode.New(errcode.KindInternal, errcode.ErrInternal,
-			"certlifecycle: no fenced writer in ctx — wire reconcile.WithFencedRepo + WithLeader")
+		return reconcile.Result{}, reconcile.PermanentError(errcode.New(errcode.KindInternal, errcode.ErrInternal,
+			"certlifecycle: no fenced writer in ctx — wire reconcile.WithFencedRepo + WithLeader"))
 	}
 	now := r.clk.Now()
 	cutoff := now.Add(r.policy.MaxLookahead)
 	candidates, err := r.repo.ListRenewalCandidates(ctx, cutoff)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("certlifecycle: scan near-expiry: %w", err)
+		// Transient (DB/scan I/O may recover): errcode.Wrap stamps the Kind so the
+		// Loop classifies it as retryable rather than guessing from a bare error.
+		return reconcile.Result{}, errcode.Wrap(errcode.KindUnavailable, errcode.ErrInternal,
+			"certlifecycle: scan near-expiry failed", err)
 	}
 	var firstErr error
+	c := sweepCounts{total: len(candidates)}
 	for _, cand := range candidates {
-		if err := r.reconcileOne(ctx, fw, cand, now); err != nil && firstErr == nil {
+		if err := r.reconcileOne(ctx, fw, cand, now, &c); err != nil && firstErr == nil {
 			// Bubble the first transient error so the Loop backs off and re-sweeps;
 			// the fenced CAS makes a re-sweep idempotent. Per-candidate deny / stale
 			// outcomes are handled inside reconcileOne and never returned.
 			firstErr = err
 		}
 	}
+	// Per-sweep summary: the reconcile Loop maps a nil return to result="success",
+	// so deny / not-due / skipped outcomes are invisible in the framework metric.
+	// This single Info line per sweep makes the renewed/denied/skipped/errored
+	// distribution observable (e.g. a long-running all-denied state) without a
+	// per-device (high-cardinality) metric.
+	r.logger.Info("certlifecycle: swept cert renewals",
+		slog.Int("candidates", c.total), slog.Int("renewed", c.renewed),
+		slog.Int("denied", c.denied), slog.Int("skipped", c.skipped),
+		slog.Int("errored", c.errored))
 	return reconcile.Result{}, firstErr
+}
+
+// sweepCounts aggregates per-candidate outcomes of one Reconcile sweep for the
+// summary log. denied counts authorization deny/error (the security-relevant
+// "policy said no"); skipped counts benign non-renewals (not-due, non-renewable
+// state, malformed row, constraint violation, lost fencing race); errored counts
+// transient failures that also bubble to the Loop.
+type sweepCounts struct {
+	total, renewed, denied, skipped, errored int
 }
 
 // reconcileOne renews one candidate. It returns a non-nil (transient) error only
@@ -162,13 +185,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 // signing failure, an unexpected fenced-write error). Deny, malformed-row, jitter
 // not-due, non-renewable state, and stale-epoch rejection are logged and skipped
 // (return nil) — they must not poison the rest of the sweep.
-func (r *Reconciler) reconcileOne(ctx context.Context, fw reconcile.FencedWriter, cand Candidate, now time.Time) error {
+func (r *Reconciler) reconcileOne(ctx context.Context, fw reconcile.FencedWriter, cand Candidate, now time.Time, c *sweepCounts) error {
 	if !cand.State.renewable() {
 		r.logger.Debug("certlifecycle: skip non-renewable cert",
 			slog.String("device_id", cand.DeviceID), slog.String("state", cand.State.String()))
+		c.skipped++
 		return nil
 	}
 	if !dueForRenewal(now, cand.NotBefore, cand.NotAfter, cand.DeviceID, cand.Serial) {
+		c.skipped++
 		return nil
 	}
 	if now.After(cand.NotAfter) {
@@ -178,35 +203,43 @@ func (r *Reconciler) reconcileOne(ctx context.Context, fw reconcile.FencedWriter
 			slog.String("device_id", cand.DeviceID), slog.Uint64("epoch", cand.Epoch),
 			slog.Duration("expired_for", now.Sub(cand.NotAfter)))
 	}
-	return r.renew(ctx, fw, cand)
+	return r.renew(ctx, fw, cand, c)
 }
 
 // renew runs the Authorize → Sign → fenced-persist pipeline for one candidate.
-func (r *Reconciler) renew(ctx context.Context, fw reconcile.FencedWriter, cand Candidate) error {
+func (r *Reconciler) renew(ctx context.Context, fw reconcile.FencedWriter, cand Candidate, c *sweepCounts) error {
 	scope, subject, err := buildScopeSubject(cand)
 	if err != nil {
 		// Malformed row data (e.g. non-canonical tenant) — retry won't fix it; skip
 		// this candidate without poisoning the sweep.
 		r.logger.Error("certlifecycle: skip candidate with invalid identity",
-			slog.String("device_id", cand.DeviceID), slog.Any("err", err))
+			slog.String("device_id", cand.DeviceID), slog.String("tenant", string(cand.TenantID)),
+			slog.Any("err", err))
+		c.skipped++
 		return nil
 	}
 	grant, ok := r.authorize(ctx, scope, subject, cand)
 	if !ok {
+		c.denied++
 		return nil // fail-closed deny: do NOT sign, existing cert untouched
 	}
 	authReq, ok := r.buildAuthorizedRequest(scope, subject, cand, grant)
 	if !ok {
+		c.skipped++
 		return nil // request build / constraint violation: do NOT sign
 	}
 	issued, err := r.signer.Sign(ctx, authReq)
 	if err != nil {
 		// Signing failure: do NOT persist or emit; the existing certificate is
-		// untouched. Bubble transient so the Loop backs off (the CA may be down).
+		// untouched. Log at Error in the certlifecycle namespace (device-level
+		// visibility) and bubble transient so the Loop backs off (the CA may be down).
+		r.logger.Error("certlifecycle: sign renewed certificate failed",
+			slog.String("device_id", cand.DeviceID), slog.Any("err", err))
+		c.errored++
 		return errcode.Wrap(errcode.KindUnavailable, errcode.ErrCertSignFailed,
 			"certlifecycle: sign renewed certificate failed", err)
 	}
-	return r.persist(ctx, fw, cand, issued)
+	return r.persist(ctx, fw, cand, issued, c)
 }
 
 // authorize evaluates the enrollment claim fail-closed. It returns ok=false (and
@@ -273,7 +306,9 @@ func (r *Reconciler) buildAuthorizedRequest(
 // epoch-bound FencedWriter. A stale-epoch rejection means another replica won the
 // fencing race: do NOT retry and do NOT emit (the winner's fenced write carries
 // the cert-issued fact). Any other write error is transient and bubbles.
-func (r *Reconciler) persist(ctx context.Context, fw reconcile.FencedWriter, cand Candidate, issued certsigning.IssuedCert) error {
+func (r *Reconciler) persist(
+	ctx context.Context, fw reconcile.FencedWriter, cand Candidate, issued certsigning.IssuedCert, c *sweepCounts,
+) error {
 	mut := &IssuedMutation{
 		DeviceID:    cand.DeviceID,
 		TenantID:    cand.TenantID,
@@ -290,10 +325,14 @@ func (r *Reconciler) persist(ctx context.Context, fw reconcile.FencedWriter, can
 		if errors.Is(err, reconcile.ErrFencedWriteStale) {
 			r.logger.Info("certlifecycle: lost fencing race — another replica renewed",
 				slog.String("device_id", cand.DeviceID), slog.Uint64("target_epoch", mut.TargetEpoch))
+			c.skipped++
 			return nil
 		}
-		return fmt.Errorf("certlifecycle: persist renewed certificate: %w", err)
+		c.errored++
+		return errcode.Wrap(errcode.KindUnavailable, errcode.ErrInternal,
+			"certlifecycle: persist renewed certificate failed", err)
 	}
+	c.renewed++
 	r.logger.Info("certlifecycle: renewed certificate",
 		slog.String("device_id", cand.DeviceID), slog.Uint64("epoch", mut.TargetEpoch),
 		slog.String("serial", mut.Serial), slog.Time("not_after", mut.NotAfter))
@@ -301,13 +340,10 @@ func (r *Reconciler) persist(ctx context.Context, fw reconcile.FencedWriter, can
 }
 
 // buildScopeSubject derives the typed CertScope and DeviceSubject from the
-// candidate row. The tenant comes from cand.TenantID (the row), never from ctx
-// (#1821 — the reconcile Loop runs under a tenantless system identity).
+// candidate row. The tenant comes from cand.TenantID (the typed row value, never
+// from ctx — #1821 the reconcile Loop runs under a tenantless system identity);
+// NewCertScope / NewDeviceSubject validate it (canonical UUID) at construction.
 func buildScopeSubject(cand Candidate) (certsigning.CertScope, certsigning.DeviceSubject, error) {
-	tenantID, err := tenant.ParseTenantID(cand.TenantID)
-	if err != nil {
-		return certsigning.CertScope{}, certsigning.DeviceSubject{}, fmt.Errorf("tenant: %w", err)
-	}
 	issuer, err := certsigning.NewIssuerID(cand.IssuerID)
 	if err != nil {
 		return certsigning.CertScope{}, certsigning.DeviceSubject{}, fmt.Errorf("issuer: %w", err)
@@ -316,11 +352,11 @@ func buildScopeSubject(cand Candidate) (certsigning.CertScope, certsigning.Devic
 	if err != nil {
 		return certsigning.CertScope{}, certsigning.DeviceSubject{}, fmt.Errorf("device: %w", err)
 	}
-	scope, err := certsigning.NewCertScope(tenantID, issuer, device)
+	scope, err := certsigning.NewCertScope(cand.TenantID, issuer, device)
 	if err != nil {
 		return certsigning.CertScope{}, certsigning.DeviceSubject{}, fmt.Errorf("scope: %w", err)
 	}
-	subject, err := certsigning.NewDeviceSubject(tenantID, device, cand.CommonName)
+	subject, err := certsigning.NewDeviceSubject(cand.TenantID, device, cand.CommonName)
 	if err != nil {
 		return certsigning.CertScope{}, certsigning.DeviceSubject{}, fmt.Errorf("subject: %w", err)
 	}

--- a/framework/runtime/certlifecycle/reconciler.go
+++ b/framework/runtime/certlifecycle/reconciler.go
@@ -15,8 +15,8 @@ import (
 	"github.com/ghbvf/gocell/framework/runtime/certsigning"
 )
 
-// Policy holds the cert-lifecycle Reconciler tuning. Both fields must be
-// positive; NewReconciler validates via Policy.validate().
+// Policy holds the cert-lifecycle Reconciler tuning. All fields must be positive;
+// NewReconciler validates via Policy.validate().
 type Policy struct {
 	// MaxLookahead is the scan-cutoff window: ListRenewalCandidates returns certs
 	// with NotAfter <= now+MaxLookahead. It must comfortably exceed 30% of the
@@ -28,6 +28,13 @@ type Policy struct {
 	// within the Authorizer's granted MaxTTL (NewAuthorizedCertRequest enforces
 	// SignTTL <= grant.MaxTTL, else the request is denied).
 	SignTTL time.Duration
+	// BatchSize caps how many candidates ListRenewalCandidates returns (and the
+	// Reconciler loads + serially signs) per sweep — the workload bound the scan
+	// cutoff alone does not provide. A full batch (len == BatchSize) means there is
+	// likely more due work, so the Reconciler self-requeues to drain the backlog
+	// across sweeps rather than signing an unbounded set in one tick. Required
+	// positive (no silent default): the deployment must choose its per-sweep cost.
+	BatchSize int
 }
 
 func (p Policy) validate() error {
@@ -39,8 +46,26 @@ func (p Policy) validate() error {
 		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"certlifecycle.Policy: SignTTL must be positive")
 	}
+	if p.BatchSize <= 0 {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"certlifecycle.Policy: BatchSize must be positive")
+	}
 	return nil
 }
+
+// fullBatchRequeueInterval is how soon the Reconciler re-sweeps after a FULL
+// batch (len(candidates) == Policy.BatchSize), to drain a renewal backlog faster
+// than the TickerTrigger interval without hammering the scan. It is an explicit
+// Result.RequeueAfter, which the Loop honors even under WithoutDefaultRequeue
+// (only the zero-Result default-tick self-requeue is suppressed there).
+const fullBatchRequeueInterval = time.Second
+
+// systemActorID is the cert-issued payload actorId the Reconciler stamps on every
+// renewal. Server-side renewal has no request principal; "system" mirrors the
+// tenantless system identity the reconcile Loop installs on the ctx (#1821,
+// reconcile's systemProducerActor) and projection.SystemPrincipalActor, so the
+// cert-issued payload actorId equals the outbox envelope principal actorId.
+const systemActorID = "system"
 
 // Reconciler is the reusable server-side certificate-lifecycle reconcile.Reconciler.
 // On each tick it sweeps every renewable certificate due for renewal (k8s 70–90%
@@ -67,6 +92,21 @@ func (p Policy) validate() error {
 // runtime/command — "reuse runtime/command" is satisfied at the reconcile-loop
 // archetype level, and the queue active-uniqueness the issue mentions is realized
 // structurally by the fencing CAS, not a command queue.
+//
+// Residual (at-most-once VALID vs at-most-once MINT). The fencing CAS guards the
+// PERSIST/DELIVER boundary: at most one renewed generation is ever persisted to
+// the row and at most one cert-issued event is emitted. It does NOT guard the
+// SIGN side effect, which runs first: Signer.Sign (and a CA's ledger.Record)
+// executes before the fenced Write, so a zombie leader that lost its lease
+// mid-sweep can mint a certificate / record a ledger entry whose subsequent
+// fenced Write is then stale-rejected — a phantom that is never persisted on the
+// row and never delivered to the device, but a wasted serial / spurious ledger
+// row. Losing the lease cancels the lease-scoped ctx (Sign must honor ctx),
+// narrowing but not closing the window. So "at-most-once VALID signing"
+// (persisted + delivered) holds; full at-most-once-MINT hardening (a fenced
+// pre-claim before Sign, or an idempotency-keyed Signer/ledger CAS) is a backlog
+// follow-up under EPIC #1895 (cluster C1) — it also touches certsigning / softca,
+// outside this PR's framework-primitive scope.
 //
 // # System identity / multi-tenant
 //
@@ -142,7 +182,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	}
 	now := r.clk.Now()
 	cutoff := now.Add(r.policy.MaxLookahead)
-	candidates, err := r.repo.ListRenewalCandidates(ctx, cutoff)
+	candidates, err := r.repo.ListRenewalCandidates(ctx, cutoff, r.policy.BatchSize)
 	if err != nil {
 		// Transient (DB/scan I/O may recover): errcode.Wrap stamps the Kind so the
 		// Loop classifies it as retryable rather than guessing from a bare error.
@@ -168,14 +208,28 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		slog.Int("candidates", c.total), slog.Int("renewed", c.renewed),
 		slog.Int("denied", c.denied), slog.Int("skipped", c.skipped),
 		slog.Int("errored", c.errored))
-	return reconcile.Result{}, firstErr
+	if firstErr != nil {
+		// The error path drives backoff/retry (RequeueAfter is ignored when err is
+		// non-nil), so surface the transient error rather than a drain requeue.
+		return reconcile.Result{}, firstErr
+	}
+	if c.total == r.policy.BatchSize {
+		// A full batch means the scan was capped — there is likely more due work.
+		// Self-requeue to drain the backlog promptly (honored despite
+		// WithoutDefaultRequeue); the next sweep skips the certs renewed this pass
+		// (their NotAfter advanced beyond the cutoff).
+		return reconcile.Result{RequeueAfter: fullBatchRequeueInterval}, nil
+	}
+	return reconcile.Result{}, nil
 }
 
 // sweepCounts aggregates per-candidate outcomes of one Reconcile sweep for the
-// summary log. denied counts authorization deny/error (the security-relevant
-// "policy said no"); skipped counts benign non-renewals (not-due, non-renewable
-// state, malformed row, constraint violation, lost fencing race); errored counts
-// transient failures that also bubble to the Loop.
+// summary log. denied counts policy denial (the security-relevant "policy said
+// no": a non-granted SignConstraints, or a malformed enrollment claim); skipped
+// counts benign non-renewals (not-due, non-renewable state, malformed row,
+// constraint violation, lost fencing race); errored counts transient failures
+// that also bubble to the Loop (sign failure, authorizer/PDP unavailable,
+// unexpected fenced-write error).
 type sweepCounts struct {
 	total, renewed, denied, skipped, errored int
 }
@@ -218,7 +272,13 @@ func (r *Reconciler) renew(ctx context.Context, fw reconcile.FencedWriter, cand 
 		c.skipped++
 		return nil
 	}
-	grant, ok := r.authorize(ctx, scope, subject, cand)
+	grant, ok, err := r.authorize(ctx, scope, subject, cand)
+	if err != nil {
+		// Authorizer/PDP unavailable (not a policy deny) — bubble transient so the
+		// Loop backs off and re-sweeps; do NOT sign, existing cert untouched.
+		c.errored++
+		return err
+	}
 	if !ok {
 		c.denied++
 		return nil // fail-closed deny: do NOT sign, existing cert untouched
@@ -242,30 +302,37 @@ func (r *Reconciler) renew(ctx context.Context, fw reconcile.FencedWriter, cand 
 	return r.persist(ctx, fw, cand, issued, c)
 }
 
-// authorize evaluates the enrollment claim fail-closed. It returns ok=false (and
-// logs) on any denial — an error, or a non-granted SignConstraints — so the
-// caller skips signing.
+// authorize evaluates the enrollment claim fail-closed, distinguishing three
+// outcomes so the caller can classify them correctly:
+//   - (grant, true, nil)  — granted: proceed to sign.
+//   - (_, false, nil)     — policy DENY (not granted) or a malformed claim from
+//     the row: fail-closed skip, counted as denied; no retry.
+//   - (_, false, err)     — authorizer/PDP UNAVAILABLE: a transient error the
+//     caller bubbles so the Loop backs off. An outage must NOT be silently folded
+//     into "denied" (which would never retry).
 func (r *Reconciler) authorize(
 	ctx context.Context, scope certsigning.CertScope, subject certsigning.DeviceSubject, cand Candidate,
-) (certsigning.SignConstraints, bool) {
+) (certsigning.SignConstraints, bool, error) {
 	claim, err := certsigning.NewEnrollmentClaim(scope, subject)
 	if err != nil {
+		// Malformed claim from already-validated scope/subject — not retryable; skip.
 		r.logger.Error("certlifecycle: build enrollment claim failed",
 			slog.String("device_id", cand.DeviceID), slog.Any("err", err))
-		return certsigning.SignConstraints{}, false
+		return certsigning.SignConstraints{}, false, nil
 	}
 	grant, err := r.authorizer.AuthorizeEnroll(ctx, claim)
 	if err != nil {
-		r.logger.Warn("certlifecycle: renewal authorization error — skipping",
+		r.logger.Warn("certlifecycle: renewal authorization unavailable — will retry",
 			slog.String("device_id", cand.DeviceID), slog.Any("err", err))
-		return certsigning.SignConstraints{}, false
+		return certsigning.SignConstraints{}, false, errcode.Wrap(errcode.KindUnavailable, errcode.ErrInternal,
+			"certlifecycle: renewal authorization unavailable", err)
 	}
 	if !grant.Granted() {
 		r.logger.Warn("certlifecycle: renewal authorization denied — skipping",
 			slog.String("device_id", cand.DeviceID))
-		return certsigning.SignConstraints{}, false
+		return certsigning.SignConstraints{}, false, nil
 	}
-	return grant, true
+	return grant, true, nil
 }
 
 // buildAuthorizedRequest rebuilds the CertRequest from the stored CSR and funnels
@@ -314,6 +381,7 @@ func (r *Reconciler) persist(
 		TenantID:    cand.TenantID,
 		IssuerID:    cand.IssuerID,
 		Serial:      issued.Serial().String(),
+		ActorID:     systemActorID,
 		TargetEpoch: cand.Epoch + 1,
 		CertDER:     issued.DER(),
 		ChainDER:    issued.Chain(),
@@ -321,7 +389,7 @@ func (r *Reconciler) persist(
 		NotAfter:    issued.NotAfter(),
 		NewState:    StateActive(),
 	}
-	if err := fw.Write(ctx, cand.DeviceID, mut); err != nil {
+	if err := fw.Write(ctx, cand.EntityKey(), mut); err != nil {
 		if errors.Is(err, reconcile.ErrFencedWriteStale) {
 			r.logger.Info("certlifecycle: lost fencing race — another replica renewed",
 				slog.String("device_id", cand.DeviceID), slog.Uint64("target_epoch", mut.TargetEpoch))
@@ -333,9 +401,11 @@ func (r *Reconciler) persist(
 			"certlifecycle: persist renewed certificate failed", err)
 	}
 	c.renewed++
+	// device_id is the operational correlation key; the cert serial is device PII
+	// (ADR #1895) and is deliberately NOT logged here.
 	r.logger.Info("certlifecycle: renewed certificate",
 		slog.String("device_id", cand.DeviceID), slog.Uint64("epoch", mut.TargetEpoch),
-		slog.String("serial", mut.Serial), slog.Time("not_after", mut.NotAfter))
+		slog.Time("not_after", mut.NotAfter))
 	return nil
 }
 

--- a/framework/runtime/certlifecycle/reconciler.go
+++ b/framework/runtime/certlifecycle/reconciler.go
@@ -1,0 +1,328 @@
+package certlifecycle
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/reconcile"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/tenant"
+	"github.com/ghbvf/gocell/framework/pkg/validation"
+	"github.com/ghbvf/gocell/framework/runtime/certsigning"
+)
+
+// Policy holds the cert-lifecycle Reconciler tuning. Both fields must be
+// positive; NewReconciler validates via Policy.validate().
+type Policy struct {
+	// MaxLookahead is the scan-cutoff window: ListRenewalCandidates returns certs
+	// with NotAfter <= now+MaxLookahead. It must comfortably exceed 30% of the
+	// longest certificate lifetime so no cert crosses its 70% jitter instant
+	// un-scanned (the precise per-cert due decision is dueForRenewal; MaxLookahead
+	// is only the coarse scan bound).
+	MaxLookahead time.Duration
+	// SignTTL is the requested validity of the renewed certificate. It must be
+	// within the Authorizer's granted MaxTTL (NewAuthorizedCertRequest enforces
+	// SignTTL <= grant.MaxTTL, else the request is denied).
+	SignTTL time.Duration
+}
+
+func (p Policy) validate() error {
+	if p.MaxLookahead <= 0 {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"certlifecycle.Policy: MaxLookahead must be positive")
+	}
+	if p.SignTTL <= 0 {
+		return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"certlifecycle.Policy: SignTTL must be positive")
+	}
+	return nil
+}
+
+// Reconciler is the reusable server-side certificate-lifecycle reconcile.Reconciler.
+// On each tick it sweeps every renewable certificate due for renewal (k8s 70–90%
+// jitter), and for each: Authorize (fail-closed) → re-sign the device's STORED
+// CSR via certsigning.Signer → persist the new generation through the fenced
+// write surface. The persisted fenced mutation also carries the cert-issued L2
+// fact, which the consumer's ApplyFenced writes ATOMICALLY with the row (the
+// Reconciler never calls outbox.Emit — L2 atomicity requires one transaction,
+// and the only transaction is the consumer's).
+//
+// It generalizes the iotdevice devicecertrenewal seed's reconcile loop SHAPE
+// (stateless full sweep, level-triggered, returns Result{}), but changes the
+// action from "enqueue a rotate-cert command (device self-renews)" to
+// server-side signing.
+//
+// # At-most-once valid signing, multi-replica safety
+//
+// The Reconciler signs INLINE (softca signs synchronously in <10ms). Cross-replica
+// correctness comes from leader-election (only the lease holder sweeps) plus the
+// FencedWriter's monotonic LEASE-epoch CAS on the persist: if a handoff window
+// briefly lets two leaders both sign, only the live-epoch Write is accepted; the
+// zombie's stale-epoch Write is rejected (ErrFencedWriteStale) and produces no
+// row change and no cert-issued event. The Reconciler does NOT reuse
+// runtime/command — "reuse runtime/command" is satisfied at the reconcile-loop
+// archetype level, and the queue active-uniqueness the issue mentions is realized
+// structurally by the fencing CAS, not a command queue.
+//
+// # System identity / multi-tenant
+//
+// The reconcile Loop installs a tenantless system identity (#1821), so the
+// Reconciler sources the tenant from each scanned Candidate row, never from ctx.
+// The Loop's construction site declares reconcile.SingleTenant() or
+// reconcile.TenantScoped(); the Candidate already carries TenantID so a
+// multi-tenant sweep keeps tenants distinct.
+type Reconciler struct {
+	clk        clock.Clock
+	repo       DeviceCertRepository
+	signer     certsigning.Signer
+	authorizer certsigning.Authorizer
+	policy     Policy
+	logger     *slog.Logger
+}
+
+// Compile-time proof the Reconciler satisfies the reconcile.Reconciler contract.
+var _ reconcile.Reconciler = (*Reconciler)(nil)
+
+// NewReconciler constructs the cert-lifecycle Reconciler. clk is a mandatory
+// positional dependency; repo, signer and authorizer are required and fail fast
+// when nil; policy fields must be positive; a nil logger falls back to
+// slog.Default(). There is deliberately no emitter dependency: the cert-issued
+// L2 fact is written transactionally inside the consumer's ApplyFenced.
+func NewReconciler(
+	clk clock.Clock,
+	repo DeviceCertRepository,
+	signer certsigning.Signer,
+	authorizer certsigning.Authorizer,
+	policy Policy,
+	logger *slog.Logger,
+) (*Reconciler, error) {
+	clock.MustHaveClock(clk, "certlifecycle.NewReconciler")
+	if validation.IsNilInterface(repo) {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"certlifecycle.NewReconciler: repo must not be nil")
+	}
+	if validation.IsNilInterface(signer) {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"certlifecycle.NewReconciler: signer must not be nil")
+	}
+	if validation.IsNilInterface(authorizer) {
+		return nil, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"certlifecycle.NewReconciler: authorizer must not be nil")
+	}
+	if err := policy.validate(); err != nil {
+		return nil, err
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Reconciler{
+		clk: clk, repo: repo, signer: signer, authorizer: authorizer,
+		policy: policy, logger: logger,
+	}, nil
+}
+
+// Reconcile sweeps every renewable certificate due for renewal. req.EntityID is
+// ignored: the Loop is driven by a TickerTrigger whose resync-all sentinel (empty
+// EntityID) means "re-observe every cert you own". The full sweep is bounded by
+// the scan cutoff; the per-cert jitter decision is applied in reconcileOne.
+func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	// Fail-closed BEFORE any work: the renewal persist MUST be fenced. A Loop wired
+	// without WithFencedRepo+WithLeader has no lease-scoped write surface, so
+	// persisting would be unfenced — refuse rather than scan and then write unsafely.
+	fw, ok := reconcile.FencedWriterFrom(ctx)
+	if !ok {
+		return reconcile.Result{}, errcode.New(errcode.KindInternal, errcode.ErrInternal,
+			"certlifecycle: no fenced writer in ctx — wire reconcile.WithFencedRepo + WithLeader")
+	}
+	now := r.clk.Now()
+	cutoff := now.Add(r.policy.MaxLookahead)
+	candidates, err := r.repo.ListRenewalCandidates(ctx, cutoff)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("certlifecycle: scan near-expiry: %w", err)
+	}
+	var firstErr error
+	for _, cand := range candidates {
+		if err := r.reconcileOne(ctx, fw, cand, now); err != nil && firstErr == nil {
+			// Bubble the first transient error so the Loop backs off and re-sweeps;
+			// the fenced CAS makes a re-sweep idempotent. Per-candidate deny / stale
+			// outcomes are handled inside reconcileOne and never returned.
+			firstErr = err
+		}
+	}
+	return reconcile.Result{}, firstErr
+}
+
+// reconcileOne renews one candidate. It returns a non-nil (transient) error only
+// for conditions worth backing off the whole sweep (scan-independent failures:
+// signing failure, an unexpected fenced-write error). Deny, malformed-row, jitter
+// not-due, non-renewable state, and stale-epoch rejection are logged and skipped
+// (return nil) — they must not poison the rest of the sweep.
+func (r *Reconciler) reconcileOne(ctx context.Context, fw reconcile.FencedWriter, cand Candidate, now time.Time) error {
+	if !cand.State.renewable() {
+		r.logger.Debug("certlifecycle: skip non-renewable cert",
+			slog.String("device_id", cand.DeviceID), slog.String("state", cand.State.String()))
+		return nil
+	}
+	if !dueForRenewal(now, cand.NotBefore, cand.NotAfter, cand.DeviceID, cand.Serial) {
+		return nil
+	}
+	if now.After(cand.NotAfter) {
+		// Past notAfter but the stored CSR is still valid — re-sign to recover
+		// (level-triggered convergence). Warn for observability; still renew.
+		r.logger.Warn("certlifecycle: cert already expired — re-signing to recover",
+			slog.String("device_id", cand.DeviceID), slog.Uint64("epoch", cand.Epoch),
+			slog.Duration("expired_for", now.Sub(cand.NotAfter)))
+	}
+	return r.renew(ctx, fw, cand)
+}
+
+// renew runs the Authorize → Sign → fenced-persist pipeline for one candidate.
+func (r *Reconciler) renew(ctx context.Context, fw reconcile.FencedWriter, cand Candidate) error {
+	scope, subject, err := buildScopeSubject(cand)
+	if err != nil {
+		// Malformed row data (e.g. non-canonical tenant) — retry won't fix it; skip
+		// this candidate without poisoning the sweep.
+		r.logger.Error("certlifecycle: skip candidate with invalid identity",
+			slog.String("device_id", cand.DeviceID), slog.Any("err", err))
+		return nil
+	}
+	grant, ok := r.authorize(ctx, scope, subject, cand)
+	if !ok {
+		return nil // fail-closed deny: do NOT sign, existing cert untouched
+	}
+	authReq, ok := r.buildAuthorizedRequest(scope, subject, cand, grant)
+	if !ok {
+		return nil // request build / constraint violation: do NOT sign
+	}
+	issued, err := r.signer.Sign(ctx, authReq)
+	if err != nil {
+		// Signing failure: do NOT persist or emit; the existing certificate is
+		// untouched. Bubble transient so the Loop backs off (the CA may be down).
+		return errcode.Wrap(errcode.KindUnavailable, errcode.ErrCertSignFailed,
+			"certlifecycle: sign renewed certificate failed", err)
+	}
+	return r.persist(ctx, fw, cand, issued)
+}
+
+// authorize evaluates the enrollment claim fail-closed. It returns ok=false (and
+// logs) on any denial — an error, or a non-granted SignConstraints — so the
+// caller skips signing.
+func (r *Reconciler) authorize(
+	ctx context.Context, scope certsigning.CertScope, subject certsigning.DeviceSubject, cand Candidate,
+) (certsigning.SignConstraints, bool) {
+	claim, err := certsigning.NewEnrollmentClaim(scope, subject)
+	if err != nil {
+		r.logger.Error("certlifecycle: build enrollment claim failed",
+			slog.String("device_id", cand.DeviceID), slog.Any("err", err))
+		return certsigning.SignConstraints{}, false
+	}
+	grant, err := r.authorizer.AuthorizeEnroll(ctx, claim)
+	if err != nil {
+		r.logger.Warn("certlifecycle: renewal authorization error — skipping",
+			slog.String("device_id", cand.DeviceID), slog.Any("err", err))
+		return certsigning.SignConstraints{}, false
+	}
+	if !grant.Granted() {
+		r.logger.Warn("certlifecycle: renewal authorization denied — skipping",
+			slog.String("device_id", cand.DeviceID))
+		return certsigning.SignConstraints{}, false
+	}
+	return grant, true
+}
+
+// buildAuthorizedRequest rebuilds the CertRequest from the stored CSR and funnels
+// it through NewAuthorizedCertRequest (TTL / SAN constraint enforcement). It
+// returns ok=false (and logs) on a request-build or constraint failure.
+func (r *Reconciler) buildAuthorizedRequest(
+	scope certsigning.CertScope, subject certsigning.DeviceSubject, cand Candidate, grant certsigning.SignConstraints,
+) (certsigning.AuthorizedCertRequest, bool) {
+	sans, err := certsigning.NewSubjectAltNames(cand.DNSNames, cand.IPAddresses, cand.URIs)
+	if err != nil {
+		r.logger.Error("certlifecycle: build SANs failed",
+			slog.String("device_id", cand.DeviceID), slog.Any("err", err))
+		return certsigning.AuthorizedCertRequest{}, false
+	}
+	usages, err := certsigning.NewKeyUsages(x509.KeyUsageDigitalSignature, x509.ExtKeyUsageClientAuth)
+	if err != nil {
+		r.logger.Error("certlifecycle: build key usages failed",
+			slog.String("device_id", cand.DeviceID), slog.Any("err", err))
+		return certsigning.AuthorizedCertRequest{}, false
+	}
+	req, err := certsigning.NewCertRequest(scope, subject, cand.CSRDER, sans, usages, r.policy.SignTTL)
+	if err != nil {
+		// Stored CSR corrupt / POP invalid — retry won't fix it; skip.
+		r.logger.Error("certlifecycle: rebuild cert request from stored CSR failed",
+			slog.String("device_id", cand.DeviceID), slog.Any("err", err))
+		return certsigning.AuthorizedCertRequest{}, false
+	}
+	authReq, err := certsigning.NewAuthorizedCertRequest(req, grant)
+	if err != nil {
+		r.logger.Warn("certlifecycle: renewal request outside granted constraints — skipping",
+			slog.String("device_id", cand.DeviceID), slog.Any("err", err))
+		return certsigning.AuthorizedCertRequest{}, false
+	}
+	return authReq, true
+}
+
+// persist writes the renewed certificate through the ONLY write surface — the
+// epoch-bound FencedWriter. A stale-epoch rejection means another replica won the
+// fencing race: do NOT retry and do NOT emit (the winner's fenced write carries
+// the cert-issued fact). Any other write error is transient and bubbles.
+func (r *Reconciler) persist(ctx context.Context, fw reconcile.FencedWriter, cand Candidate, issued certsigning.IssuedCert) error {
+	mut := &IssuedMutation{
+		DeviceID:    cand.DeviceID,
+		TenantID:    cand.TenantID,
+		IssuerID:    cand.IssuerID,
+		Serial:      issued.Serial().String(),
+		TargetEpoch: cand.Epoch + 1,
+		CertDER:     issued.DER(),
+		ChainDER:    issued.Chain(),
+		NotBefore:   issued.NotBefore(),
+		NotAfter:    issued.NotAfter(),
+		NewState:    StateActive(),
+	}
+	if err := fw.Write(ctx, cand.DeviceID, mut); err != nil {
+		if errors.Is(err, reconcile.ErrFencedWriteStale) {
+			r.logger.Info("certlifecycle: lost fencing race — another replica renewed",
+				slog.String("device_id", cand.DeviceID), slog.Uint64("target_epoch", mut.TargetEpoch))
+			return nil
+		}
+		return fmt.Errorf("certlifecycle: persist renewed certificate: %w", err)
+	}
+	r.logger.Info("certlifecycle: renewed certificate",
+		slog.String("device_id", cand.DeviceID), slog.Uint64("epoch", mut.TargetEpoch),
+		slog.String("serial", mut.Serial), slog.Time("not_after", mut.NotAfter))
+	return nil
+}
+
+// buildScopeSubject derives the typed CertScope and DeviceSubject from the
+// candidate row. The tenant comes from cand.TenantID (the row), never from ctx
+// (#1821 — the reconcile Loop runs under a tenantless system identity).
+func buildScopeSubject(cand Candidate) (certsigning.CertScope, certsigning.DeviceSubject, error) {
+	tenantID, err := tenant.ParseTenantID(cand.TenantID)
+	if err != nil {
+		return certsigning.CertScope{}, certsigning.DeviceSubject{}, fmt.Errorf("tenant: %w", err)
+	}
+	issuer, err := certsigning.NewIssuerID(cand.IssuerID)
+	if err != nil {
+		return certsigning.CertScope{}, certsigning.DeviceSubject{}, fmt.Errorf("issuer: %w", err)
+	}
+	device, err := certsigning.NewDeviceID(cand.DeviceID)
+	if err != nil {
+		return certsigning.CertScope{}, certsigning.DeviceSubject{}, fmt.Errorf("device: %w", err)
+	}
+	scope, err := certsigning.NewCertScope(tenantID, issuer, device)
+	if err != nil {
+		return certsigning.CertScope{}, certsigning.DeviceSubject{}, fmt.Errorf("scope: %w", err)
+	}
+	subject, err := certsigning.NewDeviceSubject(tenantID, device, cand.CommonName)
+	if err != nil {
+		return certsigning.CertScope{}, certsigning.DeviceSubject{}, fmt.Errorf("subject: %w", err)
+	}
+	return scope, subject, nil
+}

--- a/framework/runtime/certlifecycle/reconciler_loop_test.go
+++ b/framework/runtime/certlifecycle/reconciler_loop_test.go
@@ -66,7 +66,8 @@ func TestReconcileLoopMultiReplicaFencing(t *testing.T) {
 
 	now := time.Now()
 	nb, na := dueWindow(now)
-	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
+	cand := activeCandidate(t, "device-1", nb, na)
+	repo := newFakeRepo(cand)
 	signer := newFakeSigner(t, now, now.Add(testSignTTL))
 	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
 	rec := newReconciler(t, repo, signer, authz)
@@ -76,12 +77,13 @@ func TestReconcileLoopMultiReplicaFencing(t *testing.T) {
 	defer stop()
 	testwait.External(t, "new-leader-renewed", func() bool { return len(repo.mutations()) == 1 }, pollTimeout, pollTick)
 
-	if got := repo.LastEpoch("device-1"); got <= tokOld.Epoch {
+	// The Reconciler writes under the composite entity key (tenant|issuer|device).
+	if got := repo.LastEpoch(cand.EntityKey()); got <= tokOld.Epoch {
 		t.Fatalf("live write epoch %d must exceed the old leader's epoch %d (handoff must bump)", got, tokOld.Epoch)
 	}
 
 	// Zombie old leader replays an in-flight write at the STALE epoch — rejected.
-	accepted, err := repo.ApplyFenced(ctx, "device-1", tokOld.Epoch, "zombie-renewal")
+	accepted, err := repo.ApplyFenced(ctx, cand.EntityKey(), tokOld.Epoch, "zombie-renewal")
 	if err != nil {
 		t.Fatalf("zombie write: %v", err)
 	}

--- a/framework/runtime/certlifecycle/reconciler_loop_test.go
+++ b/framework/runtime/certlifecycle/reconciler_loop_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ghbvf/gocell/framework/kernel/clock"
 	"github.com/ghbvf/gocell/framework/kernel/reconcile/reconciletest"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/testwait"
 )
 
 // TestReconcileLoopBoundedSweep drives the Reconciler through a real Loop with a
@@ -26,7 +27,7 @@ func TestReconcileLoopBoundedSweep(t *testing.T) {
 
 	stop := driveLoop(t, rec, repo)
 	defer stop()
-	waitUntil(t, "all three certs renewed", func() bool { return len(repo.mutations()) == 3 })
+	testwait.External(t, "all-certs-renewed", func() bool { return len(repo.mutations()) == 3 }, pollTimeout, pollTick)
 
 	seen := map[string]bool{}
 	for _, m := range repo.mutations() {
@@ -73,7 +74,7 @@ func TestReconcileLoopMultiReplicaFencing(t *testing.T) {
 	// New leader (epoch N+1) drives the Loop; its renewal lands at the higher epoch.
 	stop := driveLoopWithLeader(t, rec, repo, backend.Elector("holder-new"))
 	defer stop()
-	waitUntil(t, "new leader renewed", func() bool { return len(repo.mutations()) == 1 })
+	testwait.External(t, "new-leader-renewed", func() bool { return len(repo.mutations()) == 1 }, pollTimeout, pollTick)
 
 	if got := repo.LastEpoch("device-1"); got <= tokOld.Epoch {
 		t.Fatalf("live write epoch %d must exceed the old leader's epoch %d (handoff must bump)", got, tokOld.Epoch)

--- a/framework/runtime/certlifecycle/reconciler_loop_test.go
+++ b/framework/runtime/certlifecycle/reconciler_loop_test.go
@@ -20,7 +20,7 @@ func TestReconcileLoopBoundedSweep(t *testing.T) {
 		activeCandidate(t, "device-2", nb, na),
 		activeCandidate(t, "device-3", nb, na),
 	)
-	signer := newFakeSigner(now, now.Add(testSignTTL))
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
 	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
 	rec := newReconciler(t, repo, signer, authz)
 
@@ -66,7 +66,7 @@ func TestReconcileLoopMultiReplicaFencing(t *testing.T) {
 	now := time.Now()
 	nb, na := dueWindow(now)
 	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
-	signer := newFakeSigner(now, now.Add(testSignTTL))
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
 	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
 	rec := newReconciler(t, repo, signer, authz)
 

--- a/framework/runtime/certlifecycle/reconciler_loop_test.go
+++ b/framework/runtime/certlifecycle/reconciler_loop_test.go
@@ -1,0 +1,94 @@
+package certlifecycle_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/reconcile/reconciletest"
+)
+
+// TestReconcileLoopBoundedSweep drives the Reconciler through a real Loop with a
+// resync-all pulse and asserts every due candidate is renewed in one sweep.
+func TestReconcileLoopBoundedSweep(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	nb, na := dueWindow(now)
+	repo := newFakeRepo(
+		activeCandidate(t, "device-1", nb, na),
+		activeCandidate(t, "device-2", nb, na),
+		activeCandidate(t, "device-3", nb, na),
+	)
+	signer := newFakeSigner(now, now.Add(testSignTTL))
+	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
+	rec := newReconciler(t, repo, signer, authz)
+
+	stop := driveLoop(t, rec, repo)
+	defer stop()
+	waitUntil(t, "all three certs renewed", func() bool { return len(repo.mutations()) == 3 })
+
+	seen := map[string]bool{}
+	for _, m := range repo.mutations() {
+		seen[m.DeviceID] = true
+		if m.TargetEpoch != 2 {
+			t.Errorf("%s TargetEpoch = %d, want 2", m.DeviceID, m.TargetEpoch)
+		}
+	}
+	for _, d := range []string{"device-1", "device-2", "device-3"} {
+		if !seen[d] {
+			t.Errorf("device %s was not renewed in the sweep", d)
+		}
+	}
+}
+
+// TestReconcileLoopMultiReplicaFencing proves cross-replica safety via the
+// monotonic LeaseToken.Epoch: a handoff bumps the epoch, the live leader's
+// renewal lands at the higher epoch, and a zombie old-leader write at the stale
+// epoch is rejected by the CAS — exactly one renewal effect survives.
+func TestReconcileLoopMultiReplicaFencing(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	const rid = testReconcilerID // the lease key the test Loop acquires under
+
+	backend := reconciletest.NewFakeLeaseBackend(clock.Real())
+
+	// Old leader acquires (epoch N) then hands off.
+	old := backend.Elector("holder-old")
+	tokOld, err := old.AcquireLease(ctx, rid)
+	if err != nil {
+		t.Fatalf("old acquire: %v", err)
+	}
+	if err := old.ReleaseLease(ctx, tokOld); err != nil {
+		t.Fatalf("old release: %v", err)
+	}
+
+	now := time.Now()
+	nb, na := dueWindow(now)
+	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
+	signer := newFakeSigner(now, now.Add(testSignTTL))
+	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
+	rec := newReconciler(t, repo, signer, authz)
+
+	// New leader (epoch N+1) drives the Loop; its renewal lands at the higher epoch.
+	stop := driveLoopWithLeader(t, rec, repo, backend.Elector("holder-new"))
+	defer stop()
+	waitUntil(t, "new leader renewed", func() bool { return len(repo.mutations()) == 1 })
+
+	if got := repo.LastEpoch("device-1"); got <= tokOld.Epoch {
+		t.Fatalf("live write epoch %d must exceed the old leader's epoch %d (handoff must bump)", got, tokOld.Epoch)
+	}
+
+	// Zombie old leader replays an in-flight write at the STALE epoch — rejected.
+	accepted, err := repo.ApplyFenced(ctx, "device-1", tokOld.Epoch, "zombie-renewal")
+	if err != nil {
+		t.Fatalf("zombie write: %v", err)
+	}
+	if accepted {
+		t.Fatal("stale-epoch zombie write must be rejected by the fencing CAS")
+	}
+	// Exactly one renewal effect survives (the live leader's IssuedMutation).
+	if got := len(repo.mutations()); got != 1 {
+		t.Fatalf("recorded %d renewal mutations, want exactly 1 (no duplicate from zombie)", got)
+	}
+}

--- a/framework/runtime/certlifecycle/reconciler_test.go
+++ b/framework/runtime/certlifecycle/reconciler_test.go
@@ -1,0 +1,419 @@
+package certlifecycle_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/reconcile"
+	"github.com/ghbvf/gocell/framework/kernel/reconcile/reconciletest"
+	cl "github.com/ghbvf/gocell/framework/runtime/certlifecycle"
+	cs "github.com/ghbvf/gocell/framework/runtime/certsigning"
+)
+
+const (
+	testMaxLookahead = 30 * 24 * time.Hour
+	testSignTTL      = 24 * time.Hour
+	pollTimeout      = 3 * time.Second
+	pollTick         = 5 * time.Millisecond
+	// testReconcilerID is the lease key the test Loop acquires under; the
+	// multi-replica test pre-acquires the same key to simulate a handoff. Must
+	// satisfy validateReconcilerID (lowercase [a-z0-9_], leading [a-z_]).
+	testReconcilerID = "certlifecycle_test"
+)
+
+// dueWindow returns a validity window for which now is past the 70–90% jitter
+// instant (so the cert is due) regardless of the jitter fraction.
+func dueWindow(now time.Time) (notBefore, notAfter time.Time) {
+	return now.Add(-95 * time.Hour), now.Add(5 * time.Hour)
+}
+
+// notDueWindow returns a window whose 70–90% instant is comfortably in the
+// future (so the cert is not yet due) even within the scan cutoff.
+func notDueWindow(now time.Time) (notBefore, notAfter time.Time) {
+	return now.Add(-1 * time.Hour), now.Add(99 * time.Hour)
+}
+
+// newReconciler builds a Reconciler with the given fakes and default policy.
+func newReconciler(t *testing.T, repo cl.DeviceCertRepository, signer *fakeSigner, authz *fakeAuthorizer) *cl.Reconciler {
+	t.Helper()
+	rec, err := cl.NewReconciler(clock.Real(), repo, signer, authz,
+		cl.Policy{MaxLookahead: testMaxLookahead, SignTTL: testSignTTL}, nil)
+	if err != nil {
+		t.Fatalf("NewReconciler: %v", err)
+	}
+	return rec
+}
+
+// driveLoop builds a fenced+leader Loop around rec with a fresh single-holder
+// elector, starts it, submits one resync-all pulse, and returns a stop func.
+func driveLoop(t *testing.T, rec *cl.Reconciler, repo reconcile.FencedRepository) (stop func()) {
+	t.Helper()
+	leader := reconciletest.NewFakeLeaseBackend(clock.Real()).Elector("holder-1")
+	return driveLoopWithLeader(t, rec, repo, leader)
+}
+
+// driveLoopWithLeader is driveLoop with a caller-supplied LeaderElector, so a
+// multi-replica handoff scenario can control the lease epoch. The Loop is the
+// only minter of the FencedWriter the Reconciler writes through, so all behavior
+// is exercised end-to-end here.
+func driveLoopWithLeader(t *testing.T, rec *cl.Reconciler, repo reconcile.FencedRepository, leader reconcile.LeaderElector) (stop func()) {
+	t.Helper()
+	trigger, submit := reconciletest.NewFakeTrigger()
+	loop, err := reconcile.New(rec, reconcile.SingleTenant()).
+		WithTrigger(trigger).
+		WithLeader(leader).
+		WithFencedRepo(repo).
+		WithReconcilerID(testReconcilerID).
+		WithoutDefaultRequeue().
+		Build()
+	if err != nil {
+		t.Fatalf("build loop: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	// Start is non-blocking: it returns once the worker pool is confirmed running
+	// (or an error from preStartValidate). The loop then runs in background
+	// goroutines until Stop / ctx cancel.
+	if err := loop.Start(ctx); err != nil {
+		cancel()
+		t.Fatalf("loop.Start: %v", err)
+	}
+	submit(reconcile.Request{})
+	return func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), pollTimeout)
+		defer stopCancel()
+		if err := loop.Stop(stopCtx); err != nil {
+			t.Errorf("loop.Stop: %v", err)
+		}
+		cancel()
+	}
+}
+
+// waitUntil polls cond until true or fails after pollTimeout.
+func waitUntil(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(pollTimeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(pollTick)
+	}
+	t.Fatalf("timed out waiting for: %s", what)
+}
+
+func TestReconcileHappyPathRenews(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	nb, na := dueWindow(now)
+	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
+	signer := newFakeSigner(now, now.Add(testSignTTL))
+	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
+	rec := newReconciler(t, repo, signer, authz)
+
+	stop := driveLoop(t, rec, repo)
+	defer stop()
+	waitUntil(t, "one renewal mutation", func() bool { return len(repo.mutations()) == 1 })
+
+	mut := firstMutation(t, repo)
+	if mut.TargetEpoch != 2 {
+		t.Errorf("TargetEpoch = %d, want 2 (cand.Epoch+1)", mut.TargetEpoch)
+	}
+	if mut.NewState != cl.StateActive() {
+		t.Errorf("NewState = %q, want active", mut.NewState.String())
+	}
+	if mut.TenantID != testTenant {
+		t.Errorf("mutation TenantID = %q, want %q (from row, not ctx)", mut.TenantID, testTenant)
+	}
+	if mut.IssuerID != testIssuer {
+		t.Errorf("mutation IssuerID = %q, want %q", mut.IssuerID, testIssuer)
+	}
+	if mut.Serial == "" {
+		t.Error("mutation Serial empty — must carry the issued cert serial")
+	}
+	// The signing request must carry the row tenant (not an ambient ctx tenant).
+	req, ok := signer.lastRequest()
+	if !ok {
+		t.Fatal("signer received no request")
+	}
+	if got := req.Request().Scope().Tenant().String(); got != testTenant {
+		t.Errorf("signed request scope tenant = %q, want %q (sourced from row)", got, testTenant)
+	}
+}
+
+func TestReconcileSigningFailureDoesNotDamageCert(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	nb, na := dueWindow(now)
+	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
+	signer := newFakeSigner(now, now.Add(testSignTTL))
+	signer.err = errFake
+	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
+	rec := newReconciler(t, repo, signer, authz)
+
+	stop := driveLoop(t, rec, repo)
+	defer stop()
+	// Sign is attempted; assert no persisted effect ever (existing cert untouched).
+	waitUntil(t, "signer attempted", func() bool { return signer.callCount() >= 1 })
+	if got := len(repo.mutations()); got != 0 {
+		t.Errorf("recorded %d mutations after signing failure, want 0 (existing cert untouched)", got)
+	}
+}
+
+func TestReconcileFailClosedDenyDoesNotSign(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	nb, na := dueWindow(now)
+	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
+	signer := newFakeSigner(now, now.Add(testSignTTL))
+	authz := &fakeAuthorizer{} // zero SignConstraints == not granted (deny)
+	rec := newReconciler(t, repo, signer, authz)
+
+	stop := driveLoop(t, rec, repo)
+	defer stop()
+	waitUntil(t, "authorizer consulted", func() bool { return authz.callCount() >= 1 })
+	if got := signer.callCount(); got != 0 {
+		t.Errorf("signer called %d times under fail-closed deny, want 0", got)
+	}
+	if got := len(repo.mutations()); got != 0 {
+		t.Errorf("recorded %d mutations under deny, want 0", got)
+	}
+}
+
+func TestReconcileAuthorizeErrorDoesNotSign(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	nb, na := dueWindow(now)
+	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
+	signer := newFakeSigner(now, now.Add(testSignTTL))
+	authz := &fakeAuthorizer{err: errFake}
+	rec := newReconciler(t, repo, signer, authz)
+
+	stop := driveLoop(t, rec, repo)
+	defer stop()
+	waitUntil(t, "authorizer consulted", func() bool { return authz.callCount() >= 1 })
+	if got := signer.callCount(); got != 0 {
+		t.Errorf("signer called %d times after authorize error, want 0", got)
+	}
+}
+
+func TestReconcileConstraintViolationDoesNotSign(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	nb, na := dueWindow(now)
+	cand := activeCandidate(t, "device-1", nb, na)
+	cand.DNSNames = []string{"device-1.example"} // requested SAN outside the empty grant allowance
+	repo := newFakeRepo(cand)
+	signer := newFakeSigner(now, now.Add(testSignTTL))
+	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)} // allows NO SANs
+	rec := newReconciler(t, repo, signer, authz)
+
+	stop := driveLoop(t, rec, repo)
+	defer stop()
+	waitUntil(t, "authorizer consulted", func() bool { return authz.callCount() >= 1 })
+	if got := signer.callCount(); got != 0 {
+		t.Errorf("signer called %d times on SAN constraint violation, want 0", got)
+	}
+	if got := len(repo.mutations()); got != 0 {
+		t.Errorf("recorded %d mutations on constraint violation, want 0", got)
+	}
+}
+
+func TestReconcileTTLViolationDoesNotSign(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	nb, na := dueWindow(now)
+	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
+	signer := newFakeSigner(now, now.Add(testSignTTL))
+	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL-time.Hour)} // maxTTL < SignTTL
+	rec := newReconciler(t, repo, signer, authz)
+
+	stop := driveLoop(t, rec, repo)
+	defer stop()
+	waitUntil(t, "authorizer consulted", func() bool { return authz.callCount() >= 1 })
+	if got := signer.callCount(); got != 0 {
+		t.Errorf("signer called %d times when SignTTL exceeds grant MaxTTL, want 0", got)
+	}
+}
+
+func TestReconcileNotDueSkips(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	nb, na := notDueWindow(now)
+	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
+	signer := newFakeSigner(now, now.Add(testSignTTL))
+	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
+	rec := newReconciler(t, repo, signer, authz)
+
+	stop := driveLoop(t, rec, repo)
+	defer stop()
+	waitUntil(t, "sweep ran", func() bool { return repo.listCount() >= 1 })
+	if got := authz.callCount(); got != 0 {
+		t.Errorf("authorizer called %d times for not-due cert, want 0", got)
+	}
+	if got := len(repo.mutations()); got != 0 {
+		t.Errorf("recorded %d mutations for not-due cert, want 0", got)
+	}
+}
+
+func TestReconcileNonRenewableStateSkips(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	nb, na := dueWindow(now)
+	cand := activeCandidate(t, "device-1", nb, na)
+	cand.State = cl.StateRevoked() // operator terminal — never renewed
+	repo := newFakeRepo(cand)
+	signer := newFakeSigner(now, now.Add(testSignTTL))
+	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
+	rec := newReconciler(t, repo, signer, authz)
+
+	stop := driveLoop(t, rec, repo)
+	defer stop()
+	waitUntil(t, "sweep ran", func() bool { return repo.listCount() >= 1 })
+	if got := authz.callCount(); got != 0 {
+		t.Errorf("authorizer called %d times for revoked cert, want 0 (observe-and-skip)", got)
+	}
+	if got := signer.callCount(); got != 0 {
+		t.Errorf("signer called %d times for revoked cert, want 0", got)
+	}
+}
+
+func TestReconcileExpiredCertReSignsToRecover(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	// Already past notAfter, but active with a valid stored CSR → re-sign to recover.
+	nb, na := now.Add(-100*time.Hour), now.Add(-1*time.Hour)
+	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
+	signer := newFakeSigner(now, now.Add(testSignTTL))
+	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
+	rec := newReconciler(t, repo, signer, authz)
+
+	stop := driveLoop(t, rec, repo)
+	defer stop()
+	waitUntil(t, "expired cert recovered", func() bool { return len(repo.mutations()) == 1 })
+	if got := firstMutation(t, repo).TargetEpoch; got != 2 {
+		t.Errorf("recovered cert TargetEpoch = %d, want 2", got)
+	}
+}
+
+func TestReconcileStaleFencedWriteSkipsNoDuplicate(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	nb, na := dueWindow(now)
+	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
+	// Seed a higher lease epoch for the entity so the Loop's epoch-1 write is
+	// stale-rejected by the monotonic CAS (zombie-leader scenario).
+	if _, err := repo.ApplyFenced(context.Background(), "device-1", 99, "seed-high-epoch"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	signer := newFakeSigner(now, now.Add(testSignTTL))
+	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
+	rec := newReconciler(t, repo, signer, authz)
+
+	stop := driveLoop(t, rec, repo)
+	defer stop()
+	waitUntil(t, "signer attempted", func() bool { return signer.callCount() >= 1 })
+	// The stale write is rejected → no IssuedMutation recorded (only the seed).
+	if got := len(repo.mutations()); got != 0 {
+		t.Errorf("recorded %d IssuedMutations after stale rejection, want 0", got)
+	}
+}
+
+func TestReconcileInvalidRowTenantSkips(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	nb, na := dueWindow(now)
+	cand := activeCandidate(t, "device-1", nb, na)
+	cand.TenantID = "not-a-canonical-uuid" // malformed row → identity build fails
+	repo := newFakeRepo(cand)
+	signer := newFakeSigner(now, now.Add(testSignTTL))
+	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
+	rec := newReconciler(t, repo, signer, authz)
+
+	stop := driveLoop(t, rec, repo)
+	defer stop()
+	waitUntil(t, "sweep ran", func() bool { return repo.listCount() >= 1 })
+	if got := authz.callCount(); got != 0 {
+		t.Errorf("authorizer called %d times for malformed-tenant row, want 0 (skip before authorize)", got)
+	}
+	if got := signer.callCount(); got != 0 {
+		t.Errorf("signer called %d times for malformed-tenant row, want 0", got)
+	}
+	if got := len(repo.mutations()); got != 0 {
+		t.Errorf("recorded %d mutations for malformed-tenant row, want 0", got)
+	}
+}
+
+func TestReconcileCorruptStoredCSRSkips(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	nb, na := dueWindow(now)
+	cand := activeCandidate(t, "device-1", nb, na)
+	cand.CSRDER = []byte("not-a-valid-csr") // unparseable stored CSR → request build fails
+	repo := newFakeRepo(cand)
+	signer := newFakeSigner(now, now.Add(testSignTTL))
+	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
+	rec := newReconciler(t, repo, signer, authz)
+
+	stop := driveLoop(t, rec, repo)
+	defer stop()
+	waitUntil(t, "authorizer consulted", func() bool { return authz.callCount() >= 1 })
+	if got := signer.callCount(); got != 0 {
+		t.Errorf("signer called %d times with corrupt stored CSR, want 0", got)
+	}
+	if got := len(repo.mutations()); got != 0 {
+		t.Errorf("recorded %d mutations with corrupt stored CSR, want 0", got)
+	}
+}
+
+func TestNewReconcilerValidatesDeps(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	okSigner := newFakeSigner(now, now.Add(testSignTTL))
+	okAuthz := &fakeAuthorizer{}
+	okRepo := newFakeRepo()
+	okPolicy := cl.Policy{MaxLookahead: testMaxLookahead, SignTTL: testSignTTL}
+
+	cases := []struct {
+		name   string
+		repo   cl.DeviceCertRepository
+		signer cs.Signer
+		authz  cs.Authorizer
+		policy cl.Policy
+	}{
+		{"nil repo", nil, okSigner, okAuthz, okPolicy},
+		{"nil signer", okRepo, nil, okAuthz, okPolicy},
+		{"nil authorizer", okRepo, okSigner, nil, okPolicy},
+		{"zero MaxLookahead", okRepo, okSigner, okAuthz, cl.Policy{SignTTL: testSignTTL}},
+		{"zero SignTTL", okRepo, okSigner, okAuthz, cl.Policy{MaxLookahead: testMaxLookahead}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := cl.NewReconciler(clock.Real(), tc.repo, tc.signer, tc.authz, tc.policy, nil); err == nil {
+				t.Errorf("NewReconciler(%s) = nil error, want validation failure", tc.name)
+			}
+		})
+	}
+}
+
+func TestReconcileNoFencedWriterFailsClosed(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	nb, na := dueWindow(now)
+	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
+	signer := newFakeSigner(now, now.Add(testSignTTL))
+	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
+	rec := newReconciler(t, repo, signer, authz)
+
+	// Direct call with a plain ctx (no Loop-injected writer) must fail closed and
+	// never sign.
+	_, err := rec.Reconcile(context.Background(), reconcile.Request{})
+	if err == nil {
+		t.Fatal("Reconcile with no fenced writer returned nil error, want fail-closed")
+	}
+	if signer.callCount() != 0 {
+		t.Errorf("signer called %d times without a fenced writer, want 0", signer.callCount())
+	}
+}

--- a/framework/runtime/certlifecycle/reconciler_test.go
+++ b/framework/runtime/certlifecycle/reconciler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/clock"
 	"github.com/ghbvf/gocell/framework/kernel/reconcile"
 	"github.com/ghbvf/gocell/framework/kernel/reconcile/reconciletest"
+	"github.com/ghbvf/gocell/framework/pkg/tenant"
 	cl "github.com/ghbvf/gocell/framework/runtime/certlifecycle"
 	cs "github.com/ghbvf/gocell/framework/runtime/certsigning"
 )
@@ -108,7 +109,7 @@ func TestReconcileHappyPathRenews(t *testing.T) {
 	now := time.Now()
 	nb, na := dueWindow(now)
 	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
-	signer := newFakeSigner(now, now.Add(testSignTTL))
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
 	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
 	rec := newReconciler(t, repo, signer, authz)
 
@@ -123,7 +124,7 @@ func TestReconcileHappyPathRenews(t *testing.T) {
 	if mut.NewState != cl.StateActive() {
 		t.Errorf("NewState = %q, want active", mut.NewState.String())
 	}
-	if mut.TenantID != testTenant {
+	if string(mut.TenantID) != testTenant {
 		t.Errorf("mutation TenantID = %q, want %q (from row, not ctx)", mut.TenantID, testTenant)
 	}
 	if mut.IssuerID != testIssuer {
@@ -147,7 +148,7 @@ func TestReconcileSigningFailureDoesNotDamageCert(t *testing.T) {
 	now := time.Now()
 	nb, na := dueWindow(now)
 	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
-	signer := newFakeSigner(now, now.Add(testSignTTL))
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
 	signer.err = errFake
 	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
 	rec := newReconciler(t, repo, signer, authz)
@@ -166,7 +167,7 @@ func TestReconcileFailClosedDenyDoesNotSign(t *testing.T) {
 	now := time.Now()
 	nb, na := dueWindow(now)
 	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
-	signer := newFakeSigner(now, now.Add(testSignTTL))
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
 	authz := &fakeAuthorizer{} // zero SignConstraints == not granted (deny)
 	rec := newReconciler(t, repo, signer, authz)
 
@@ -186,7 +187,7 @@ func TestReconcileAuthorizeErrorDoesNotSign(t *testing.T) {
 	now := time.Now()
 	nb, na := dueWindow(now)
 	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
-	signer := newFakeSigner(now, now.Add(testSignTTL))
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
 	authz := &fakeAuthorizer{err: errFake}
 	rec := newReconciler(t, repo, signer, authz)
 
@@ -205,7 +206,7 @@ func TestReconcileConstraintViolationDoesNotSign(t *testing.T) {
 	cand := activeCandidate(t, "device-1", nb, na)
 	cand.DNSNames = []string{"device-1.example"} // requested SAN outside the empty grant allowance
 	repo := newFakeRepo(cand)
-	signer := newFakeSigner(now, now.Add(testSignTTL))
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
 	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)} // allows NO SANs
 	rec := newReconciler(t, repo, signer, authz)
 
@@ -225,7 +226,7 @@ func TestReconcileTTLViolationDoesNotSign(t *testing.T) {
 	now := time.Now()
 	nb, na := dueWindow(now)
 	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
-	signer := newFakeSigner(now, now.Add(testSignTTL))
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
 	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL-time.Hour)} // maxTTL < SignTTL
 	rec := newReconciler(t, repo, signer, authz)
 
@@ -242,7 +243,7 @@ func TestReconcileNotDueSkips(t *testing.T) {
 	now := time.Now()
 	nb, na := notDueWindow(now)
 	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
-	signer := newFakeSigner(now, now.Add(testSignTTL))
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
 	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
 	rec := newReconciler(t, repo, signer, authz)
 
@@ -264,7 +265,7 @@ func TestReconcileNonRenewableStateSkips(t *testing.T) {
 	cand := activeCandidate(t, "device-1", nb, na)
 	cand.State = cl.StateRevoked() // operator terminal — never renewed
 	repo := newFakeRepo(cand)
-	signer := newFakeSigner(now, now.Add(testSignTTL))
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
 	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
 	rec := newReconciler(t, repo, signer, authz)
 
@@ -285,7 +286,7 @@ func TestReconcileExpiredCertReSignsToRecover(t *testing.T) {
 	// Already past notAfter, but active with a valid stored CSR → re-sign to recover.
 	nb, na := now.Add(-100*time.Hour), now.Add(-1*time.Hour)
 	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
-	signer := newFakeSigner(now, now.Add(testSignTTL))
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
 	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
 	rec := newReconciler(t, repo, signer, authz)
 
@@ -307,7 +308,7 @@ func TestReconcileStaleFencedWriteSkipsNoDuplicate(t *testing.T) {
 	if _, err := repo.ApplyFenced(context.Background(), "device-1", 99, "seed-high-epoch"); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	signer := newFakeSigner(now, now.Add(testSignTTL))
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
 	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
 	rec := newReconciler(t, repo, signer, authz)
 
@@ -325,9 +326,9 @@ func TestReconcileInvalidRowTenantSkips(t *testing.T) {
 	now := time.Now()
 	nb, na := dueWindow(now)
 	cand := activeCandidate(t, "device-1", nb, na)
-	cand.TenantID = "not-a-canonical-uuid" // malformed row → identity build fails
+	cand.TenantID = tenant.TenantID("not-a-canonical-uuid") // malformed row → identity build fails
 	repo := newFakeRepo(cand)
-	signer := newFakeSigner(now, now.Add(testSignTTL))
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
 	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
 	rec := newReconciler(t, repo, signer, authz)
 
@@ -352,7 +353,7 @@ func TestReconcileCorruptStoredCSRSkips(t *testing.T) {
 	cand := activeCandidate(t, "device-1", nb, na)
 	cand.CSRDER = []byte("not-a-valid-csr") // unparseable stored CSR → request build fails
 	repo := newFakeRepo(cand)
-	signer := newFakeSigner(now, now.Add(testSignTTL))
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
 	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
 	rec := newReconciler(t, repo, signer, authz)
 
@@ -370,7 +371,7 @@ func TestReconcileCorruptStoredCSRSkips(t *testing.T) {
 func TestNewReconcilerValidatesDeps(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
-	okSigner := newFakeSigner(now, now.Add(testSignTTL))
+	okSigner := newFakeSigner(t, now, now.Add(testSignTTL))
 	okAuthz := &fakeAuthorizer{}
 	okRepo := newFakeRepo()
 	okPolicy := cl.Policy{MaxLookahead: testMaxLookahead, SignTTL: testSignTTL}
@@ -398,12 +399,34 @@ func TestNewReconcilerValidatesDeps(t *testing.T) {
 	}
 }
 
+func TestReconcileScanErrorBubblesTransient(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepo() // candidates irrelevant — the scan itself fails
+	repo.listErr = errFake
+	now := time.Now()
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
+	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
+	rec := newReconciler(t, repo, signer, authz)
+
+	stop := driveLoop(t, rec, repo)
+	defer stop()
+	// A scan error bubbles as transient → the Loop backs off and re-sweeps, so the
+	// scan is retried (listCount climbs past the first attempt). Nothing is signed.
+	waitUntil(t, "scan retried after transient error", func() bool { return repo.listCount() >= 2 })
+	if got := signer.callCount(); got != 0 {
+		t.Errorf("signer called %d times when scan failed, want 0", got)
+	}
+	if got := len(repo.mutations()); got != 0 {
+		t.Errorf("recorded %d mutations when scan failed, want 0", got)
+	}
+}
+
 func TestReconcileNoFencedWriterFailsClosed(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
 	nb, na := dueWindow(now)
 	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
-	signer := newFakeSigner(now, now.Add(testSignTTL))
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
 	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
 	rec := newReconciler(t, repo, signer, authz)
 

--- a/framework/runtime/certlifecycle/reconciler_test.go
+++ b/framework/runtime/certlifecycle/reconciler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/reconcile"
 	"github.com/ghbvf/gocell/framework/kernel/reconcile/reconciletest"
 	"github.com/ghbvf/gocell/framework/pkg/tenant"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/testwait"
 	cl "github.com/ghbvf/gocell/framework/runtime/certlifecycle"
 	cs "github.com/ghbvf/gocell/framework/runtime/certsigning"
 )
@@ -22,18 +23,26 @@ const (
 	// multi-replica test pre-acquires the same key to simulate a handoff. Must
 	// satisfy validateReconcilerID (lowercase [a-z0-9_], leading [a-z_]).
 	testReconcilerID = "certlifecycle_test"
+
+	// Validity-window offsets (TEST-TIME-LITERAL-01: no inline test-time literals).
+	dueElapsed      = 95 * time.Hour // age of a cert past its 70–90% jitter instant
+	dueRemaining    = 5 * time.Hour  // remaining validity of a due (not-yet-expired) cert
+	notDueElapsed   = 1 * time.Hour  // age of a freshly-issued cert
+	notDueRemaining = 99 * time.Hour // remaining validity before the jitter instant
+	expiredElapsed  = 100 * time.Hour
+	expiredAgo      = 1 * time.Hour // how long ago an expired cert's notAfter passed
 )
 
 // dueWindow returns a validity window for which now is past the 70–90% jitter
 // instant (so the cert is due) regardless of the jitter fraction.
 func dueWindow(now time.Time) (notBefore, notAfter time.Time) {
-	return now.Add(-95 * time.Hour), now.Add(5 * time.Hour)
+	return now.Add(-dueElapsed), now.Add(dueRemaining)
 }
 
 // notDueWindow returns a window whose 70–90% instant is comfortably in the
 // future (so the cert is not yet due) even within the scan cutoff.
 func notDueWindow(now time.Time) (notBefore, notAfter time.Time) {
-	return now.Add(-1 * time.Hour), now.Add(99 * time.Hour)
+	return now.Add(-notDueElapsed), now.Add(notDueRemaining)
 }
 
 // newReconciler builds a Reconciler with the given fakes and default policy.
@@ -91,19 +100,6 @@ func driveLoopWithLeader(t *testing.T, rec *cl.Reconciler, repo reconcile.Fenced
 	}
 }
 
-// waitUntil polls cond until true or fails after pollTimeout.
-func waitUntil(t *testing.T, what string, cond func() bool) {
-	t.Helper()
-	deadline := time.Now().Add(pollTimeout)
-	for time.Now().Before(deadline) {
-		if cond() {
-			return
-		}
-		time.Sleep(pollTick)
-	}
-	t.Fatalf("timed out waiting for: %s", what)
-}
-
 func TestReconcileHappyPathRenews(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
@@ -115,7 +111,7 @@ func TestReconcileHappyPathRenews(t *testing.T) {
 
 	stop := driveLoop(t, rec, repo)
 	defer stop()
-	waitUntil(t, "one renewal mutation", func() bool { return len(repo.mutations()) == 1 })
+	testwait.External(t, "renewal-mutation-recorded", func() bool { return len(repo.mutations()) == 1 }, pollTimeout, pollTick)
 
 	mut := firstMutation(t, repo)
 	if mut.TargetEpoch != 2 {
@@ -156,7 +152,7 @@ func TestReconcileSigningFailureDoesNotDamageCert(t *testing.T) {
 	stop := driveLoop(t, rec, repo)
 	defer stop()
 	// Sign is attempted; assert no persisted effect ever (existing cert untouched).
-	waitUntil(t, "signer attempted", func() bool { return signer.callCount() >= 1 })
+	testwait.External(t, "signer-attempted", func() bool { return signer.callCount() >= 1 }, pollTimeout, pollTick)
 	if got := len(repo.mutations()); got != 0 {
 		t.Errorf("recorded %d mutations after signing failure, want 0 (existing cert untouched)", got)
 	}
@@ -173,7 +169,7 @@ func TestReconcileFailClosedDenyDoesNotSign(t *testing.T) {
 
 	stop := driveLoop(t, rec, repo)
 	defer stop()
-	waitUntil(t, "authorizer consulted", func() bool { return authz.callCount() >= 1 })
+	testwait.External(t, "authorizer-consulted", func() bool { return authz.callCount() >= 1 }, pollTimeout, pollTick)
 	if got := signer.callCount(); got != 0 {
 		t.Errorf("signer called %d times under fail-closed deny, want 0", got)
 	}
@@ -193,7 +189,7 @@ func TestReconcileAuthorizeErrorDoesNotSign(t *testing.T) {
 
 	stop := driveLoop(t, rec, repo)
 	defer stop()
-	waitUntil(t, "authorizer consulted", func() bool { return authz.callCount() >= 1 })
+	testwait.External(t, "authorizer-consulted", func() bool { return authz.callCount() >= 1 }, pollTimeout, pollTick)
 	if got := signer.callCount(); got != 0 {
 		t.Errorf("signer called %d times after authorize error, want 0", got)
 	}
@@ -212,7 +208,7 @@ func TestReconcileConstraintViolationDoesNotSign(t *testing.T) {
 
 	stop := driveLoop(t, rec, repo)
 	defer stop()
-	waitUntil(t, "authorizer consulted", func() bool { return authz.callCount() >= 1 })
+	testwait.External(t, "authorizer-consulted", func() bool { return authz.callCount() >= 1 }, pollTimeout, pollTick)
 	if got := signer.callCount(); got != 0 {
 		t.Errorf("signer called %d times on SAN constraint violation, want 0", got)
 	}
@@ -232,7 +228,7 @@ func TestReconcileTTLViolationDoesNotSign(t *testing.T) {
 
 	stop := driveLoop(t, rec, repo)
 	defer stop()
-	waitUntil(t, "authorizer consulted", func() bool { return authz.callCount() >= 1 })
+	testwait.External(t, "authorizer-consulted", func() bool { return authz.callCount() >= 1 }, pollTimeout, pollTick)
 	if got := signer.callCount(); got != 0 {
 		t.Errorf("signer called %d times when SignTTL exceeds grant MaxTTL, want 0", got)
 	}
@@ -249,7 +245,7 @@ func TestReconcileNotDueSkips(t *testing.T) {
 
 	stop := driveLoop(t, rec, repo)
 	defer stop()
-	waitUntil(t, "sweep ran", func() bool { return repo.listCount() >= 1 })
+	testwait.External(t, "sweep-ran", func() bool { return repo.listCount() >= 1 }, pollTimeout, pollTick)
 	if got := authz.callCount(); got != 0 {
 		t.Errorf("authorizer called %d times for not-due cert, want 0", got)
 	}
@@ -271,7 +267,7 @@ func TestReconcileNonRenewableStateSkips(t *testing.T) {
 
 	stop := driveLoop(t, rec, repo)
 	defer stop()
-	waitUntil(t, "sweep ran", func() bool { return repo.listCount() >= 1 })
+	testwait.External(t, "sweep-ran", func() bool { return repo.listCount() >= 1 }, pollTimeout, pollTick)
 	if got := authz.callCount(); got != 0 {
 		t.Errorf("authorizer called %d times for revoked cert, want 0 (observe-and-skip)", got)
 	}
@@ -284,7 +280,7 @@ func TestReconcileExpiredCertReSignsToRecover(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
 	// Already past notAfter, but active with a valid stored CSR → re-sign to recover.
-	nb, na := now.Add(-100*time.Hour), now.Add(-1*time.Hour)
+	nb, na := now.Add(-expiredElapsed), now.Add(-expiredAgo)
 	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
 	signer := newFakeSigner(t, now, now.Add(testSignTTL))
 	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
@@ -292,7 +288,7 @@ func TestReconcileExpiredCertReSignsToRecover(t *testing.T) {
 
 	stop := driveLoop(t, rec, repo)
 	defer stop()
-	waitUntil(t, "expired cert recovered", func() bool { return len(repo.mutations()) == 1 })
+	testwait.External(t, "expired-cert-recovered", func() bool { return len(repo.mutations()) == 1 }, pollTimeout, pollTick)
 	if got := firstMutation(t, repo).TargetEpoch; got != 2 {
 		t.Errorf("recovered cert TargetEpoch = %d, want 2", got)
 	}
@@ -314,7 +310,7 @@ func TestReconcileStaleFencedWriteSkipsNoDuplicate(t *testing.T) {
 
 	stop := driveLoop(t, rec, repo)
 	defer stop()
-	waitUntil(t, "signer attempted", func() bool { return signer.callCount() >= 1 })
+	testwait.External(t, "signer-attempted", func() bool { return signer.callCount() >= 1 }, pollTimeout, pollTick)
 	// The stale write is rejected → no IssuedMutation recorded (only the seed).
 	if got := len(repo.mutations()); got != 0 {
 		t.Errorf("recorded %d IssuedMutations after stale rejection, want 0", got)
@@ -334,7 +330,7 @@ func TestReconcileInvalidRowTenantSkips(t *testing.T) {
 
 	stop := driveLoop(t, rec, repo)
 	defer stop()
-	waitUntil(t, "sweep ran", func() bool { return repo.listCount() >= 1 })
+	testwait.External(t, "sweep-ran", func() bool { return repo.listCount() >= 1 }, pollTimeout, pollTick)
 	if got := authz.callCount(); got != 0 {
 		t.Errorf("authorizer called %d times for malformed-tenant row, want 0 (skip before authorize)", got)
 	}
@@ -359,7 +355,7 @@ func TestReconcileCorruptStoredCSRSkips(t *testing.T) {
 
 	stop := driveLoop(t, rec, repo)
 	defer stop()
-	waitUntil(t, "authorizer consulted", func() bool { return authz.callCount() >= 1 })
+	testwait.External(t, "authorizer-consulted", func() bool { return authz.callCount() >= 1 }, pollTimeout, pollTick)
 	if got := signer.callCount(); got != 0 {
 		t.Errorf("signer called %d times with corrupt stored CSR, want 0", got)
 	}
@@ -412,7 +408,7 @@ func TestReconcileScanErrorBubblesTransient(t *testing.T) {
 	defer stop()
 	// A scan error bubbles as transient → the Loop backs off and re-sweeps, so the
 	// scan is retried (listCount climbs past the first attempt). Nothing is signed.
-	waitUntil(t, "scan retried after transient error", func() bool { return repo.listCount() >= 2 })
+	testwait.External(t, "scan-retried", func() bool { return repo.listCount() >= 2 }, pollTimeout, pollTick)
 	if got := signer.callCount(); got != 0 {
 		t.Errorf("signer called %d times when scan failed, want 0", got)
 	}

--- a/framework/runtime/certlifecycle/reconciler_test.go
+++ b/framework/runtime/certlifecycle/reconciler_test.go
@@ -17,8 +17,11 @@ import (
 const (
 	testMaxLookahead = 30 * 24 * time.Hour
 	testSignTTL      = 24 * time.Hour
-	pollTimeout      = 3 * time.Second
-	pollTick         = 5 * time.Millisecond
+	// testBatchSize is comfortably larger than any single-test candidate count, so
+	// ordinary tests return a partial (non-full) batch and do NOT self-requeue.
+	testBatchSize = 100
+	pollTimeout   = 3 * time.Second
+	pollTick      = 5 * time.Millisecond
 	// testReconcilerID is the lease key the test Loop acquires under; the
 	// multi-replica test pre-acquires the same key to simulate a handoff. Must
 	// satisfy validateReconcilerID (lowercase [a-z0-9_], leading [a-z_]).
@@ -49,7 +52,7 @@ func notDueWindow(now time.Time) (notBefore, notAfter time.Time) {
 func newReconciler(t *testing.T, repo cl.DeviceCertRepository, signer *fakeSigner, authz *fakeAuthorizer) *cl.Reconciler {
 	t.Helper()
 	rec, err := cl.NewReconciler(clock.Real(), repo, signer, authz,
-		cl.Policy{MaxLookahead: testMaxLookahead, SignTTL: testSignTTL}, nil)
+		cl.Policy{MaxLookahead: testMaxLookahead, SignTTL: testSignTTL, BatchSize: testBatchSize}, nil)
 	if err != nil {
 		t.Fatalf("NewReconciler: %v", err)
 	}
@@ -129,6 +132,11 @@ func TestReconcileHappyPathRenews(t *testing.T) {
 	if mut.Serial == "" {
 		t.Error("mutation Serial empty — must carry the issued cert serial")
 	}
+	// actorId is a REQUIRED cert-issued payload field; server-side renewal stamps
+	// the system actor (matches the Loop's installed tenantless system identity).
+	if mut.ActorID != "system" {
+		t.Errorf("mutation ActorID = %q, want %q (system actor for server-side renewal)", mut.ActorID, "system")
+	}
 	// The signing request must carry the row tenant (not an ambient ctx tenant).
 	req, ok := signer.lastRequest()
 	if !ok {
@@ -178,20 +186,26 @@ func TestReconcileFailClosedDenyDoesNotSign(t *testing.T) {
 	}
 }
 
-func TestReconcileAuthorizeErrorDoesNotSign(t *testing.T) {
+func TestReconcileAuthorizeErrorBubblesTransient(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
 	nb, na := dueWindow(now)
 	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
 	signer := newFakeSigner(t, now, now.Add(testSignTTL))
-	authz := &fakeAuthorizer{err: errFake}
+	authz := &fakeAuthorizer{err: errFake} // authorizer/PDP unavailable, not a deny
 	rec := newReconciler(t, repo, signer, authz)
 
 	stop := driveLoop(t, rec, repo)
 	defer stop()
-	testwait.External(t, "authorizer-consulted", func() bool { return authz.callCount() >= 1 }, pollTimeout, pollTick)
+	// An authorizer ERROR is transient (distinct from a policy deny): it bubbles so
+	// the Loop backs off and re-sweeps, so the authorizer is consulted again
+	// (callCount climbs past 1). A silent deny would never retry. Still no signing.
+	testwait.External(t, "authorize-retried", func() bool { return authz.callCount() >= 2 }, pollTimeout, pollTick)
 	if got := signer.callCount(); got != 0 {
 		t.Errorf("signer called %d times after authorize error, want 0", got)
+	}
+	if got := len(repo.mutations()); got != 0 {
+		t.Errorf("recorded %d mutations after authorize error, want 0", got)
 	}
 }
 
@@ -254,25 +268,40 @@ func TestReconcileNotDueSkips(t *testing.T) {
 	}
 }
 
-func TestReconcileNonRenewableStateSkips(t *testing.T) {
+// TestReconcileNonRenewableStatesSkipped pins renewable()=active only: every
+// other state in the closed vocabulary — including expired, whose recovery is the
+// active+past-NotAfter path (TestReconcileExpiredCertReSignsToRecover), NOT a
+// persisted State=expired — is observed-and-skipped, never re-signed.
+func TestReconcileNonRenewableStatesSkipped(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
-	nb, na := dueWindow(now)
-	cand := activeCandidate(t, "device-1", nb, na)
-	cand.State = cl.StateRevoked() // operator terminal — never renewed
-	repo := newFakeRepo(cand)
-	signer := newFakeSigner(t, now, now.Add(testSignTTL))
-	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
-	rec := newReconciler(t, repo, signer, authz)
+	nb, na := dueWindow(now) // due by time, so only the STATE gate can skip it
+	for _, st := range cl.AllStates() {
+		if st == cl.StateActive() {
+			continue // the one renewable state — covered by the happy-path tests
+		}
+		t.Run(st.String(), func(t *testing.T) {
+			t.Parallel()
+			cand := activeCandidate(t, "device-1", nb, na)
+			cand.State = st
+			repo := newFakeRepo(cand)
+			signer := newFakeSigner(t, now, now.Add(testSignTTL))
+			authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
+			rec := newReconciler(t, repo, signer, authz)
 
-	stop := driveLoop(t, rec, repo)
-	defer stop()
-	testwait.External(t, "sweep-ran", func() bool { return repo.listCount() >= 1 }, pollTimeout, pollTick)
-	if got := authz.callCount(); got != 0 {
-		t.Errorf("authorizer called %d times for revoked cert, want 0 (observe-and-skip)", got)
-	}
-	if got := signer.callCount(); got != 0 {
-		t.Errorf("signer called %d times for revoked cert, want 0", got)
+			stop := driveLoop(t, rec, repo)
+			defer stop()
+			testwait.External(t, "sweep-ran", func() bool { return repo.listCount() >= 1 }, pollTimeout, pollTick)
+			if got := authz.callCount(); got != 0 {
+				t.Errorf("authorizer called %d times for state %q, want 0 (renewable()=active only)", got, st)
+			}
+			if got := signer.callCount(); got != 0 {
+				t.Errorf("signer called %d times for state %q, want 0", got, st)
+			}
+			if got := len(repo.mutations()); got != 0 {
+				t.Errorf("recorded %d mutations for state %q, want 0", got, st)
+			}
+		})
 	}
 }
 
@@ -298,10 +327,12 @@ func TestReconcileStaleFencedWriteSkipsNoDuplicate(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
 	nb, na := dueWindow(now)
-	repo := newFakeRepo(activeCandidate(t, "device-1", nb, na))
-	// Seed a higher lease epoch for the entity so the Loop's epoch-1 write is
-	// stale-rejected by the monotonic CAS (zombie-leader scenario).
-	if _, err := repo.ApplyFenced(context.Background(), "device-1", 99, "seed-high-epoch"); err != nil {
+	cand := activeCandidate(t, "device-1", nb, na)
+	repo := newFakeRepo(cand)
+	// Seed a higher lease epoch under the SAME entity key the Reconciler writes
+	// (the composite cand.EntityKey, not the bare deviceID) so the Loop's epoch-1
+	// write is stale-rejected by the monotonic CAS (zombie-leader scenario).
+	if _, err := repo.ApplyFenced(context.Background(), cand.EntityKey(), 99, "seed-high-epoch"); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	signer := newFakeSigner(t, now, now.Add(testSignTTL))
@@ -314,6 +345,36 @@ func TestReconcileStaleFencedWriteSkipsNoDuplicate(t *testing.T) {
 	// The stale write is rejected → no IssuedMutation recorded (only the seed).
 	if got := len(repo.mutations()); got != 0 {
 		t.Errorf("recorded %d IssuedMutations after stale rejection, want 0", got)
+	}
+}
+
+// TestReconcileMultiTenantSameDeviceNoCollision proves the fenced entity key
+// encodes the full {tenant,issuer,device} identity: two tenants sharing one
+// deviceID write under DISTINCT keys, so neither stale-rejects the other and both
+// renew (the cross-tenant epoch-collision F2 guards against).
+func TestReconcileMultiTenantSameDeviceNoCollision(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	nb, na := dueWindow(now)
+	candA := activeCandidateForTenant(t, testTenant, "device-1", nb, na)
+	candB := activeCandidateForTenant(t, testTenant2, "device-1", nb, na)
+	if candA.EntityKey() == candB.EntityKey() {
+		t.Fatalf("same-device candidates share an EntityKey %q — tenant not encoded", candA.EntityKey())
+	}
+	repo := newFakeRepo(candA, candB)
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
+	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
+	rec := newReconciler(t, repo, signer, authz)
+
+	stop := driveLoop(t, rec, repo)
+	defer stop()
+	testwait.External(t, "both-tenants-renewed", func() bool { return len(repo.mutations()) == 2 }, pollTimeout, pollTick)
+	tenants := map[string]bool{}
+	for _, m := range repo.mutations() {
+		tenants[string(m.TenantID)] = true
+	}
+	if !tenants[testTenant] || !tenants[testTenant2] {
+		t.Errorf("renewed tenants = %v, want both %q and %q (no cross-tenant stale rejection)", tenants, testTenant, testTenant2)
 	}
 }
 
@@ -364,13 +425,41 @@ func TestReconcileCorruptStoredCSRSkips(t *testing.T) {
 	}
 }
 
+// TestReconcileFullBatchBoundsScanAndDrains proves F5: the scan is capped at
+// Policy.BatchSize, and a FULL batch self-requeues to drain the backlog (the only
+// re-sweep driver besides the single submitted pulse in this fake-trigger setup).
+func TestReconcileFullBatchBoundsScanAndDrains(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	nb, na := dueWindow(now)
+	const batch = 2
+	repo := newFakeRepo(
+		activeCandidate(t, "device-1", nb, na),
+		activeCandidate(t, "device-2", nb, na),
+	)
+	signer := newFakeSigner(t, now, now.Add(testSignTTL))
+	authz := &fakeAuthorizer{grant: grantAll(t, testSignTTL)}
+	rec, err := cl.NewReconciler(clock.Real(), repo, signer, authz,
+		cl.Policy{MaxLookahead: testMaxLookahead, SignTTL: testSignTTL, BatchSize: batch}, nil)
+	if err != nil {
+		t.Fatalf("NewReconciler: %v", err)
+	}
+
+	stop := driveLoop(t, rec, repo)
+	defer stop()
+	testwait.External(t, "full-batch-drained", func() bool { return repo.listCount() >= 2 }, pollTimeout, pollTick)
+	if got := repo.lastListLimit(); got != batch {
+		t.Errorf("scan limit = %d, want %d (Policy.BatchSize bounds the scan)", got, batch)
+	}
+}
+
 func TestNewReconcilerValidatesDeps(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
 	okSigner := newFakeSigner(t, now, now.Add(testSignTTL))
 	okAuthz := &fakeAuthorizer{}
 	okRepo := newFakeRepo()
-	okPolicy := cl.Policy{MaxLookahead: testMaxLookahead, SignTTL: testSignTTL}
+	okPolicy := cl.Policy{MaxLookahead: testMaxLookahead, SignTTL: testSignTTL, BatchSize: testBatchSize}
 
 	cases := []struct {
 		name   string
@@ -382,8 +471,9 @@ func TestNewReconcilerValidatesDeps(t *testing.T) {
 		{"nil repo", nil, okSigner, okAuthz, okPolicy},
 		{"nil signer", okRepo, nil, okAuthz, okPolicy},
 		{"nil authorizer", okRepo, okSigner, nil, okPolicy},
-		{"zero MaxLookahead", okRepo, okSigner, okAuthz, cl.Policy{SignTTL: testSignTTL}},
-		{"zero SignTTL", okRepo, okSigner, okAuthz, cl.Policy{MaxLookahead: testMaxLookahead}},
+		{"zero MaxLookahead", okRepo, okSigner, okAuthz, cl.Policy{SignTTL: testSignTTL, BatchSize: testBatchSize}},
+		{"zero SignTTL", okRepo, okSigner, okAuthz, cl.Policy{MaxLookahead: testMaxLookahead, BatchSize: testBatchSize}},
+		{"zero BatchSize", okRepo, okSigner, okAuthz, cl.Policy{MaxLookahead: testMaxLookahead, SignTTL: testSignTTL}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/framework/runtime/certlifecycle/repository.go
+++ b/framework/runtime/certlifecycle/repository.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ghbvf/gocell/framework/kernel/reconcile"
+	"github.com/ghbvf/gocell/framework/pkg/tenant"
 )
 
 // Candidate is the projection [DeviceCertRepository.ListRenewalCandidates]
@@ -20,9 +21,11 @@ type Candidate struct {
 	// subject device.
 	DeviceID string
 	// TenantID is the isolation domain of this certificate, sourced from the row
-	// (NOT ctx). It flows into the CertScope/DeviceSubject and the cert-issued
-	// event so a multi-tenant reconciler keeps tenants distinct.
-	TenantID string
+	// (NOT ctx). Typed (tenancy.md FR-003: repo/service APIs carry typed tenant,
+	// not a bare string) so the consumer must parse/validate at the row boundary;
+	// it flows into the CertScope/DeviceSubject and the cert-issued event so a
+	// multi-tenant reconciler keeps tenants distinct.
+	TenantID tenant.TenantID
 	// IssuerID identifies the issuing CA for the scope.
 	IssuerID string
 	// Serial is the current certificate's serial — the stable per-certificate
@@ -70,9 +73,10 @@ type Candidate struct {
 // reconciler.
 type IssuedMutation struct {
 	// DeviceID / TenantID / IssuerID / Serial identify the issued certificate for
-	// both the row and the cert-issued event's certRef.
+	// both the row and the cert-issued event's certRef. TenantID is typed
+	// (tenancy.md FR-003) so the consumer's ApplyFenced writes a validated tenant.
 	DeviceID string
-	TenantID string
+	TenantID tenant.TenantID
 	IssuerID string
 	Serial   string
 	// TargetEpoch is the renewed generation (Candidate.Epoch+1) — the cert epoch
@@ -112,20 +116,34 @@ type DeviceCertRepository interface {
 	// before cutoff AND whose State is renewable (active), in a deterministic
 	// order (NotAfter ascending, then DeviceID). It is a bounded full sweep per
 	// tick (the cutoff bounds the scan; there is no LIMIT) — the precise per-cert
-	// 70–90% jitter decision is applied by the Reconciler, not the scan.
+	// 70–90% jitter decision is applied by the Reconciler, not the scan. The
+	// implementation returns only State=active rows: near-expiry / renewing are
+	// computed in-memory by the Reconciler and never persisted, so the consumer
+	// does NOT write those states.
 	ListRenewalCandidates(ctx context.Context, cutoff time.Time) ([]Candidate, error)
 
 	// ApplyFenced is the reconcile.FencedRepository monotonic-epoch CAS. The Loop
 	// (via FencedWriter) calls it with the LEASE epoch as the fencing token; the
 	// implementation MUST apply the write only when epoch >= the highest lease
 	// epoch seen for entityID (advancing it), returning accepted=false (NOT an
-	// error) on a stale epoch so a zombie leader's late write is rejected. mutation
-	// is an *IssuedMutation; the implementation type-asserts it and, in ONE local
-	// transaction, persists the certificate row (advancing the CERT epoch to
-	// IssuedMutation.TargetEpoch and the state to NewState) AND writes the
-	// cert-issued L2 outbox entry. The two epochs are distinct monotonic counters:
-	// the LEASE epoch (this param) fences cross-replica ordering; the CERT epoch
-	// (mutation.TargetEpoch) tracks renewal generations on the row.
+	// error) on a stale epoch so a zombie leader's late write is rejected.
+	//
+	// CONTRACT (L2 atomicity — load-bearing): mutation is an *IssuedMutation; the
+	// implementation type-asserts it and, in ONE local transaction, persists the
+	// certificate row (advancing the CERT epoch to IssuedMutation.TargetEpoch and
+	// the state to NewState) AND writes the event.deviceidentity.cert-issued.v1 L2
+	// outbox entry (Action=renewed). This single-transaction co-write IS the L2
+	// guarantee: an implementation that writes the row but NOT the outbox entry (or
+	// writes them in separate transactions) silently downgrades the lifecycle to
+	// L1 — the cert-issued event is lost with no retry path once the transaction
+	// commits. The Reconciler cannot do this co-write itself (the only transaction
+	// is the consumer's, and the framework module cannot import the generated
+	// contract types), so it carries every cert-issued field on IssuedMutation and
+	// relies on this contract.
+	//
+	// The two epochs are distinct monotonic counters: the LEASE epoch (this param)
+	// fences cross-replica ordering; the CERT epoch (mutation.TargetEpoch) tracks
+	// renewal generations on the row.
 	reconcile.FencedRepository
 }
 

--- a/framework/runtime/certlifecycle/repository.go
+++ b/framework/runtime/certlifecycle/repository.go
@@ -1,0 +1,134 @@
+package certlifecycle
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"time"
+
+	"github.com/ghbvf/gocell/framework/kernel/reconcile"
+)
+
+// Candidate is the projection [DeviceCertRepository.ListRenewalCandidates]
+// returns: everything the Reconciler needs to make the renewal decision and
+// rebuild a certsigning.CertRequest, WITHOUT reading the reconcile ctx for the
+// tenant. The reconcile Loop installs a tenantless system identity at its
+// chokepoint (#1821), so the tenant dimension MUST come from the scanned row
+// (TenantID below), never from ctx.
+type Candidate struct {
+	// DeviceID is the entity locator: the FencedWriter Write key and the cert
+	// subject device.
+	DeviceID string
+	// TenantID is the isolation domain of this certificate, sourced from the row
+	// (NOT ctx). It flows into the CertScope/DeviceSubject and the cert-issued
+	// event so a multi-tenant reconciler keeps tenants distinct.
+	TenantID string
+	// IssuerID identifies the issuing CA for the scope.
+	IssuerID string
+	// Serial is the current certificate's serial — the stable per-certificate
+	// identity for the deterministic renewal jitter (so each generation jitters to
+	// its own instant) and for diagnostics.
+	Serial string
+	// Epoch is the current certificate generation (monotonic per device). The
+	// renewed generation is Epoch+1.
+	Epoch uint64
+	// NotBefore / NotAfter is the current certificate's validity window, used by
+	// the deterministic jitter decision (70–90% lifetime model).
+	NotBefore time.Time
+	NotAfter  time.Time
+	// State is the current lifecycle state. The Reconciler renews only active
+	// certificates (State.renewable); revoked / pre-active rows are skipped.
+	State State
+	// CommonName is the X.509 subject CN for the renewed certificate.
+	CommonName string
+	// CSRDER is the device's STORED PKCS#10 CSR (DER). Server-side renewal
+	// re-signs this same CSR (same public key) with a fresh validity window — the
+	// device's private key never leaves the device. NewCertRequest re-verifies its
+	// proof-of-possession at construction.
+	CSRDER []byte
+	// DNSNames / IPAddresses / URIs are the requested subject alternative names,
+	// rebuilt into a certsigning.SubjectAltNames for the renewal request.
+	DNSNames    []string
+	IPAddresses []net.IP
+	URIs        []*url.URL
+}
+
+// IssuedMutation is the payload of the Reconciler's single fenced write. It
+// carries BOTH the persisted certificate material AND every field of the
+// event.deviceidentity.cert-issued.v1 L2 fact, because the consumer's
+// [DeviceCertRepository.ApplyFenced] persists the certificate row and writes the
+// cert-issued outbox entry ATOMICALLY in one local transaction (L2 = local tx +
+// outbox). The Reconciler never calls outbox.Emit itself: the only transaction
+// is the consumer's, and emitting outside it would break L2 atomicity (a crash
+// between a separate persist and emit would drop the at-least-once event). This
+// is the FencedRepository-sanctioned "device writes / command emission from
+// inside Reconcile" via the single fenced write surface.
+//
+// The cert-issued action for a Reconciler-driven write is always "renewed" (the
+// Reconciler only renews; enrollment is the EST path), so it is not a field here
+// — the consumer stamps Action=renewed when ApplyFenced is driven by this
+// reconciler.
+type IssuedMutation struct {
+	// DeviceID / TenantID / IssuerID / Serial identify the issued certificate for
+	// both the row and the cert-issued event's certRef.
+	DeviceID string
+	TenantID string
+	IssuerID string
+	Serial   string
+	// TargetEpoch is the renewed generation (Candidate.Epoch+1) — the cert epoch
+	// the row advances to and the cert-issued event's epoch. NOTE: this is the
+	// CERT epoch, distinct from the LEASE epoch the FencedWriter passes to
+	// ApplyFenced as the fencing token (see ApplyFenced).
+	TargetEpoch uint64
+	// CertDER / ChainDER is the newly minted certificate and its intermediate
+	// chain (DER), persisted on the row.
+	CertDER  []byte
+	ChainDER [][]byte
+	// NotBefore / NotAfter is the renewed validity window, persisted on the row
+	// and carried on the cert-issued event.
+	NotBefore time.Time
+	NotAfter  time.Time
+	// NewState is the row's lifecycle state after the renewal — StateActive: the
+	// renewed generation is immediately active (a renewed cert is not a terminal
+	// "rotated" row; rotated/expired are vocabulary, not persisted by renewal).
+	NewState State
+}
+
+// DeviceCertRepository is the consumer-implemented persistence + scan seam for
+// the cert-lifecycle Reconciler. It has exactly two methods, which makes the
+// fenced ApplyFenced the STRUCTURAL single write surface — there is no other
+// write method the Reconciler could call to bypass the fencing CAS.
+//
+// It also IS a reconcile.FencedRepository (it declares ApplyFenced with the
+// reconcile signature), so the construction site passes the same value to both
+// the Reconciler (for ListRenewalCandidates) and reconcile.New(...).
+// WithFencedRepo(repo) (so the Loop mints the epoch-bound FencedWriter over it).
+// The Reconciler NEVER calls ApplyFenced directly
+// (RECONCILE-FENCED-WRITE-FUNNEL-01): it writes exclusively through
+// reconcile.FencedWriterFrom(ctx).Write — declaring the method is legal; calling
+// it from outside the sanctioned funnel is not.
+type DeviceCertRepository interface {
+	// ListRenewalCandidates returns all certificates whose NotAfter is at or
+	// before cutoff AND whose State is renewable (active), in a deterministic
+	// order (NotAfter ascending, then DeviceID). It is a bounded full sweep per
+	// tick (the cutoff bounds the scan; there is no LIMIT) — the precise per-cert
+	// 70–90% jitter decision is applied by the Reconciler, not the scan.
+	ListRenewalCandidates(ctx context.Context, cutoff time.Time) ([]Candidate, error)
+
+	// ApplyFenced is the reconcile.FencedRepository monotonic-epoch CAS. The Loop
+	// (via FencedWriter) calls it with the LEASE epoch as the fencing token; the
+	// implementation MUST apply the write only when epoch >= the highest lease
+	// epoch seen for entityID (advancing it), returning accepted=false (NOT an
+	// error) on a stale epoch so a zombie leader's late write is rejected. mutation
+	// is an *IssuedMutation; the implementation type-asserts it and, in ONE local
+	// transaction, persists the certificate row (advancing the CERT epoch to
+	// IssuedMutation.TargetEpoch and the state to NewState) AND writes the
+	// cert-issued L2 outbox entry. The two epochs are distinct monotonic counters:
+	// the LEASE epoch (this param) fences cross-replica ordering; the CERT epoch
+	// (mutation.TargetEpoch) tracks renewal generations on the row.
+	reconcile.FencedRepository
+}
+
+// Compile-time proof that DeviceCertRepository embeds the fenced-repository seam,
+// so a value implementing it can be wired via reconcile.WithFencedRepo.
+var _ reconcile.FencedRepository = (DeviceCertRepository)(nil)

--- a/framework/runtime/certlifecycle/repository.go
+++ b/framework/runtime/certlifecycle/repository.go
@@ -17,8 +17,10 @@ import (
 // chokepoint (#1821), so the tenant dimension MUST come from the scanned row
 // (TenantID below), never from ctx.
 type Candidate struct {
-	// DeviceID is the entity locator: the FencedWriter Write key and the cert
-	// subject device.
+	// DeviceID is the cert subject device. It is NOT the fenced-write key on its
+	// own: the FencedWriter entity key is the composite Candidate.EntityKey
+	// (tenant|issuer|device) so a multi-tenant sweep never collides two tenants
+	// that share a deviceID on one epoch namespace.
 	DeviceID string
 	// TenantID is the isolation domain of this certificate, sourced from the row
 	// (NOT ctx). Typed (tenancy.md FR-003: repo/service APIs carry typed tenant,
@@ -56,6 +58,21 @@ type Candidate struct {
 	URIs        []*url.URL
 }
 
+// EntityKey is the reconcile FencedWriter entity key for this candidate's
+// certificate — the full isolation identity tenant|issuer|device, NOT the bare
+// DeviceID. Encoding all three keeps the monotonic lease-epoch CAS namespace
+// PER-CERTIFICATE so a TenantScoped reconciler never lets two tenants that share
+// a deviceID collide on one epoch space (where one tenant's renewal would
+// stale-reject the other's). For a SingleTenant deployment the deviceID is
+// already globally unique, so the extra dimensions are harmless. The three
+// components are validated identifiers (canonical-UUID tenant, NewIssuerID /
+// NewDeviceID-shaped issuer and device), none of which can contain the '|'
+// separator, so the encoding is unambiguous. This is also the entityID the
+// consumer's ApplyFenced receives.
+func (c Candidate) EntityKey() string {
+	return string(c.TenantID) + "|" + c.IssuerID + "|" + c.DeviceID
+}
+
 // IssuedMutation is the payload of the Reconciler's single fenced write. It
 // carries BOTH the persisted certificate material AND every field of the
 // event.deviceidentity.cert-issued.v1 L2 fact, because the consumer's
@@ -79,6 +96,15 @@ type IssuedMutation struct {
 	TenantID tenant.TenantID
 	IssuerID string
 	Serial   string
+	// ActorID is the principal that triggered issuance — a REQUIRED field of the
+	// cert-issued payload schema. Server-side renewal has no request principal, so
+	// the Reconciler stamps the system actor ("system"), which matches the
+	// tenantless system identity the reconcile Loop installs on the ctx (#1821):
+	// the payload's actorId therefore equals the outbox envelope's principal
+	// actorId by construction. The consumer maps this onto the generated payload's
+	// actorId; the framework module cannot import the generated type, so it must
+	// ride on the mutation rather than being derived consumer-side.
+	ActorID string
 	// TargetEpoch is the renewed generation (Candidate.Epoch+1) — the cert epoch
 	// the row advances to and the cert-issued event's epoch. NOTE: this is the
 	// CERT epoch, distinct from the LEASE epoch the FencedWriter passes to
@@ -112,15 +138,18 @@ type IssuedMutation struct {
 // reconcile.FencedWriterFrom(ctx).Write — declaring the method is legal; calling
 // it from outside the sanctioned funnel is not.
 type DeviceCertRepository interface {
-	// ListRenewalCandidates returns all certificates whose NotAfter is at or
-	// before cutoff AND whose State is renewable (active), in a deterministic
-	// order (NotAfter ascending, then DeviceID). It is a bounded full sweep per
-	// tick (the cutoff bounds the scan; there is no LIMIT) — the precise per-cert
-	// 70–90% jitter decision is applied by the Reconciler, not the scan. The
-	// implementation returns only State=active rows: near-expiry / renewing are
-	// computed in-memory by the Reconciler and never persisted, so the consumer
-	// does NOT write those states.
-	ListRenewalCandidates(ctx context.Context, cutoff time.Time) ([]Candidate, error)
+	// ListRenewalCandidates returns certificates whose NotAfter is at or before
+	// cutoff AND whose State is renewable (active), in a deterministic order
+	// (NotAfter ascending, then DeviceID), capped at limit rows (the SQL LIMIT).
+	// The scan is bounded on BOTH axes: the cutoff bounds WHICH certs are due, and
+	// limit bounds HOW MANY a single sweep loads + signs, so a large backlog cannot
+	// load and serially sign every candidate in one tick. The Reconciler drains a
+	// full batch across sweeps (it self-requeues when the returned slice fills the
+	// limit). The precise per-cert 70–90% jitter decision is applied by the
+	// Reconciler, not the scan. The implementation returns only State=active rows:
+	// near-expiry / renewing are computed in-memory by the Reconciler and never
+	// persisted, so the consumer does NOT write those states.
+	ListRenewalCandidates(ctx context.Context, cutoff time.Time, limit int) ([]Candidate, error)
 
 	// ApplyFenced is the reconcile.FencedRepository monotonic-epoch CAS. The Loop
 	// (via FencedWriter) calls it with the LEASE epoch as the fencing token; the

--- a/framework/runtime/certlifecycle/state.go
+++ b/framework/runtime/certlifecycle/state.go
@@ -67,11 +67,24 @@ func (s State) String() string { return s.v }
 func (s State) IsZero() bool { return s.v == "" }
 
 // renewable reports whether the Reconciler should attempt to renew a certificate
-// in this state. Only active certificates are renewed: revoked is a terminal the
-// Reconciler observes-and-skips, and the pre-active (requested/issued) and
-// derived/terminal (near-expiry/renewing/rotated/expired) states are out of the
-// PR-7 renewal sweep's scope. This is the single behavioral gate the Reconciler
-// consults so a revoked/pre-active cert is never re-signed.
+// in this state. ONLY active is renewable, and that is coherent with the rest of
+// the model — it is not a missed case:
+//
+//   - The scan (ListRenewalCandidates) returns ONLY State=active rows, so a
+//     persisted non-active state never reaches this gate in production; the gate
+//     is defense-in-depth that keeps a revoked / pre-active cert from ever being
+//     re-signed even if a consumer hands one to reconcileOne.
+//   - "Expired-cert recovery" does NOT mean renewing a State=expired row. A cert
+//     past its NotAfter is still State=active until something flips it, so the
+//     Reconciler recovers it via the active + past-NotAfter path in reconcileOne
+//     (it re-signs the stored CSR). expired/rotated are event/observation
+//     vocabulary, not persisted renewal inputs (see the State type doc); a row
+//     persisted as expired is intentionally left for an operator/EST path, not
+//     auto-renewed here.
+//   - near-expiry / renewing are DERIVED / in-flight (computed per tick, never
+//     persisted), so they are never a stored gate input either.
+//
+// This is the single behavioral gate the Reconciler consults.
 func (s State) renewable() bool { return s.v == stateActive }
 
 // ParseState resolves a persisted-row string to its State, reporting ok=false

--- a/framework/runtime/certlifecycle/state.go
+++ b/framework/runtime/certlifecycle/state.go
@@ -1,0 +1,98 @@
+package certlifecycle
+
+// State is the sealed certificate-lifecycle state — the closed vocabulary of a
+// device certificate's life: requested → issued → active → near-expiry →
+// renewing → {rotated | revoked | expired}. It is a struct with a single
+// unexported field, so a populated composite literal outside this package is a
+// compile error (type-system Hard closed value-set): the only way to obtain a
+// State is one of the accessor functions below or ParseState. This mirrors the
+// reconcile.Tenancy / certsigning newtype convention — accessor funcs (not
+// exported vars) keep the values immutable to importers.
+//
+// # The eight states are the lifecycle VOCABULARY, not all reconciler-driven
+//
+// The full eight-state machine is the issue-specified lifecycle model. PR-7's
+// Reconciler behaviorally distinguishes only three classes:
+//
+//   - active   — the steady state the Reconciler renews (and maintains: a
+//     successful renewal writes the new generation back as active). renewable.
+//   - revoked  — an operator/PDP terminal the Reconciler OBSERVES and skips: a
+//     revoked certificate is never renewed. NOT renewable.
+//   - everything else (requested, issued, near-expiry, renewing, rotated,
+//     expired) — NOT acted on by PR-7's renewal sweep:
+//     · requested / issued are the EST-enroll pre-active transitions (PR-8),
+//     set externally; the Reconciler skips a cert not yet active.
+//     · near-expiry / renewing are DERIVED / in-flight — the Reconciler
+//     computes near-expiry from (notAfter, jitter) per tick rather than
+//     persisting it, and renewing is a transient in-memory phase of one
+//     Reconcile; neither is written back to the row.
+//     · rotated / expired are event/observation vocabulary, not row states the
+//     Reconciler persists (a renewed cert is written back as active, and an
+//     expired-but-recoverable cert is re-signed rather than marked dead).
+//
+// So the persisted-row states PR-7 reads/writes are active (maintained) and
+// revoked (observed); the remaining values exist so future PRs (enroll,
+// revocation) populate the same closed vocabulary.
+type State struct{ v string }
+
+// The closed value-set. Each accessor returns the canonical State; there is no
+// exported variable to reassign and no exported field to set.
+func StateRequested() State  { return State{v: stateRequested} }
+func StateIssued() State     { return State{v: stateIssued} }
+func StateActive() State     { return State{v: stateActive} }
+func StateNearExpiry() State { return State{v: stateNearExpiry} }
+func StateRenewing() State   { return State{v: stateRenewing} }
+func StateRotated() State    { return State{v: stateRotated} }
+func StateRevoked() State    { return State{v: stateRevoked} }
+func StateExpired() State    { return State{v: stateExpired} }
+
+// stateValue literals — the single source for the wire/DB string of each state
+// (snake-free dotted-free lower kebab, matching the lifecycle vocabulary names).
+const (
+	stateRequested  = "requested"
+	stateIssued     = "issued"
+	stateActive     = "active"
+	stateNearExpiry = "near-expiry"
+	stateRenewing   = "renewing"
+	stateRotated    = "rotated"
+	stateRevoked    = "revoked"
+	stateExpired    = "expired"
+)
+
+// String returns the canonical lifecycle string (empty for the zero value).
+func (s State) String() string { return s.v }
+
+// IsZero reports whether s is the invalid zero value (no accessor / ParseState
+// produced it).
+func (s State) IsZero() bool { return s.v == "" }
+
+// renewable reports whether the Reconciler should attempt to renew a certificate
+// in this state. Only active certificates are renewed: revoked is a terminal the
+// Reconciler observes-and-skips, and the pre-active (requested/issued) and
+// derived/terminal (near-expiry/renewing/rotated/expired) states are out of the
+// PR-7 renewal sweep's scope. This is the single behavioral gate the Reconciler
+// consults so a revoked/pre-active cert is never re-signed.
+func (s State) renewable() bool { return s.v == stateActive }
+
+// ParseState resolves a persisted-row string to its State, reporting ok=false
+// for any value outside the closed set (fail-closed hydration — an unknown row
+// state never silently becomes a valid State).
+func ParseState(s string) (State, bool) {
+	switch s {
+	case stateRequested, stateIssued, stateActive, stateNearExpiry,
+		stateRenewing, stateRotated, stateRevoked, stateExpired:
+		return State{v: s}, true
+	default:
+		return State{}, false
+	}
+}
+
+// AllStates returns the closed value-set in lifecycle order. It exists for
+// table-driven tests and completeness checks (a new state added to one place but
+// not here fails the AllStates length assertion).
+func AllStates() []State {
+	return []State{
+		StateRequested(), StateIssued(), StateActive(), StateNearExpiry(),
+		StateRenewing(), StateRotated(), StateRevoked(), StateExpired(),
+	}
+}

--- a/framework/runtime/certlifecycle/state_test.go
+++ b/framework/runtime/certlifecycle/state_test.go
@@ -1,0 +1,84 @@
+package certlifecycle
+
+import "testing"
+
+func TestStateClosedValueSet(t *testing.T) {
+	t.Parallel()
+	// AllStates is the completeness anchor: a state added to the type but not to
+	// AllStates (or vice versa) fails here.
+	if got := len(AllStates()); got != 8 {
+		t.Fatalf("AllStates length = %d, want 8 (closed lifecycle vocabulary)", got)
+	}
+	// Every AllStates entry must round-trip through its canonical string.
+	for _, s := range AllStates() {
+		if s.IsZero() {
+			t.Errorf("AllStates contains the zero State (string=%q)", s.String())
+		}
+		got, ok := ParseState(s.String())
+		if !ok {
+			t.Errorf("ParseState(%q) ok=false, want true", s.String())
+			continue
+		}
+		if got != s {
+			t.Errorf("ParseState(%q) = %+v, want %+v (round-trip)", s.String(), got, s)
+		}
+	}
+}
+
+func TestParseStateRejectsUnknown(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{"", "bogus", "Active", "ACTIVE", "renew", "near_expiry"} {
+		if got, ok := ParseState(in); ok {
+			t.Errorf("ParseState(%q) ok=true (got %+v), want fail-closed false", in, got)
+		}
+	}
+}
+
+func TestStateZeroValue(t *testing.T) {
+	t.Parallel()
+	var z State
+	if !z.IsZero() {
+		t.Error("zero State.IsZero() = false, want true")
+	}
+	if z.String() != "" {
+		t.Errorf("zero State.String() = %q, want empty", z.String())
+	}
+	if z.renewable() {
+		t.Error("zero State.renewable() = true, want false (fail-closed)")
+	}
+}
+
+func TestStateRenewableTruthTable(t *testing.T) {
+	t.Parallel()
+	// Only active is renewable; every other state (incl. revoked terminal and the
+	// pre-active / derived states) must be skipped by the renewal sweep.
+	cases := []struct {
+		state State
+		want  bool
+	}{
+		{StateRequested(), false},
+		{StateIssued(), false},
+		{StateActive(), true},
+		{StateNearExpiry(), false},
+		{StateRenewing(), false},
+		{StateRotated(), false},
+		{StateRevoked(), false},
+		{StateExpired(), false},
+	}
+	for _, tc := range cases {
+		if got := tc.state.renewable(); got != tc.want {
+			t.Errorf("State(%q).renewable() = %v, want %v", tc.state.String(), got, tc.want)
+		}
+	}
+}
+
+func TestStateAccessorsDistinct(t *testing.T) {
+	t.Parallel()
+	seen := map[string]bool{}
+	for _, s := range AllStates() {
+		if seen[s.String()] {
+			t.Errorf("duplicate state string %q across accessors", s.String())
+		}
+		seen[s.String()] = true
+	}
+}

--- a/framework/runtime/certlifecycle/testsupport_test.go
+++ b/framework/runtime/certlifecycle/testsupport_test.go
@@ -1,0 +1,225 @@
+package certlifecycle_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/framework/kernel/reconcile/reconciletest"
+	cl "github.com/ghbvf/gocell/framework/runtime/certlifecycle"
+	cs "github.com/ghbvf/gocell/framework/runtime/certsigning"
+)
+
+const (
+	testTenant = "11111111-1111-1111-1111-111111111111"
+	testIssuer = "ca-test"
+)
+
+// errFake is a reusable error for fake failure injection.
+var errFake = errors.New("fake failure")
+
+// deviceCSR generates a POP-valid PKCS#10 CSR DER for cn (self-signed by a fresh
+// ecdsa key, so certsigning.NewCertRequest's CheckSignature passes).
+func deviceCSR(t *testing.T, cn string) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen csr key: %v", err)
+	}
+	der, err := x509.CreateCertificateRequest(rand.Reader,
+		&x509.CertificateRequest{Subject: pkix.Name{CommonName: cn}}, key)
+	if err != nil {
+		t.Fatalf("create csr: %v", err)
+	}
+	return der
+}
+
+// leafCertDER builds a parseable self-signed leaf certificate DER with the given
+// CN, serial and validity window — for the fakeSigner to wrap in an IssuedCert
+// (NewIssuedCert parses it to derive serial / notBefore / notAfter).
+func leafCertDER(cn string, serial int64, notBefore, notAfter time.Time) []byte {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(serial),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		panic(err)
+	}
+	return der
+}
+
+// fakeSigner is a certsigning.Signer minting an IssuedCert from a per-call leaf
+// DER. It records every AuthorizedCertRequest and can be configured to fail.
+type fakeSigner struct {
+	mu        sync.Mutex
+	err       error
+	notBefore time.Time
+	notAfter  time.Time
+	serial    int64
+	requests  []cs.AuthorizedCertRequest
+	calls     int
+}
+
+func newFakeSigner(notBefore, notAfter time.Time) *fakeSigner {
+	return &fakeSigner{notBefore: notBefore, notAfter: notAfter, serial: 1000}
+}
+
+func (s *fakeSigner) Sign(_ context.Context, req cs.AuthorizedCertRequest) (cs.IssuedCert, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	s.requests = append(s.requests, req)
+	if s.err != nil {
+		return cs.IssuedCert{}, s.err
+	}
+	s.serial++
+	der := leafCertDER(req.Request().Subject().CommonName(), s.serial, s.notBefore, s.notAfter)
+	issued, err := cs.NewIssuedCert(req.Request().Scope(), der, nil, 0)
+	if err != nil {
+		panic(err)
+	}
+	return issued, nil
+}
+
+func (s *fakeSigner) TrustBundle(context.Context) ([][]byte, error) { return nil, nil }
+
+func (s *fakeSigner) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+func (s *fakeSigner) lastRequest() (cs.AuthorizedCertRequest, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.requests) == 0 {
+		return cs.AuthorizedCertRequest{}, false
+	}
+	return s.requests[len(s.requests)-1], true
+}
+
+// fakeAuthorizer is a certsigning.Authorizer with a configurable outcome.
+type fakeAuthorizer struct {
+	mu    sync.Mutex
+	grant cs.SignConstraints
+	err   error
+	calls int
+}
+
+func (a *fakeAuthorizer) AuthorizeEnroll(context.Context, cs.EnrollmentClaim) (cs.SignConstraints, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.calls++
+	return a.grant, a.err
+}
+
+func (a *fakeAuthorizer) callCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.calls
+}
+
+// grantAll returns a granted SignConstraints with maxTTL and no SAN allowance
+// (empty allowed SANs accommodates an empty requested SAN set).
+func grantAll(t *testing.T, maxTTL time.Duration) cs.SignConstraints {
+	t.Helper()
+	emptySANs, err := cs.NewSubjectAltNames(nil, nil, nil)
+	if err != nil {
+		t.Fatalf("empty SANs: %v", err)
+	}
+	grant, err := cs.NewSignConstraints(maxTTL, emptySANs)
+	if err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	return grant
+}
+
+// fakeRepo embeds the kernel fenced-repository fake (monotonic CAS + Effects) and
+// adds ListRenewalCandidates. It is BOTH the cl.DeviceCertRepository the
+// Reconciler holds AND the reconcile.FencedRepository the Loop writes through.
+type fakeRepo struct {
+	*reconciletest.FakeFencedRepository
+	mu         sync.Mutex
+	candidates []cl.Candidate
+	listErr    error
+	listCalls  int
+}
+
+func newFakeRepo(candidates ...cl.Candidate) *fakeRepo {
+	return &fakeRepo{
+		FakeFencedRepository: reconciletest.NewFakeFencedRepository(),
+		candidates:           candidates,
+	}
+}
+
+func (r *fakeRepo) ListRenewalCandidates(context.Context, time.Time) ([]cl.Candidate, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.listCalls++
+	if r.listErr != nil {
+		return nil, r.listErr
+	}
+	return append([]cl.Candidate(nil), r.candidates...), nil
+}
+
+func (r *fakeRepo) listCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.listCalls
+}
+
+var _ cl.DeviceCertRepository = (*fakeRepo)(nil)
+
+// mutations returns the IssuedMutation values recorded by accepted fenced writes.
+func (r *fakeRepo) mutations() []*cl.IssuedMutation {
+	var out []*cl.IssuedMutation
+	for _, e := range r.Effects() {
+		if m, ok := e.Mutation.(*cl.IssuedMutation); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// firstMutation returns the single recorded mutation or fails.
+func firstMutation(t *testing.T, r *fakeRepo) *cl.IssuedMutation {
+	t.Helper()
+	muts := r.mutations()
+	if len(muts) != 1 {
+		t.Fatalf("recorded %d mutations, want exactly 1", len(muts))
+	}
+	return muts[0]
+}
+
+// activeCandidate builds a renewable (active) candidate with the given validity
+// window. Caller controls due-ness via the window relative to the test clock.
+func activeCandidate(t *testing.T, deviceID string, notBefore, notAfter time.Time) cl.Candidate {
+	t.Helper()
+	return cl.Candidate{
+		DeviceID:   deviceID,
+		TenantID:   testTenant,
+		IssuerID:   testIssuer,
+		Serial:     "00aa",
+		Epoch:      1,
+		NotBefore:  notBefore,
+		NotAfter:   notAfter,
+		State:      cl.StateActive(),
+		CommonName: deviceID,
+		CSRDER:     deviceCSR(t, deviceID),
+	}
+}

--- a/framework/runtime/certlifecycle/testsupport_test.go
+++ b/framework/runtime/certlifecycle/testsupport_test.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	testTenant = "11111111-1111-1111-1111-111111111111"
-	testIssuer = "ca-test"
+	testTenant  = "11111111-1111-1111-1111-111111111111"
+	testTenant2 = "22222222-2222-2222-2222-222222222222"
+	testIssuer  = "ca-test"
 )
 
 // errFake is a reusable error for fake failure injection.
@@ -156,6 +157,7 @@ type fakeRepo struct {
 	candidates []cl.Candidate
 	listErr    error
 	listCalls  int
+	lastLimit  int
 }
 
 func newFakeRepo(candidates ...cl.Candidate) *fakeRepo {
@@ -165,20 +167,31 @@ func newFakeRepo(candidates ...cl.Candidate) *fakeRepo {
 	}
 }
 
-func (r *fakeRepo) ListRenewalCandidates(context.Context, time.Time) ([]cl.Candidate, error) {
+func (r *fakeRepo) ListRenewalCandidates(_ context.Context, _ time.Time, limit int) ([]cl.Candidate, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.listCalls++
+	r.lastLimit = limit
 	if r.listErr != nil {
 		return nil, r.listErr
 	}
-	return append([]cl.Candidate(nil), r.candidates...), nil
+	out := append([]cl.Candidate(nil), r.candidates...)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit] // honor the scan cap like a real SQL LIMIT
+	}
+	return out, nil
 }
 
 func (r *fakeRepo) listCount() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.listCalls
+}
+
+func (r *fakeRepo) lastListLimit() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lastLimit
 }
 
 var _ cl.DeviceCertRepository = (*fakeRepo)(nil)
@@ -208,9 +221,16 @@ func firstMutation(t *testing.T, r *fakeRepo) *cl.IssuedMutation {
 // window. Caller controls due-ness via the window relative to the test clock.
 func activeCandidate(t *testing.T, deviceID string, notBefore, notAfter time.Time) cl.Candidate {
 	t.Helper()
+	return activeCandidateForTenant(t, testTenant, deviceID, notBefore, notAfter)
+}
+
+// activeCandidateForTenant is activeCandidate scoped to an explicit tenant — used
+// to prove two tenants sharing a deviceID get distinct fenced entity keys.
+func activeCandidateForTenant(t *testing.T, tenantID, deviceID string, notBefore, notAfter time.Time) cl.Candidate {
+	t.Helper()
 	return cl.Candidate{
 		DeviceID:   deviceID,
-		TenantID:   tenant.TenantID(testTenant),
+		TenantID:   tenant.TenantID(tenantID),
 		IssuerID:   testIssuer,
 		Serial:     "00aa",
 		Epoch:      1,

--- a/framework/runtime/certlifecycle/testsupport_test.go
+++ b/framework/runtime/certlifecycle/testsupport_test.go
@@ -8,12 +8,14 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"errors"
+	"fmt"
 	"math/big"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/ghbvf/gocell/framework/kernel/reconcile/reconciletest"
+	"github.com/ghbvf/gocell/framework/pkg/tenant"
 	cl "github.com/ghbvf/gocell/framework/runtime/certlifecycle"
 	cs "github.com/ghbvf/gocell/framework/runtime/certsigning"
 )
@@ -42,31 +44,13 @@ func deviceCSR(t *testing.T, cn string) []byte {
 	return der
 }
 
-// leafCertDER builds a parseable self-signed leaf certificate DER with the given
-// CN, serial and validity window — for the fakeSigner to wrap in an IssuedCert
-// (NewIssuedCert parses it to derive serial / notBefore / notAfter).
-func leafCertDER(cn string, serial int64, notBefore, notAfter time.Time) []byte {
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		panic(err)
-	}
-	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(serial),
-		Subject:      pkix.Name{CommonName: cn},
-		NotBefore:    notBefore,
-		NotAfter:     notAfter,
-	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	if err != nil {
-		panic(err)
-	}
-	return der
-}
-
 // fakeSigner is a certsigning.Signer minting an IssuedCert from a per-call leaf
-// DER. It records every AuthorizedCertRequest and can be configured to fail.
+// DER (signed by a key generated once at construction). It records every
+// AuthorizedCertRequest and can be configured to fail. Runtime crypto errors are
+// returned (never panicked) so a Sign failure surfaces as a clean test failure.
 type fakeSigner struct {
 	mu        sync.Mutex
+	key       *ecdsa.PrivateKey
 	err       error
 	notBefore time.Time
 	notAfter  time.Time
@@ -75,8 +59,13 @@ type fakeSigner struct {
 	calls     int
 }
 
-func newFakeSigner(notBefore, notAfter time.Time) *fakeSigner {
-	return &fakeSigner{notBefore: notBefore, notAfter: notAfter, serial: 1000}
+func newFakeSigner(t *testing.T, notBefore, notAfter time.Time) *fakeSigner {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen signer key: %v", err)
+	}
+	return &fakeSigner{key: key, notBefore: notBefore, notAfter: notAfter, serial: 1000}
 }
 
 func (s *fakeSigner) Sign(_ context.Context, req cs.AuthorizedCertRequest) (cs.IssuedCert, error) {
@@ -88,10 +77,19 @@ func (s *fakeSigner) Sign(_ context.Context, req cs.AuthorizedCertRequest) (cs.I
 		return cs.IssuedCert{}, s.err
 	}
 	s.serial++
-	der := leafCertDER(req.Request().Subject().CommonName(), s.serial, s.notBefore, s.notAfter)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(s.serial),
+		Subject:      pkix.Name{CommonName: req.Request().Subject().CommonName()},
+		NotBefore:    s.notBefore,
+		NotAfter:     s.notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &s.key.PublicKey, s.key)
+	if err != nil {
+		return cs.IssuedCert{}, fmt.Errorf("fake sign: create cert: %w", err)
+	}
 	issued, err := cs.NewIssuedCert(req.Request().Scope(), der, nil, 0)
 	if err != nil {
-		panic(err)
+		return cs.IssuedCert{}, fmt.Errorf("fake sign: new issued cert: %w", err)
 	}
 	return issued, nil
 }
@@ -212,7 +210,7 @@ func activeCandidate(t *testing.T, deviceID string, notBefore, notAfter time.Tim
 	t.Helper()
 	return cl.Candidate{
 		DeviceID:   deviceID,
-		TenantID:   testTenant,
+		TenantID:   tenant.TenantID(testTenant),
 		IssuerID:   testIssuer,
 		Serial:     "00aa",
 		Epoch:      1,

--- a/tools/archtest/certlifecycle_invariants_test.go
+++ b/tools/archtest/certlifecycle_invariants_test.go
@@ -1,0 +1,155 @@
+//go:build archtest
+
+// INVARIANT: CERTLIFECYCLE-SIGN-VIA-FUNNEL-01
+//
+// The cert-lifecycle reconciler (framework/runtime/certlifecycle) obtains issued
+// certificates EXCLUSIVELY via certsigning.Signer.Sign — it never mints an
+// IssuedCert nor reaches into a concrete CA.
+//
+// # Rating: the SECURITY PROPERTY is Hard by inheritance; this archtest is the
+// Medium reverse self-check + anti-vacuity (AI-robust §"内容扫描规则必须有
+// synthetic red case 和 anti-vacuity"). No new Hard mechanism is introduced
+// because three existing mechanisms already make Signer.Sign the only compilable
+// way for certlifecycle to obtain an IssuedCert:
+//
+//   - certsigning.IssuedCert has only unexported fields, so certlifecycle cannot
+//     forge one by composite literal (compile-time Hard,
+//     CERT-VALUE-SEALED-CONSTRUCTION-01);
+//   - the sole minter certsigning.NewIssuedCert is restricted by the existing
+//     CERT-SIGN-FUNNEL-01 caller-allowlist (certIssuedMintAllowlist) to
+//     {adapters/softca}, which excludes certlifecycle;
+//   - certlifecycle cannot import adapters/softca: softca is a separate Go module
+//     that requires the framework module, so the reverse import is a circular
+//     module dependency the build refuses (module-topology Hard).
+//
+// This file pins those guarantees against drift with three legs:
+//
+//   - GreenProduction (anti-vacuity): certlifecycle is actually scanned, imports
+//     the certsigning seam, calls certsigning.Signer.Sign at least once (the
+//     funnel is USED, not stubbed), and calls certsigning.NewIssuedCert zero
+//     times (it never self-mints).
+//   - NotInMintAllowlist (cross-rule pin): certlifecycle is absent from
+//     certIssuedMintAllowlist, so the existing CERT-SIGN-FUNNEL-01 genuinely
+//     covers it — a future PR adding it (re-opening direct minting) fails here.
+//   - RedFixture (synthetic red case): a lifecycle-shaped fixture that mints an
+//     IssuedCert directly must fire the mint detector.
+//
+// Blind spot (per AI-robust §强制盲区自检): the "calls Signer.Sign" leg is an
+// AST/types call-site scan; a Signer passed to an external func via closure that
+// invokes it would be invisible. That residual is immaterial here because the
+// security property does not rest on this positive leg — it rests on the three
+// inherited Hard mechanisms above; this leg only guards against the funnel being
+// silently removed from certlifecycle.
+
+package archtest
+
+import (
+	"go/ast"
+	"go/types"
+	"testing"
+
+	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
+)
+
+// certlifecyclePkgPath is the import path of the cert-lifecycle reconciler.
+func certlifecyclePkgPath() string { return PlatformFrameworkModulePath + "/runtime/certlifecycle" }
+
+const certlifecycleMintMsg = "forbidden call certsigning.NewIssuedCert from certlifecycle — the lifecycle " +
+	"reconciler must obtain certificates via certsigning.Signer.Sign, never mint them"
+
+// isCertsigningSignerSign reports whether fn is the Sign method of the
+// certsigning.Signer interface (resolved alias/pointer/value-proof).
+func isCertsigningSignerSign(fn *types.Func, csPath string) bool {
+	if fn == nil || fn.Pkg() == nil || fn.Pkg().Path() != csPath || fn.Name() != "Sign" {
+		return false
+	}
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok || sig.Recv() == nil {
+		return false
+	}
+	recv := sig.Recv().Type()
+	if ptr, ok := recv.(*types.Pointer); ok {
+		recv = ptr.Elem()
+	}
+	named, ok := recv.(*types.Named)
+	return ok && named.Obj() != nil && named.Obj().Name() == "Signer"
+}
+
+// TestCertlifecycleSignViaFunnel01_GreenProduction asserts the certlifecycle
+// package is scanned, imports the certsigning seam, calls Signer.Sign (funnel
+// use), and never calls NewIssuedCert (no self-mint).
+func TestCertlifecycleSignViaFunnel01_GreenProduction(t *testing.T) {
+	t.Parallel()
+	csPath := certSigningPkgPath()
+	clPath := certlifecyclePkgPath()
+	var visited, importsCS, callsSign bool
+	diags := Run(t, Production(TypedOpts{Tests: false}), func(p *Pass) []Diagnostic {
+		if p.Pkg == nil || p.Pkg.Path() != clPath {
+			return nil
+		}
+		visited = true
+		importsCS = pkgImports(p.Pkg, csPath)
+		var out []Diagnostic
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			scanner.EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+				if IsCallToPkgFunc(p.TypesInfo, call, csPath, "NewIssuedCert") {
+					pos := p.Fset.Position(call.Pos())
+					out = append(out, Diagnostic{Rel: rel, Line: pos.Line, Message: certlifecycleMintMsg})
+				}
+				if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel != nil && sel.Sel.Name == "Sign" {
+					if fn, ok := ResolveMethodCall(p.TypesInfo, sel); ok && isCertsigningSignerSign(fn, csPath) {
+						callsSign = true
+					}
+				}
+			})
+		}
+		return out
+	})
+	if !visited {
+		t.Fatal("CERTLIFECYCLE-SIGN-VIA-FUNNEL-01: certlifecycle package was never scanned — the check is vacuous")
+	}
+	if !importsCS {
+		t.Error("CERTLIFECYCLE-SIGN-VIA-FUNNEL-01: certlifecycle does not import certsigning — it must depend on the seam")
+	}
+	if !callsSign {
+		t.Error("CERTLIFECYCLE-SIGN-VIA-FUNNEL-01: certlifecycle never calls certsigning.Signer.Sign — the signing " +
+			"funnel is not used (anti-vacuity failure)")
+	}
+	if len(diags) > 0 {
+		t.Errorf("CERTLIFECYCLE-SIGN-VIA-FUNNEL-01: certlifecycle must not mint certificates: %v", diags)
+	}
+}
+
+// TestCertlifecycleSignViaFunnel01_NotInMintAllowlist pins the load-bearing
+// cross-rule assumption that the existing CERT-SIGN-FUNNEL-01 mint allowlist
+// covers certlifecycle: certlifecycle must NOT be a member (it obtains certs via
+// Signer.Sign, never mints). Adding it would re-open direct minting and fail here.
+func TestCertlifecycleSignViaFunnel01_NotInMintAllowlist(t *testing.T) {
+	t.Parallel()
+	if _, ok := certIssuedMintAllowlist[certlifecyclePkgPath()]; ok {
+		t.Fatal("CERTLIFECYCLE-SIGN-VIA-FUNNEL-01: certlifecycle is in certIssuedMintAllowlist — it must obtain " +
+			"certificates via certsigning.Signer.Sign, never mint them directly")
+	}
+}
+
+// TestCertlifecycleSignViaFunnel01_RedFixture loads the archtest_fixture-tagged
+// lifecycle-bypass fixture (a lifecycle-shaped package calling NewIssuedCert) and
+// asserts the mint detector fires — the reverse self-check that the GREEN mint
+// baseline is meaningful.
+func TestCertlifecycleSignViaFunnel01_RedFixture(t *testing.T) {
+	t.Parallel()
+	csPath := certSigningPkgPath()
+	diags := Run(t, Fixture(FixtureOpts{Tests: false},
+		[]string{"./tools/archtest/internal/certlifecyclebypassfixture/..."}),
+		func(p *Pass) []Diagnostic {
+			return scanCertMintCallers(p, csPath)
+		})
+	for _, d := range diags {
+		t.Logf("RED fixture hit: %s:%d %s", d.Rel, d.Line, d.Message)
+	}
+	if len(diags) == 0 {
+		t.Error("CERTLIFECYCLE-SIGN-VIA-FUNNEL-01 RED fixture: scanner found 0 NewIssuedCert calls; expected ≥ 1 " +
+			"from certlifecyclebypassfixture — the mint detector may be broken")
+	}
+}

--- a/tools/archtest/internal/certlifecyclebypassfixture/forbidden_mint.go
+++ b/tools/archtest/internal/certlifecyclebypassfixture/forbidden_mint.go
@@ -1,0 +1,21 @@
+//go:build archtest_fixture
+
+// Package certlifecyclebypassfixture is an intentionally-violating stand-in for a
+// cert-lifecycle reconciler that BYPASSES the certsigning.Signer seam by minting
+// an IssuedCert directly. It is the RED self-check for
+// CERTLIFECYCLE-SIGN-VIA-FUNNEL-01: the mint detector must fire on this
+// NewIssuedCert call from a package that is not the sanctioned signer adapter.
+// Gated by the archtest_fixture build tag (a hard-coded literal that must agree
+// with the unexported fixtureBuildTag const in tools/archtest/fixture.go; Go
+// build-directive syntax cannot reference a Go constant).
+package certlifecyclebypassfixture
+
+import cs "github.com/ghbvf/gocell/framework/runtime/certsigning"
+
+// VIOLATION: a lifecycle-shaped package minting a certificate directly instead of
+// obtaining it through certsigning.Signer.Sign. The empty cs.CertScope{} literal
+// compiles (a struct with only unexported fields permits its EMPTY literal); the
+// scanner flags the CALL to NewIssuedCert, not the scope literal.
+//
+//nolint:all // intentional violation for archtest RED fixture
+var redLifecycleMint, _ = cs.NewIssuedCert(cs.CertScope{}, nil, nil, 0) //nolint:unused


### PR DESCRIPTION
## Summary

新建 `framework/runtime/certlifecycle`：可复用的 **server-side 证书生命周期 `reconcile.Reconciler`**（PR-7/#1895）。复用 `kernel/reconcile.Loop`（不新造控制环），周期扫描 near-expiry 证书 → `Authorize`(fail-closed) → 重签设备**存储的 CSR**（经 `certsigning.Signer`，同公钥/新有效期）→ 经 `FencedWriter` 持久化新一代。`cert-issued` L2 事件由消费 cell 的 `ApplyFenced` 与 cert 行**同一 tx 原子**落地。

## Why / 背景

EPIC #1895 把设备证书从 iotdevice 示例提升为框架能力。本 PR 泛化 iotdevice 种子（`devicecertrenewal`）的**环形状**，但把动作从「下发 rotate-cert 命令、设备自续」换成服务端签发（cert-manager/SPIFFE 范式）。L4 设备长延迟闭环；`cert-issued` = L2（元数据-only，设备经 status 端点 refetch）。

## Refs

Closes #1903 · EPIC #1895（PR-5 #2193 certsigning / PR-2 PrincipalDevice / PR-6 #2226 softca 已合）
ref: cert-manager / kubelet 证书轮换 70-90% renewal 模型

## Risk / 兼容性

无破坏性变更。纯新增 framework 原语，**尚未 wire**（PR-10 `bootstrap.WithCertLifecycle` 接线；与 PR-5 certsigning 先于 softca 落地同范式）。iotdevice 旧 `devicecertrenewal` slice 退役/重接由 **PR-9** 处理（无 shim）。无契约变更（`cert-issued` 已存在，draft producer-only）。

### 关键设计决策（实施期 grounding 修正，已对齐用户）
- **至多一次有效签发** = leader 选举 + `FencedWriter` 单调 epoch CAS（**不** import `runtime/command`；softca <10ms 同步签发，无需 async 命令）。
- **cert-issued L2 emit 经 fenced mutation 原子落地**：`framework` 模块不能 import `generated`（独立模块），且 L2 要求 persist+emit 同 tx（唯一 tx 在 cell 的 `ApplyFenced`）→ reconciler 不直 emit，`IssuedMutation` 携带事件字段，cell 原子写 cert 行 + outbox entry。
- **过期证书重签恢复**（非标 dead）→ reconciler 唯一写口 = 单条 fenced mutation。

## Enforcement

| ID | 评级 | 机制 |
|----|------|------|
| CERTLIFECYCLE-SIGN-VIA-FUNNEL-01 | 安全属性 **Hard-by-inheritance** / archtest **Medium** 反向自检 | `IssuedCert` 字面量封印 + 既有 `CERT-SIGN-FUNNEL-01` allowlist 排除 certlifecycle + 模块拓扑循环依赖（framework↛adapters/softca）三重组合；新 archtest = GREEN(调 Signer.Sign + 不调 NewIssuedCert + anti-vacuity) + cross-rule pin(∉ allowlist) + RED fixture |
| RECONCILE-FENCED-WRITE-FUNNEL-01 | Hard（复用） | 持久化仅经 `FencedWriterFrom(ctx).Write` |
| State 枚举 | Hard | sealed 闭值集（unexported 字段，不可字面量构造） |

## Test plan

- [x] `go -C framework build ./...` + `go build -tags=integration ./...` 通过
- [x] `go -C framework test ./runtime/certlifecycle/` 通过，覆盖率 **90.8%**（runtime ≥80% 达标）
- [x] `go -C tools test -tags=archtest ./archtest/ -run CertlifecycleSignViaFunnel01` GREEN + RED fixture 命中
- [x] `golangci-lint run ./runtime/certlifecycle/...` 0 issues（race 测试通过）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
