### PR TITLE
feat(transport): #2251 remote 可观测/Ops 收尾 — span 单源 (CrossCellObs) + readiness probe

### DIFF
--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -61,12 +61,18 @@ dial→503，见 P2.8）。`error.type` 超出该有界 kind 的细节留在 tra
 须同步 `allTransportOutcomes` 注册表（anti-vacuity，`TestTransportOutcome_FrozenRegistry`）+ 本节。
 
 **span tracer 单源（#2251 P1.3，D4 span 半闭合）**：remote 调用的 span 与 metrics 同源——
-metrics + tracer 由 sealed `transport.CrossCellObs`（unexported 字段，唯一 minter =
-`composition.Builder`）捆绑承载，`celltransport.Resolve` 收**一个**预建捆绑参（非分离的 metrics +
-tracer），故「接 metrics 忘 tracer」在 Resolve 边界类型级不可表达（Hard）。tracer 单源 = `SharedDeps.Tracer`：
-Builder 同时 append `bootstrap.WithTracer`（router + in-proc + event-router）并注入捆绑（remote），
-保证 remote 与 in-proc span 用同一 tracer。`SharedDeps.Tracer` 可为 nil（无 tracing，降级 NoopTracer）；
-今生产 seam-only（未接真 otel）。
+metrics + tracer 由 sealed `transport.CrossCellObs`（unexported 字段）捆绑承载，`celltransport.Resolve`
+收**一个**预建捆绑参（非分离的 metrics + tracer），故「接 metrics 忘 tracer」在 Resolve 边界类型级
+不可表达（Hard sealed-param）。tracer 单源 = `SharedDeps.Tracer`：Builder 同时 append
+`bootstrap.WithTracer`（router + in-proc + event-router）并注入捆绑（remote），保证 remote 与 in-proc
+span 用同一 tracer。`SharedDeps.Tracer` 可为 nil 或 typed-nil（无 tracing，经 `validation.IsNilInterface`
+归一降级 NoopTracer——构造边界统一用该 helper，bare `== nil` 会漏 typed-nil 致 remote `Start` panic）；
+今生产 seam-only（未接真 otel）。**「remote 与 in-proc span 同源」的 minter 评级分层**
+（funnel 双向锁）：下游 = **Hard**（`CrossCellObs` 字段 unexported，包外不可 struct-literal 伪造，唯一 mint
+路径是构造器）；上游「唯一 minter = `composition.Builder`」= **Medium**，由 caller-funnel
+`CROSSCELLOBS-MINTER-FUNNEL-01`（type-aware AST scan，allowlist 仅 `framework/runtime/composition`）守——
+`NewCrossCellObs` 是跨模块 exported 构造器，Go 可见性不可表达「只 composition mint」，同
+`EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01` 族的文档化 Go 天花板。
 
 **remote peer readiness（#2251 P2.7）**：split topology 下 `celltransport.Resolve` 的 remote 分支
 经 `ModuleResult.Resources` 注册一个 `<cell>_remote_ready` readiness probe（typed

--- a/.claude/rules/gocell/observability.md
+++ b/.claude/rules/gocell/observability.md
@@ -60,6 +60,22 @@ dial→503，见 P2.8）。`error.type` 超出该有界 kind 的细节留在 tra
 不进 metric label，保持低基数（success + 5 个有界失败 kind × 二值 mode = ≤12 series）。新增 outcome
 须同步 `allTransportOutcomes` 注册表（anti-vacuity，`TestTransportOutcome_FrozenRegistry`）+ 本节。
 
+**span tracer 单源（#2251 P1.3，D4 span 半闭合）**：remote 调用的 span 与 metrics 同源——
+metrics + tracer 由 sealed `transport.CrossCellObs`（unexported 字段，唯一 minter =
+`composition.Builder`）捆绑承载，`celltransport.Resolve` 收**一个**预建捆绑参（非分离的 metrics +
+tracer），故「接 metrics 忘 tracer」在 Resolve 边界类型级不可表达（Hard）。tracer 单源 = `SharedDeps.Tracer`：
+Builder 同时 append `bootstrap.WithTracer`（router + in-proc + event-router）并注入捆绑（remote），
+保证 remote 与 in-proc span 用同一 tracer。`SharedDeps.Tracer` 可为 nil（无 tracing，降级 NoopTracer）；
+今生产 seam-only（未接真 otel）。
+
+**remote peer readiness（#2251 P2.7）**：split topology 下 `celltransport.Resolve` 的 remote 分支
+经 `ModuleResult.Resources` 注册一个 `<cell>_remote_ready` readiness probe（typed
+`healthz.RemoteCellReadyProbeName`，`_ready` 依赖可用性约定）。probe 只对 resolved endpoint 做
+**TCP dial**（`transport.EndpointDialTarget` 解析，与 rewriteToAbsolute 同源），**不**打远端
+`/readyz`——cascade-safe：避免 A↔B 互探 readiness 死锁。peer 不可达 → 本 cell `/readyz` 降级（运维
+据此摘流量），但只进 readiness aggregator、**不** kill liveness。更丰富的 peer health（HTTP /readyz
+深度探测、多副本、依赖环检测）归 EPIC「类 k8s cell 运行时管理」。
+
 ## Redis namespace
 
 Redis key namespace 使用 owner 维度表达：cell、role、resource。禁止把 service token、

--- a/cellmodules/accesscore/module.go
+++ b/cellmodules/accesscore/module.go
@@ -106,7 +106,7 @@ func (m module) Provide(
 		return composition.ModuleResult{}, err
 	}
 
-	innerSessionStore, storageOpts, err := resolveAccessStorageOpts(shared, sessionProto, accessOpts)
+	innerSessionStore, storageOpts, transportResources, err := resolveAccessStorageOpts(shared, sessionProto, accessOpts)
 	if err != nil {
 		return composition.ModuleResult{}, err
 	}
@@ -168,9 +168,14 @@ func (m module) Provide(
 	// fails before bootstrap.Run starts) from that one entry. The module does not
 	// call bootstrap.WithManagedResource itself (WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01).
 	limiterRes := bootstrapLimiterResource{lim: rlLimiter}
+	// transportResources carries the remote config-getter peer readiness probe in
+	// split topology (#2251 P2.7); nil/empty when configcore is co-located. Build
+	// derives BOTH the steady-state WithManagedResource registration AND the
+	// pre-Run rollback stack from ModuleResult.Resources (single source).
+	resources := append([]kernellifecycle.ManagedResource{limiterRes}, transportResources...)
 	return composition.ModuleResult{
 		Cell:      c,
-		Resources: []kernellifecycle.ManagedResource{limiterRes},
+		Resources: resources,
 	}, nil
 }
 
@@ -226,49 +231,54 @@ func buildAccessBaseOpts(shared *composition.SharedDeps) ([]accesscell.Option, *
 	return opts, sessionProto, nil
 }
 
-// accessPostgresOptions builds the postgres-specific accesscore options.
-func accessPostgresOptions(shared *composition.SharedDeps, sessionProto *session.Protocol) ([]accesscell.Option, session.Store, error) {
+// accessPostgresOptions builds the postgres-specific accesscore options. It also
+// returns any readiness ManagedResources the config-getter transport contributes
+// (a remote-peer probe in split topology; nil when co-located) so Provide can
+// surface them via ModuleResult.Resources (#2251 P2.7).
+func accessPostgresOptions(shared *composition.SharedDeps, sessionProto *session.Protocol) ([]accesscell.Option, session.Store, []kernellifecycle.ManagedResource, error) {
 	if shared.PG == nil {
-		return nil, nil, fmt.Errorf("AccessCoreModule: postgres mode requires the postgres capability provider " +
+		return nil, nil, nil, fmt.Errorf("AccessCoreModule: postgres mode requires the postgres capability provider " +
 			"(the composition root must provision the postgres capability on SharedDeps before composition.Build)")
 	}
 	db, poolErr := cellsecrets.PgxPoolFromProvider(shared.PG)
 	if poolErr != nil {
-		return nil, nil, fmt.Errorf("AccessCoreModule: %w", poolErr)
+		return nil, nil, nil, fmt.Errorf("AccessCoreModule: %w", poolErr)
 	}
 	txMgr := shared.PG.TxManager()
 	pgBundle, err := accesspg.NewBundle(db, txMgr, shared.Clock)
 	if err != nil {
-		return nil, nil, fmt.Errorf("AccessCoreModule: PGBundle: %w", err)
+		return nil, nil, nil, fmt.Errorf("AccessCoreModule: PGBundle: %w", err)
 	}
 	pgSessionStore, err := adapterpg.NewSessionStore(db, txMgr, sessionProto, shared.Clock)
 	if err != nil {
-		return nil, nil, fmt.Errorf("AccessCoreModule: PGSessionStore: %w", err)
+		return nil, nil, nil, fmt.Errorf("AccessCoreModule: PGSessionStore: %w", err)
 	}
 	pgRefreshStore, err := adapterpg.NewRefreshStore(
 		db, txMgr,
 		accesscell.DefaultRefreshPolicy(), shared.Clock, rand.Reader,
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("AccessCoreModule: PGRefreshStore: %w", err)
+		return nil, nil, nil, fmt.Errorf("AccessCoreModule: PGRefreshStore: %w", err)
 	}
 	accessOpts := []accesscell.Option{
 		accesscell.WithOutboxDeps(nil, outbox.WrapWriterForCell(shared.PG.OutboxWriter())),
 		accesscell.WithPGBundle(pgBundle),
 		accesscell.WithRefreshStore(pgRefreshStore),
 	}
-	// Wire the ConfigGetter through the in-process CellTransport seam (US4 #1963).
+	// Wire the ConfigGetter through the CellTransport seam (US4 #1963 / US5 #1966).
 	// signing uses shared.InternalHMACRing (promoted from cmd-private
 	// internalGuard.ring onto composition.SharedDeps); the transport carries the
 	// signed request to configcore's internal handler.
+	var resources []kernellifecycle.ManagedResource
 	if shared.InternalHMACRing != nil {
-		opts, err := wireConfigGetter(shared, accessOpts)
+		opts, res, err := wireConfigGetter(shared, accessOpts)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		accessOpts = opts
+		resources = res
 	}
-	return accessOpts, pgSessionStore, nil
+	return accessOpts, pgSessionStore, resources, nil
 }
 
 // configProviderCell is the cell that provides the internal config-get contract
@@ -284,56 +294,62 @@ const configProviderCell = "configcore"
 //
 // Previously (US4) the remote path fail-fast'ed with a placeholder error; US5
 // replaces that with the real celltransport.Resolve which handles both cases.
-func wireConfigGetter(shared *composition.SharedDeps, accessOpts []accesscell.Option) ([]accesscell.Option, error) {
+func wireConfigGetter(
+	shared *composition.SharedDeps, accessOpts []accesscell.Option,
+) ([]accesscell.Option, []kernellifecycle.ManagedResource, error) {
 	topo, err := bootstrap.NewDeploymentTopology(shared.DeploymentTopology)
 	if err != nil {
-		return nil, fmt.Errorf("accesscore: deployment topology: %w", err)
+		return nil, nil, fmt.Errorf("accesscore: deployment topology: %w", err)
 	}
 	// celltransport.Resolve is the single topology-gated entry for CellTransport
-	// selection (CELLTRANSPORT-SELECT-FUNNEL-01). The SHARED transport metrics
-	// (minted once by composition.Builder, reused — not re-registered) are threaded
-	// so a split-topology remote call emits cell_transport_requests_total{transport_mode=remote}
-	// per ADR D4 (#1966 review P1.3). The tracer stays nil: the cross-cell span
-	// tracer is late-bound at bootstrap phase5 (InProcessTransport.Bind) and is not
-	// available at module-Provide time, so remote span tracing is a tracked
-	// follow-up (#1966 review P1.3 span half); a nil tracer degrades to NoopTracer
-	// per the NewRemoteHTTP contract.
-	ct, err := celltransport.Resolve(topo, configProviderCell,
-		shared.InProcessTransport, shared.Clock, shared.TransportMetrics, nil)
+	// selection (CELLTRANSPORT-SELECT-FUNNEL-01). The SHARED cross-cell observability
+	// bundle (shared.TransportObs: transport metrics + tracer, minted once by
+	// composition.Builder) is threaded as ONE value so a split-topology remote call
+	// emits cell_transport_requests_total{transport_mode=remote} AND produces spans
+	// with the SAME tracer bootstrap wires for in-process calls — closing the ADR D4
+	// span half (#2251 P1.3, was a nil-tracer follow-up under #1966). Resolve also
+	// returns a TCP-dial readiness ManagedResource for the remote peer so an
+	// unreachable configcore degrades this cell's /readyz (#2251 P2.7); it is
+	// surfaced via ModuleResult.Resources by the Provide caller.
+	ct, resources, err := celltransport.Resolve(topo, configProviderCell,
+		shared.InProcessTransport, shared.Clock, shared.TransportObs)
 	if err != nil {
-		return nil, fmt.Errorf("accesscore: celltransport.Resolve: %w", err)
+		return nil, nil, fmt.Errorf("accesscore: celltransport.Resolve: %w", err)
 	}
 	return append(accessOpts,
-		configgetter.WithTransport(ct, shared.InternalHMACRing, shared.Clock)), nil
+		configgetter.WithTransport(ct, shared.InternalHMACRing, shared.Clock)), resources, nil
 }
 
-// resolveAccessStorageOpts selects postgres or memory storage options.
+// resolveAccessStorageOpts selects postgres or memory storage options. It also
+// returns any readiness ManagedResources the transport seam contributes (remote
+// config-getter peer probe in postgres split topology; nil in memory mode where
+// no cross-cell transport is wired) so Provide can surface them (#2251 P2.7).
 func resolveAccessStorageOpts(
 	shared *composition.SharedDeps,
 	sessionProto *session.Protocol,
 	base []accesscell.Option,
-) (session.Store, []accesscell.Option, error) {
+) (session.Store, []accesscell.Option, []kernellifecycle.ManagedResource, error) {
 	if shared.Topology.StorageBackend() == "postgres" {
-		pgOpts, pgSessionStore, err := accessPostgresOptions(shared, sessionProto)
+		pgOpts, pgSessionStore, resources, err := accessPostgresOptions(shared, sessionProto)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		return pgSessionStore, append(base, pgOpts...), nil
+		return pgSessionStore, append(base, pgOpts...), resources, nil
 	}
 	sessionMemStore, err := session.NewMemStore(sessionProto, shared.Clock)
 	if err != nil {
-		return nil, nil, fmt.Errorf("accesscore: session.NewMemStore: %w", err)
+		return nil, nil, nil, fmt.Errorf("accesscore: session.NewMemStore: %w", err)
 	}
 	refreshMemStore, err := refreshmem.New(accesscell.DefaultRefreshPolicy(), shared.Clock, nil)
 	if err != nil {
-		return nil, nil, fmt.Errorf("accesscore: refreshmem.New: %w", err)
+		return nil, nil, nil, fmt.Errorf("accesscore: refreshmem.New: %w", err)
 	}
 	base = append(
 		base,
 		accesscell.WithMemBundle(accessmem.NewBundle(shared.Clock)),
 		accesscell.WithRefreshStore(refreshMemStore),
 	)
-	return sessionMemStore, base, nil
+	return sessionMemStore, base, nil, nil
 }
 
 // wrapSessionStoreWithCache decides whether to wrap inner with the AUTH-CACHE-01

--- a/cellmodules/accesscore/module.go
+++ b/cellmodules/accesscore/module.go
@@ -235,7 +235,9 @@ func buildAccessBaseOpts(shared *composition.SharedDeps) ([]accesscell.Option, *
 // returns any readiness ManagedResources the config-getter transport contributes
 // (a remote-peer probe in split topology; nil when co-located) so Provide can
 // surface them via ModuleResult.Resources (#2251 P2.7).
-func accessPostgresOptions(shared *composition.SharedDeps, sessionProto *session.Protocol) ([]accesscell.Option, session.Store, []kernellifecycle.ManagedResource, error) {
+func accessPostgresOptions(
+	shared *composition.SharedDeps, sessionProto *session.Protocol,
+) ([]accesscell.Option, session.Store, []kernellifecycle.ManagedResource, error) {
 	if shared.PG == nil {
 		return nil, nil, nil, fmt.Errorf("AccessCoreModule: postgres mode requires the postgres capability provider " +
 			"(the composition root must provision the postgres capability on SharedDeps before composition.Build)")

--- a/cellmodules/accesscore/module_configgetter_test.go
+++ b/cellmodules/accesscore/module_configgetter_test.go
@@ -34,9 +34,10 @@ func configGetterTestDeps(t *testing.T, spec bootstrap.DeploymentTopologySpec, t
 // → the config getter is wired through the in-process transport.
 func TestWireConfigGetter_Colocated_InjectsGetter(t *testing.T) {
 	shared := configGetterTestDeps(t, bootstrap.DeploymentTopologySpec{}, transport.NewInProcess(nil))
-	opts, err := wireConfigGetter(shared, nil)
+	opts, res, err := wireConfigGetter(shared, nil)
 	require.NoError(t, err)
 	assert.Len(t, opts, 1, "colocated configcore must append exactly the config getter option")
+	assert.Empty(t, res, "colocated configcore has no remote peer → no readiness resource")
 }
 
 // TestWireConfigGetter_RemoteConfigcore_InjectsGetter: configcore declared remote
@@ -49,16 +50,21 @@ func TestWireConfigGetter_RemoteConfigcore_InjectsGetter(t *testing.T) {
 		Remote:    []bootstrap.RemoteCellEndpoint{{CellID: "configcore", Endpoint: "configcore:9090"}},
 	}
 	shared := configGetterTestDeps(t, spec, transport.NewInProcess(nil))
-	opts, err := wireConfigGetter(shared, nil)
+	opts, res, err := wireConfigGetter(shared, nil)
 	require.NoError(t, err, "remote configcore must now succeed — US5 wires the RemoteHTTPTransport")
 	assert.Len(t, opts, 1, "remote configcore must append exactly the config getter option")
+	// Remote configcore contributes a TCP-dial readiness probe (#2251 P2.7).
+	require.Len(t, res, 1, "remote configcore must contribute one readiness resource")
+	probes := res[0].Probes()
+	require.Len(t, probes, 1)
+	assert.Equal(t, "configcore_remote_ready", probes[0].Name().String())
 }
 
 // TestWireConfigGetter_NilTransport_FailFast: colocated configcore but the
 // composition root failed to mint the in-process transport → fail-fast.
 func TestWireConfigGetter_NilTransport_FailFast(t *testing.T) {
 	shared := configGetterTestDeps(t, bootstrap.DeploymentTopologySpec{}, nil)
-	_, err := wireConfigGetter(shared, nil)
+	_, _, err := wireConfigGetter(shared, nil)
 	require.Error(t, err)
 	errcodetest.AssertCode(t, err, errcode.ErrCellInvalidConfig)
 }
@@ -68,7 +74,7 @@ func TestWireConfigGetter_NilTransport_FailFast(t *testing.T) {
 func TestWireConfigGetter_Unclassified_FailFast(t *testing.T) {
 	spec := bootstrap.DeploymentTopologySpec{Colocated: []string{"accesscore"}}
 	shared := configGetterTestDeps(t, spec, transport.NewInProcess(nil))
-	_, err := wireConfigGetter(shared, nil)
+	_, _, err := wireConfigGetter(shared, nil)
 	require.Error(t, err)
 	errcodetest.AssertCode(t, err, errcode.ErrCellInvalidConfig)
 }

--- a/cellmodules/celltransport/resolve.go
+++ b/cellmodules/celltransport/resolve.go
@@ -137,6 +137,6 @@ type remoteReadinessResource struct {
 	probe healthz.Probe
 }
 
-func (r remoteReadinessResource) Probes() []healthz.Probe { return []healthz.Probe{r.probe} }
-func (remoteReadinessResource) Worker() worker.Worker     { return nil }
+func (r remoteReadinessResource) Probes() []healthz.Probe   { return []healthz.Probe{r.probe} }
+func (remoteReadinessResource) Worker() worker.Worker       { return nil }
 func (remoteReadinessResource) Close(context.Context) error { return nil }

--- a/cellmodules/celltransport/resolve.go
+++ b/cellmodules/celltransport/resolve.go
@@ -1,11 +1,15 @@
 package celltransport
 
 import (
+	"context"
+	"net"
 	"net/http"
 	"time"
 
 	"github.com/ghbvf/gocell/framework/kernel/clock"
-	"github.com/ghbvf/gocell/framework/kernel/wrapper"
+	"github.com/ghbvf/gocell/framework/kernel/healthz"
+	"github.com/ghbvf/gocell/framework/kernel/lifecycle"
+	"github.com/ghbvf/gocell/framework/kernel/worker"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
 	"github.com/ghbvf/gocell/framework/runtime/transport"
@@ -37,46 +41,102 @@ const (
 //   - topo: the sealed deployment topology (obtained via
 //     bootstrap.NewDeploymentTopology from the assembly spec).
 //   - cellID: the target cell whose transport to resolve.
-//   - inProc: the shared in-process transport; must be non-nil (the composition
-//     root's Builder.Build always populates it).
+//   - inProc: the shared in-process transport; must be non-nil for a co-located
+//     cell (the composition root's Builder.Build always populates it).
 //   - clk: mandatory positional clock (clock.MustHaveClock, ADR clock-positional).
-//   - metrics: transport metrics for the remote transport; nil = no recording.
-//   - tracer: tracing backend for the remote transport; nil = no-op.
+//   - obs: the SINGLE-SOURCE cross-cell observability bundle (metrics + tracer)
+//     minted by composition.Builder. Passing one bundle (rather than separate
+//     metrics + tracer args) makes "wired metrics but forgot the tracer"
+//     unrepresentable at this boundary (#2251 P1.3). A zero-value bundle = no
+//     observability (nil metrics, NoopTracer).
 //
-// Selection logic:
+// Returns the selected transport plus the readiness ManagedResources it
+// contributes:
 //
-//   - co-located → returns inProc.
-//   - remote → builds and returns a *transport.RemoteHTTPTransport targeting
-//     the declared endpoint, using a transport.StaticResolver over the topology's
-//     remote endpoint map.
-//   - un-classified → returns (nil, KindInternal) as defense-in-depth (TOPO-11
+//   - co-located → (inProc, nil, nil): the in-process peer shares this process,
+//     so there is no remote endpoint to health-check.
+//   - remote → (RemoteHTTPTransport, [remote-readiness probe], nil): a TCP-dial
+//     readiness probe for the declared endpoint so an unreachable peer degrades
+//     this cell's /readyz (lets ops shed traffic) without killing liveness
+//     (#2251 P2.7).
+//   - un-classified → (nil, nil, KindInternal): defense-in-depth (TOPO-11
 //     normally prevents this at static-analysis time).
 func Resolve(
 	topo bootstrap.DeploymentTopology,
 	cellID string,
 	inProc *transport.InProcessTransport,
 	clk clock.Clock,
-	metrics *transport.Metrics,
-	tracer wrapper.Tracer,
-) (transport.CellTransport, error) {
+	obs transport.CrossCellObs,
+) (transport.CellTransport, []lifecycle.ManagedResource, error) {
 	clock.MustHaveClock(clk, "celltransport.Resolve")
 
 	if topo.IsColocated(cellID) {
 		if inProc == nil {
-			return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+			return nil, nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
 				msgNilInProc,
 				errcode.WithInternal(errcode.InternalAttr("cellID", cellID)))
 		}
-		return inProc, nil
+		return inProc, nil, nil
 	}
 
 	endpoint, ok := topo.RemoteEndpoint(cellID)
 	if !ok {
-		return nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+		return nil, nil, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
 			msgUnclassifiedCell,
 			errcode.WithInternal(errcode.InternalAttr("cellID", cellID)))
 	}
 
+	readiness, err := remoteReadiness(cellID, endpoint)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	resolver := transport.NewStaticResolver(map[string]string{cellID: endpoint})
-	return transport.NewRemoteHTTP(clk, cellID, resolver, &http.Client{Timeout: remoteHTTPClientTimeout}, metrics, tracer), nil
+	ct := transport.NewRemoteHTTP(clk, cellID, resolver,
+		&http.Client{Timeout: remoteHTTPClientTimeout}, obs.Metrics(), obs.Tracer())
+	return ct, []lifecycle.ManagedResource{readiness}, nil
 }
+
+// remoteReadiness builds the TCP-dial readiness ManagedResource for a remote
+// peer endpoint. The dial target and typed probe name are resolved eagerly so an
+// invalid endpoint / cellID fails fast at Resolve time rather than per /readyz
+// invocation.
+//
+// The probe TCP-dials the peer's resolved host:port ONLY — it never issues an
+// HTTP /readyz — so it reports reachability without recursively importing the
+// peer's own readiness (cascade-safe: a peer that depends on this cell cannot
+// deadlock both /readyz endpoints). A failed dial degrades readiness (this cell
+// returns /readyz 503) but never kills liveness (the probe joins the readiness
+// aggregator, not a liveness gate).
+func remoteReadiness(cellID, endpoint string) (lifecycle.ManagedResource, error) {
+	target, err := transport.EndpointDialTarget(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	name, err := healthz.RemoteCellReadyProbeName(cellID)
+	if err != nil {
+		return nil, err
+	}
+	probe := healthz.NewProbe(name, func(ctx context.Context) error {
+		conn, dialErr := (&net.Dialer{}).DialContext(ctx, "tcp", target)
+		if dialErr != nil {
+			return dialErr
+		}
+		return conn.Close()
+	})
+	return remoteReadinessResource{probe: probe}, nil
+}
+
+// remoteReadinessResource adapts a single readiness probe to the ManagedResource
+// contract so a cell module can contribute it via ModuleResult.Resources
+// (WITHMANAGEDRESOURCE-CELLMODULE-FUNNEL-01). It owns no background goroutine and
+// holds nothing to close: the endpoint is a startup-period snapshot of the sealed
+// (static) deployment topology, and the per-Check dial connection is closed in
+// the probe itself.
+type remoteReadinessResource struct {
+	probe healthz.Probe
+}
+
+func (r remoteReadinessResource) Probes() []healthz.Probe { return []healthz.Probe{r.probe} }
+func (remoteReadinessResource) Worker() worker.Worker     { return nil }
+func (remoteReadinessResource) Close(context.Context) error { return nil }

--- a/cellmodules/celltransport/resolve.go
+++ b/cellmodules/celltransport/resolve.go
@@ -2,6 +2,7 @@ package celltransport
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -21,6 +22,14 @@ import (
 // first in all normal paths. This value exists solely to prevent goroutine leaks
 // from unbounded-context callers — it is NOT a second per-request budget.
 const remoteHTTPClientTimeout = 30 * time.Second
+
+// remoteReadinessDialTimeout is the backstop dial timeout for the readiness
+// probe. DialContext uses the earlier of this and the ctx deadline, so the
+// /readyz aggregator deadline (bootstrap.WithReadyzDeadline) still binds when
+// tighter; this backstop only guards a caller that passes a deadline-less ctx,
+// preventing a SYN-blackhole peer from hanging the probe until the kernel TCP
+// timeout (#2251 review F2).
+const remoteReadinessDialTimeout = 3 * time.Second
 
 // Error messages — MESSAGE-CONST-LITERAL-01.
 const (
@@ -111,18 +120,22 @@ func Resolve(
 func remoteReadiness(cellID, endpoint string) (lifecycle.ManagedResource, error) {
 	target, err := transport.EndpointDialTarget(endpoint)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("celltransport: remote readiness dial target for cell %q: %w", cellID, err)
 	}
 	name, err := healthz.RemoteCellReadyProbeName(cellID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("celltransport: remote readiness probe name for cell %q: %w", cellID, err)
 	}
 	probe := healthz.NewProbe(name, func(ctx context.Context) error {
-		conn, dialErr := (&net.Dialer{}).DialContext(ctx, "tcp", target)
+		conn, dialErr := (&net.Dialer{Timeout: remoteReadinessDialTimeout}).DialContext(ctx, "tcp", target)
 		if dialErr != nil {
 			return dialErr
 		}
-		return conn.Close()
+		// A successful dial alone proves TCP reachability; a Close error is a
+		// local cleanup concern unrelated to peer health, so it must NOT degrade
+		// readiness (#2251 review F1).
+		_ = conn.Close()
+		return nil
 	})
 	return remoteReadinessResource{probe: probe}, nil
 }

--- a/cellmodules/celltransport/resolve_test.go
+++ b/cellmodules/celltransport/resolve_test.go
@@ -1,11 +1,16 @@
 package celltransport_test
 
 import (
+	"context"
 	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/ghbvf/gocell/cellmodules/celltransport"
 	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/wrapper"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
 	"github.com/ghbvf/gocell/framework/runtime/transport"
@@ -22,6 +27,17 @@ func assertKindInternal(t *testing.T, err error) {
 	}
 }
 
+func remoteTopo(t *testing.T, endpoint string) bootstrap.DeploymentTopology {
+	t.Helper()
+	topo, err := bootstrap.NewDeploymentTopology(bootstrap.DeploymentTopologySpec{
+		Remote: []bootstrap.RemoteCellEndpoint{{CellID: "configcore", Endpoint: endpoint}},
+	})
+	if err != nil {
+		t.Fatalf("NewDeploymentTopology: %v", err)
+	}
+	return topo
+}
+
 // TestResolve_Colocated verifies that a co-located cellID returns the inProc transport.
 func TestResolve_Colocated(t *testing.T) {
 	t.Parallel()
@@ -34,12 +50,16 @@ func TestResolve_Colocated(t *testing.T) {
 	}
 
 	inProc := transport.NewInProcess(nil)
-	got, err := celltransport.Resolve(topo, "configcore", inProc, clock.Real(), nil, nil)
+	got, res, err := celltransport.Resolve(topo, "configcore", inProc, clock.Real(), transport.CrossCellObs{})
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
 	if got != inProc {
 		t.Errorf("Resolve returned %v, want %v (inProc)", got, inProc)
+	}
+	// Co-located has no remote peer → contributes no readiness probe resource.
+	if len(res) != 0 {
+		t.Errorf("co-located Resolve returned %d resources, want 0", len(res))
 	}
 }
 
@@ -48,17 +68,9 @@ func TestResolve_Colocated(t *testing.T) {
 func TestResolve_Remote(t *testing.T) {
 	t.Parallel()
 
-	topo, err := bootstrap.NewDeploymentTopology(bootstrap.DeploymentTopologySpec{
-		Remote: []bootstrap.RemoteCellEndpoint{
-			{CellID: "configcore", Endpoint: "127.0.0.1:9090"},
-		},
-	})
-	if err != nil {
-		t.Fatalf("NewDeploymentTopology: %v", err)
-	}
-
+	topo := remoteTopo(t, "127.0.0.1:9090")
 	inProc := transport.NewInProcess(nil)
-	got, err := celltransport.Resolve(topo, "configcore", inProc, clock.Real(), nil, nil)
+	got, _, err := celltransport.Resolve(topo, "configcore", inProc, clock.Real(), transport.CrossCellObs{})
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -68,7 +80,6 @@ func TestResolve_Remote(t *testing.T) {
 	if got == transport.CellTransport(inProc) {
 		t.Error("Resolve returned inProc for a remote cell — expected a RemoteHTTPTransport")
 	}
-	// Type assertion: must be *transport.RemoteHTTPTransport, not the inProc impl.
 	if _, ok := got.(*transport.RemoteHTTPTransport); !ok {
 		t.Errorf("Resolve returned %T for remote cell, want *transport.RemoteHTTPTransport", got)
 	}
@@ -93,8 +104,7 @@ func TestResolve_NilClockPanics(t *testing.T) {
 	}
 
 	inProc := transport.NewInProcess(nil)
-	// nil clock must panic via clock.MustHaveClock("celltransport.Resolve").
-	_, _ = celltransport.Resolve(topo, "configcore", inProc, nil, nil, nil)
+	_, _, _ = celltransport.Resolve(topo, "configcore", inProc, nil, transport.CrossCellObs{})
 }
 
 // TestResolve_UnclassifiedCellReturnsKindInternal verifies defense-in-depth for
@@ -110,7 +120,7 @@ func TestResolve_UnclassifiedCellReturnsKindInternal(t *testing.T) {
 	}
 
 	inProc := transport.NewInProcess(nil)
-	_, resolveErr := celltransport.Resolve(topo, "configcore", inProc, clock.Real(), nil, nil)
+	_, _, resolveErr := celltransport.Resolve(topo, "configcore", inProc, clock.Real(), transport.CrossCellObs{})
 	if resolveErr == nil {
 		t.Fatal("expected error for unclassified cell, got nil")
 	}
@@ -129,7 +139,7 @@ func TestResolve_ColocatedNilInProcReturnsError(t *testing.T) {
 		t.Fatalf("NewDeploymentTopology: %v", err)
 	}
 
-	_, resolveErr := celltransport.Resolve(topo, "configcore", nil, clock.Real(), nil, nil)
+	_, _, resolveErr := celltransport.Resolve(topo, "configcore", nil, clock.Real(), transport.CrossCellObs{})
 	if resolveErr == nil {
 		t.Fatal("expected error for nil inProc, got nil")
 	}
@@ -147,7 +157,7 @@ func TestResolve_ZeroTopoIsColocated(t *testing.T) {
 	}
 
 	inProc := transport.NewInProcess(nil)
-	got, err := celltransport.Resolve(topo, "configcore", inProc, clock.Real(), nil, nil)
+	got, _, err := celltransport.Resolve(topo, "configcore", inProc, clock.Real(), transport.CrossCellObs{})
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -155,3 +165,160 @@ func TestResolve_ZeroTopoIsColocated(t *testing.T) {
 		t.Errorf("Resolve returned %v, want inProc for zero topo", got)
 	}
 }
+
+// --- #2251 P1.3: tracer propagation through the sealed bundle ---
+
+// TestResolve_Remote_PropagatesTracer asserts the remote transport opens a span
+// with transport_mode=remote using the tracer carried by the CrossCellObs bundle
+// (closes ADR D4 span half: remote calls were previously NoopTracer-only).
+func TestResolve_Remote_PropagatesTracer(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rec := &recTracer{}
+	topo := remoteTopo(t, srv.URL)
+	inProc := transport.NewInProcess(nil)
+
+	ct, _, err := celltransport.Resolve(topo, "configcore", inProc, clock.Real(),
+		transport.NewCrossCellObs(nil, rec))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "http://placeholder/internal/v1/config/k", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := ct.DoContract(context.Background(), "http.config.internal.get.v1", req)
+	if err != nil {
+		t.Fatalf("DoContract: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if !rec.hasAttr("transport_mode", "remote") {
+		t.Error("remote DoContract span missing transport_mode=remote attr (tracer not propagated)")
+	}
+}
+
+// --- #2251 P2.7: remote-peer readiness probe ---
+
+// TestResolve_Remote_ContributesReadinessProbe asserts the remote branch returns
+// exactly one readiness ManagedResource named "<cell>_remote_ready".
+func TestResolve_Remote_ContributesReadinessProbe(t *testing.T) {
+	t.Parallel()
+
+	topo := remoteTopo(t, "127.0.0.1:9090")
+	inProc := transport.NewInProcess(nil)
+
+	_, res, err := celltransport.Resolve(topo, "configcore", inProc, clock.Real(), transport.CrossCellObs{})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("remote Resolve returned %d resources, want 1", len(res))
+	}
+	probes := res[0].Probes()
+	if len(probes) != 1 {
+		t.Fatalf("readiness resource exposed %d probes, want 1", len(probes))
+	}
+	if got := probes[0].Name().String(); got != "configcore_remote_ready" {
+		t.Errorf("probe name = %q, want configcore_remote_ready", got)
+	}
+	// The readiness resource owns no goroutine and nothing to close.
+	if res[0].Worker() != nil {
+		t.Error("readiness resource Worker() must be nil")
+	}
+	if err := res[0].Close(context.Background()); err != nil {
+		t.Errorf("readiness resource Close() = %v, want nil", err)
+	}
+}
+
+// TestResolve_RemoteProbe_TCPDial is the cascade-safety core: the probe TCP-dials
+// the peer endpoint only (it does NOT issue an HTTP /readyz), so a peer that
+// accepts TCP but speaks no HTTP is still reported ready — proving no recursive
+// /readyz cascade. A closed endpoint degrades the probe; a canceled ctx errors.
+func TestResolve_RemoteProbe_TCPDial(t *testing.T) {
+	t.Parallel()
+
+	// A raw TCP listener that accepts connections but never speaks HTTP.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	defer ln.Close()
+
+	probe := remoteReadinessProbe(t, ln.Addr().String())
+
+	// Reachable: TCP dial succeeds even though the listener never sends HTTP.
+	if err := probe.Check(context.Background()); err != nil {
+		t.Errorf("probe.Check on reachable raw-TCP peer = %v, want nil (TCP-only, no /readyz)", err)
+	}
+
+	// Canceled ctx must surface as an error (honors the /readyz deadline).
+	cctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := probe.Check(cctx); err == nil {
+		t.Error("probe.Check with canceled ctx = nil, want error")
+	}
+
+	// Unreachable: bind+close to get a (very likely) refused address.
+	dead, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen(dead): %v", err)
+	}
+	deadAddr := dead.Addr().String()
+	_ = dead.Close()
+	deadProbe := remoteReadinessProbe(t, deadAddr)
+	if err := deadProbe.Check(context.Background()); err == nil {
+		t.Errorf("probe.Check on closed endpoint %q = nil, want error (peer down → readiness degrades)", deadAddr)
+	}
+}
+
+// remoteReadinessProbe resolves a remote topology for endpoint and returns the
+// single readiness probe its ManagedResource exposes.
+func remoteReadinessProbe(t *testing.T, endpoint string) interface {
+	Check(context.Context) error
+} {
+	t.Helper()
+	topo := remoteTopo(t, endpoint)
+	inProc := transport.NewInProcess(nil)
+	_, res, err := celltransport.Resolve(topo, "configcore", inProc, clock.Real(), transport.CrossCellObs{})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(res) != 1 || len(res[0].Probes()) != 1 {
+		t.Fatalf("expected 1 readiness probe, got resources=%d", len(res))
+	}
+	return res[0].Probes()[0]
+}
+
+// --- local test tracer (celltransport_test cannot reach transport's internal one) ---
+
+type recTracer struct {
+	attrs []wrapper.Attr
+}
+
+func (rt *recTracer) Start(ctx context.Context, _ string, attrs ...wrapper.Attr) (context.Context, wrapper.Span) {
+	rt.attrs = append(rt.attrs, attrs...)
+	return ctx, &recSpan{rt: rt}
+}
+
+func (rt *recTracer) hasAttr(key string, val any) bool {
+	for _, a := range rt.attrs {
+		if a.Key == key && a.Value == val {
+			return true
+		}
+	}
+	return false
+}
+
+type recSpan struct{ rt *recTracer }
+
+func (s *recSpan) SetAttributes(attrs ...wrapper.Attr) { s.rt.attrs = append(s.rt.attrs, attrs...) }
+func (s *recSpan) RecordError(error)                   {}
+func (s *recSpan) SetStatus(wrapper.StatusCode, string) {}
+func (s *recSpan) End()                                {}

--- a/cellmodules/celltransport/resolve_test.go
+++ b/cellmodules/celltransport/resolve_test.go
@@ -249,7 +249,7 @@ func TestResolve_RemoteProbe_TCPDial(t *testing.T) {
 	if err != nil {
 		t.Fatalf("net.Listen: %v", err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	probe := remoteReadinessProbe(t, ln.Addr().String())
 
@@ -318,7 +318,7 @@ func (rt *recTracer) hasAttr(key string, val any) bool {
 
 type recSpan struct{ rt *recTracer }
 
-func (s *recSpan) SetAttributes(attrs ...wrapper.Attr) { s.rt.attrs = append(s.rt.attrs, attrs...) }
-func (s *recSpan) RecordError(error)                   {}
+func (s *recSpan) SetAttributes(attrs ...wrapper.Attr)  { s.rt.attrs = append(s.rt.attrs, attrs...) }
+func (s *recSpan) RecordError(error)                    {}
 func (s *recSpan) SetStatus(wrapper.StatusCode, string) {}
-func (s *recSpan) End()                                {}
+func (s *recSpan) End()                                 {}

--- a/cellmodules/celltransport/resolve_test.go
+++ b/cellmodules/celltransport/resolve_test.go
@@ -202,6 +202,9 @@ func TestResolve_Remote_PropagatesTracer(t *testing.T) {
 	if !rec.hasAttr("transport_mode", "remote") {
 		t.Error("remote DoContract span missing transport_mode=remote attr (tracer not propagated)")
 	}
+	if !rec.hasAttr("contract.id", "http.config.internal.get.v1") {
+		t.Error("remote DoContract span missing contract.id attr")
+	}
 }
 
 // --- #2251 P2.7: remote-peer readiness probe ---

--- a/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
+++ b/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
@@ -338,12 +338,21 @@ US5（#1966）落地 sync 跨进程：`transport.Resolver`（cellID→endpoint�
 
 - **span tracer 单源（P1.3，D4 span 半闭合）**：放弃「remote 须复制 in-proc phase5 late-bind」的方向
   ——remote transport 不依赖 phase5 才存在的 handler（只需 tracer），故构造期即可注入。tracer + metrics
-  收敛进 sealed `transport.CrossCellObs`（unexported 字段，唯一 minter = `composition.Builder`）；
-  `SharedDeps` 以输入 `Tracer` + 派生 `TransportObs` **替换**松散 `TransportMetrics` 字段，Builder 同时
-  `bootstrap.WithTracer`（router/in-proc/event-router）+ 注入捆绑（remote），故 remote 与 in-proc span
-  **同源**。`celltransport.Resolve` 收**一个**预建捆绑参——边界上无可省略/可 nil 的 tracer 参数，「接
-  metrics 忘 tracer」**类型级不可表达**（Hard sealed-construction，取代原拟 Medium AST 守卫）。范围 seam-only：
-  `SharedDeps.Tracer` 可 nil（降级 NoopTracer），生产暂未接真 otel（见 EPIC）。
+  收敛进 sealed `transport.CrossCellObs`（unexported 字段）；`SharedDeps` 以输入 `Tracer` + 派生
+  `TransportObs` **替换**松散 `TransportMetrics` 字段，Builder 同时 `bootstrap.WithTracer`
+  （router/in-proc/event-router）+ 注入捆绑（remote），故 remote 与 in-proc span **同源**。
+  `celltransport.Resolve` 收**一个**预建捆绑参——边界上无可省略/可 nil 的 tracer 参数，「接 metrics 忘
+  tracer」**类型级不可表达**（Hard sealed-construction）。范围 seam-only：`SharedDeps.Tracer` 可 nil 或
+  typed-nil（经 `validation.IsNilInterface` 归一降级 NoopTracer，#2251 review F2），生产暂未接真 otel（见 EPIC）。
+  - **评级分层（AI-robust「funnel 双向锁」，#2251 review F1）**：「remote 与 in-proc span 同源」依赖
+    「唯一 minter = `composition.Builder`」，须分上下游评级。**下游 = Hard**：`CrossCellObs` 字段 unexported，
+    包外不可 struct-literal 伪造，唯一 mint 路径是构造器。**上游「只 composition mint」= Medium**：由
+    caller-funnel `CROSSCELLOBS-MINTER-FUNNEL-01`（type-aware AST scan + RED fixture）守。**原 amendment 把
+    整句标 Hard 是 overclaim**——`NewCrossCellObs` 是 exported 构造器；bundle 类型在 `framework/runtime/transport`、
+    minter 在 `framework/runtime/composition`、consumer 在 `cellmodules/celltransport`，三包跨两模块、字段所有权
+    属 transport，sealed mint token 会成跨模块 import cycle，故 Go 可见性**不可**表达「只 composition mint」。
+    这是与 `EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01` / `COMMAND-ASYNC-EMIT-CALLER-01` / RowScopeAll minter
+    同族的文档化永久 Go/module 天花板，不开 fake Hard-upgrade issue。
 - **remote peer readiness（P2.7）**：`celltransport.Resolve` 的 remote 分支经 `ModuleResult.Resources`
   注册 `<cell>_remote_ready`（typed `healthz.RemoteCellReadyProbeName`）。probe 只对 resolved endpoint 做
   **TCP dial**（`transport.EndpointDialTarget` 解析，与 `rewriteToAbsolute` 同源），**不**打远端 `/readyz`

--- a/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
+++ b/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
@@ -326,11 +326,36 @@ US5（#1966）落地 sync 跨进程：`transport.Resolver`（cellID→endpoint�
   accesscore `celltransport.Resolve` 传入（非 nil），split topology remote 调用现发 `transport_mode=remote`
   指标（关闭 ADR D4 指标缺口）。**span tracer 半残留**：cross-cell span tracer 在 bootstrap phase5
   late-bind（`InProcessTransport.Bind`），module-Provide 期不可得 → remote span tracing 追踪在独立 follow-up
-  issue（结构性 late-bind blocker，非静默缺口）。
+  issue（结构性 late-bind blocker，非静默缺口）。**→ #2251 已闭合**（见 §#2251 Amendment）。
 - **AI-robust 护栏补全（P1.4 / P1.5）**：`SVCTOKEN-CALLER-CELL-REQUIRED-01` 增「auth 包外生产代码禁直调
   `GenerateServiceToken`（须走 `SignInternalRequest` funnel）」arm + red fixture——把 godoc 已宣称但未 enforce
   的禁令落为机器可判定（Medium）；`CELLTRANSPORT-SELECT-FUNNEL-01` 扫描根加 `corecells` + red fixture，封死
   core cell 直构 `transport.NewRemoteHTTP` 绕 topology gate 的未来路径。
+
+### #2251 Amendment — remote 可观测/Ops 收尾（span 半闭合 + readiness 闭环）
+
+承接 §#1966 Amendment 拆出的两条 follow-up，**关闭 D4 trace 半缺口**并补 remote peer 的 readiness 闭环。
+
+- **span tracer 单源（P1.3，D4 span 半闭合）**：放弃「remote 须复制 in-proc phase5 late-bind」的方向
+  ——remote transport 不依赖 phase5 才存在的 handler（只需 tracer），故构造期即可注入。tracer + metrics
+  收敛进 sealed `transport.CrossCellObs`（unexported 字段，唯一 minter = `composition.Builder`）；
+  `SharedDeps` 以输入 `Tracer` + 派生 `TransportObs` **替换**松散 `TransportMetrics` 字段，Builder 同时
+  `bootstrap.WithTracer`（router/in-proc/event-router）+ 注入捆绑（remote），故 remote 与 in-proc span
+  **同源**。`celltransport.Resolve` 收**一个**预建捆绑参——边界上无可省略/可 nil 的 tracer 参数，「接
+  metrics 忘 tracer」**类型级不可表达**（Hard sealed-construction，取代原拟 Medium AST 守卫）。范围 seam-only：
+  `SharedDeps.Tracer` 可 nil（降级 NoopTracer），生产暂未接真 otel（见 EPIC）。
+- **remote peer readiness（P2.7）**：`celltransport.Resolve` 的 remote 分支经 `ModuleResult.Resources`
+  注册 `<cell>_remote_ready`（typed `healthz.RemoteCellReadyProbeName`）。probe 只对 resolved endpoint 做
+  **TCP dial**（`transport.EndpointDialTarget` 解析，与 `rewriteToAbsolute` 同源），**不**打远端 `/readyz`
+  ——cascade-safe（避免 A↔B 互探 readiness 死锁）。peer 不可达 → 本 cell `/readyz` 降级（运维摘流量），
+  只进 readiness aggregator、**不** kill liveness。**威胁矩阵补全**：D4 此前认为「健康检查已由 readyz/
+  ConsumerBase 覆盖」对 remote peer 不成立（peer down 时本 cell /readyz 仍 200）——本条把 remote 依赖纳入
+  本 cell readiness 闭环，纠正该盲区。
+- **范围切割（EPIC）**：本 PR 只做 TCP-dial 基线。更丰富的 peer health（HTTP `/readyz` 深度探测 + 远端
+  health-listener 地址发现、多副本 endpoint 替换 `StaticResolver`、liveness/readiness 编排、依赖环检测、
+  对标 k8s controller-runtime/readiness gate）归独立 EPIC「类 k8s cell 运行时管理」。
+- **golden 顺带修复**：`SHAREDDEPS-FIELDSET-FROZEN-01` golden 此前漏更 #1966 加的 `TransportMetrics`
+  字段（drift，base 已红）；本 PR 移除该字段 + 加 `Tracer`/`TransportObs`，golden 同步归绿。
 
 ### #1964 Amendment — per-cell 基础设施 seam 落地记录
 

--- a/docs/ops/readyz.md
+++ b/docs/ops/readyz.md
@@ -594,6 +594,33 @@ statuses:
 Ops diagnostics for `CompensationFailed` instances use the `saga_events` table
 (see `docs/ops/saga-runbook.md` §场景 2), not readyz.
 
+## Cross-cell remote-peer readiness probes (split topology) — `<cell>_remote_ready`
+
+In a **split topology** (a cell's cross-cell HTTP dependency is deployed in a
+SEPARATE process, not co-located), the consuming cell registers one readiness
+probe **per remote peer**, named `<peerCellID>_remote_ready` (e.g. accesscore →
+remote configcore produces `configcore_remote_ready`). It appears in the
+`/readyz?verbose` `dependencies` map exactly like adapter probes (#2251 P2.7).
+
+- **Semantics: TCP dial only, NOT an HTTP `/readyz` call.** The probe opens a TCP
+  connection to the peer's resolved endpoint (`host:port`) and closes it
+  immediately. It proves the peer's listener is reachable — it does **not** call
+  the peer's `/readyz`, deliberately, to avoid an A↔B readiness cascade
+  (mutual `/readyz` probing can deadlock both endpoints). So a peer whose TCP
+  listener is up but whose own dependencies are down still reports `healthy` here;
+  deeper peer-health is a tracked EPIC follow-up.
+- **Failure impact: readiness degrade, never liveness kill.** Peer unreachable →
+  this cell's `/readyz` goes 503 (kubelet/LB sheds traffic). The probe joins the
+  readiness aggregator only; it never trips a liveness gate, so the pod is not
+  restarted (avoids a dependency-cycle restart storm).
+- **Only present in split topology.** Co-located peers (same process) register no
+  such probe — absence of `<cell>_remote_ready` means the peer is in-process.
+- **Backstop dial timeout 3s** (`remoteReadinessDialTimeout`), bounded further by
+  the `/readyz` aggregator deadline (`-readyz-deadline`) when tighter.
+- Alert authors: this probe family is split-topology-only; do not hard-require it
+  in single-process deployments. The probe name is a typed funnel
+  (`healthz.RemoteCellReadyProbeName`); renames sync here + dashboards/alerts.
+
 ## Concurrent probe storms
 
 Concurrent `/readyz` requests (kubelet + LB + manual curl) are

--- a/framework/kernel/healthz/probename.go
+++ b/framework/kernel/healthz/probename.go
@@ -155,6 +155,34 @@ func EmitterFailOpenProbeName(cellID string) (ProbeName, error) {
 	return NewProbeName(emitterFailOpenProbeNamePrefix + cellID)
 }
 
+// remoteCellReadyProbeNameSuffix is the terminal segment of the cross-cell
+// remote-peer readiness probe name ("<cellID>_remote_ready"). It is a
+// dependency-availability probe (the remote peer's listener is TCP-reachable),
+// so it carries the "_ready" suffix per observability.md.
+const remoteCellReadyProbeNameSuffix = "_remote_ready"
+
+// RemoteCellReadyProbeName composes the typed probe name for a split-topology
+// remote-peer readiness probe scoped to targetCellID: "<cellID>_remote_ready"
+// (#2251 P2.7). It is registered by celltransport.Resolve's remote branch so a
+// peer that becomes unreachable degrades the consuming cell's /readyz (lets ops
+// shed traffic) without killing liveness.
+//
+// The cellID is validated against the full [NewProbeName] shape, so an invalid
+// cellID surfaces at transport-resolution time rather than per-probe invocation.
+// Budget: suffix "_remote_ready" (13) + cellID (≤32, pkg/scaffoldid cap) = ≤45 < 64.
+//
+// This is the SOLE sanctioned composed-name constructor for remote-peer
+// readiness probes — bare `cellID + "_remote_ready"` concat at callsites is
+// rejected by archtest PROBENAME-SEALED-FUNNEL-01 (A2 cast-ban + A4 NewProbeName
+// caller-allowlist), the same closure as [EmitterFailOpenProbeName].
+func RemoteCellReadyProbeName(targetCellID string) (ProbeName, error) {
+	if targetCellID == "" {
+		return "", errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"healthz: remote-cell readiness probe targetCellID must not be empty")
+	}
+	return NewProbeName(targetCellID + remoteCellReadyProbeNameSuffix)
+}
+
 // projectionProbeNameInfix forms the fixed middle segment shared by all
 // projection probe names: "<cellID>_projection_<projectionID>_…".
 // Length = len("_projection_") = 12.

--- a/framework/kernel/healthz/remotecell_probename_test.go
+++ b/framework/kernel/healthz/remotecell_probename_test.go
@@ -1,0 +1,64 @@
+package healthz
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRemoteCellReadyProbeName_Valid asserts the composed-name constructor for
+// the cross-cell remote-peer readiness probe produces "<cellID>_remote_ready"
+// and that the value satisfies the typed-name funnel (#2251 P2.7).
+func TestRemoteCellReadyProbeName_Valid(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		cellID string
+		want   string
+	}{
+		{"configcore", "configcore_remote_ready"},
+		{"auditcore", "auditcore_remote_ready"},
+		{"a", "a_remote_ready"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.cellID, func(t *testing.T) {
+			t.Parallel()
+			got, err := RemoteCellReadyProbeName(tc.cellID)
+			if err != nil {
+				t.Fatalf("RemoteCellReadyProbeName(%q): unexpected error %v", tc.cellID, err)
+			}
+			if got.String() != tc.want {
+				t.Errorf("RemoteCellReadyProbeName(%q) = %q, want %q", tc.cellID, got.String(), tc.want)
+			}
+			// anti-vacuity: the value must carry the dependency-availability
+			// "_ready" suffix per observability.md, not just be non-empty.
+			if !strings.HasSuffix(got.String(), "_ready") {
+				t.Errorf("probe name %q must end in _ready (dependency-availability convention)", got.String())
+			}
+		})
+	}
+}
+
+// TestRemoteCellReadyProbeName_Invalid asserts fail-fast on empty / malformed /
+// over-budget cellID (it routes through NewProbeName, inheriting its validation).
+func TestRemoteCellReadyProbeName_Invalid(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		cellID string
+	}{
+		{"empty", ""},
+		{"uppercase", "ConfigCore"},
+		{"hyphen", "config-core"},
+		{"whitespace", "config core"},
+		{"too_long", strings.Repeat("a", 60)}, // + "_remote_ready"(13) > 64
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := RemoteCellReadyProbeName(tc.cellID); err == nil {
+				t.Errorf("RemoteCellReadyProbeName(%q): expected error, got nil", tc.cellID)
+			}
+		})
+	}
+}

--- a/framework/runtime/composition/builder.go
+++ b/framework/runtime/composition/builder.go
@@ -221,8 +221,10 @@ func (b *Builder) Build(
 	}
 	// Share the SAME *transport.Metrics with both the in-process holder and any
 	// remote transport a module resolves via celltransport.Resolve (#1966 P1.3):
-	// reuse, never re-register, the single counter.
-	shared.TransportMetrics = txMetrics
+	// reuse, never re-register, the single counter. The metrics is bundled with the
+	// (optional) tracer into the SINGLE-SOURCE CrossCellObs so a module cannot wire
+	// metrics while forgetting the tracer (#2251 P1.3).
+	shared.TransportObs = transport.NewCrossCellObs(txMetrics, shared.Tracer)
 	shared.InProcessTransport = transport.NewInProcess(txMetrics)
 
 	var cells []cell.Cell
@@ -275,6 +277,13 @@ func (b *Builder) Build(
 		bootstrap.WithDeploymentTopology(shared.DeploymentTopology),
 		bootstrap.WithInProcessTransport(shared.InProcessTransport),
 	)
+	//   4. WithTracer: when a tracer is configured, thread the SINGLE source
+	//      (shared.Tracer) into bootstrap so router/in-process/event-router tracing
+	//      use the SAME tracer the remote transport got via shared.TransportObs
+	//      (#2251 P1.3). Nil = no tracing (no option appended; seam-only default).
+	if shared.Tracer != nil {
+		cellOpts = append(cellOpts, bootstrap.WithTracer(shared.Tracer))
+	}
 
 	runtimeOpts, err := runtimeOptsFn(cells)
 	if err != nil {

--- a/framework/runtime/composition/builder.go
+++ b/framework/runtime/composition/builder.go
@@ -281,7 +281,11 @@ func (b *Builder) Build(
 	//      (shared.Tracer) into bootstrap so router/in-process/event-router tracing
 	//      use the SAME tracer the remote transport got via shared.TransportObs
 	//      (#2251 P1.3). Nil = no tracing (no option appended; seam-only default).
-	if shared.Tracer != nil {
+	//      IsNilInterface (not a bare != nil) so a typed-nil tracer value is also
+	//      treated as "unset" — consistent with the kernel projection coordinator's
+	//      tracer guard, and avoids handing bootstrap a non-nil interface wrapping a
+	//      nil pointer that would panic on Start (#2251 review F3).
+	if !validation.IsNilInterface(shared.Tracer) {
 		cellOpts = append(cellOpts, bootstrap.WithTracer(shared.Tracer))
 	}
 

--- a/framework/runtime/composition/shared_deps.go
+++ b/framework/runtime/composition/shared_deps.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/idempotency"
 	kernelmetrics "github.com/ghbvf/gocell/framework/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/framework/kernel/outbox"
+	"github.com/ghbvf/gocell/framework/kernel/wrapper"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/framework/pkg/validation"
 	"github.com/ghbvf/gocell/framework/runtime/auth"
@@ -171,14 +172,26 @@ type SharedDeps struct {
 	// internal-listener handler into it at phase5. Build always populates it.
 	InProcessTransport *transport.InProcessTransport
 
-	// TransportMetrics is the SHARED *transport.Metrics minted once by Build (from
-	// MetricsProvider) and reused by both the in-process transport and any remote
-	// transport a module resolves via celltransport.Resolve — so split-topology
-	// remote calls emit cell_transport_requests_total{transport_mode=remote}
-	// instead of dropping the metric (#1966 review P1.3, ADR D4). It is the SAME
-	// instance the in-process holder uses; reusing it (not re-registering) avoids
-	// a duplicate-counter registration error. Build always populates it.
-	TransportMetrics *transport.Metrics
+	// Tracer is the OPTIONAL cross-cell tracing backend (input). It is the SINGLE
+	// source for distributed tracing: when non-nil, Build threads it into BOTH the
+	// bootstrap tracer (router + in-process transport late-bind + event router, via
+	// bootstrap.WithTracer) AND the remote transport (via TransportObs below), so a
+	// split-topology remote call gets the SAME tracer as in-process calls — closing
+	// the ADR D4 span half (#2251 P1.3). Nil = no tracing configured (remote and
+	// in-process both degrade to wrapper.NoopTracer{}); production currently leaves
+	// it nil (seam-only) until a composition root wires a real otel tracer. Adding
+	// it here (rather than a per-call argument) makes "wired metrics but forgot the
+	// tracer" unrepresentable at the celltransport.Resolve boundary.
+	Tracer wrapper.Tracer
+
+	// TransportObs is the SHARED cross-cell observability bundle (transport metrics
+	// + Tracer) minted ONCE by Build and consumed by both the in-process transport
+	// and any remote transport a module resolves via celltransport.Resolve — so
+	// split-topology remote calls emit cell_transport_requests_total{transport_mode=
+	// remote} and produce spans instead of dropping them (#1966 review P1.3 / #2251,
+	// ADR D4). The metrics instance is reused (not re-registered) to avoid a
+	// duplicate-counter error. Build-populated (derived), not a caller input.
+	TransportObs transport.CrossCellObs
 
 	// HealthHTTPAddr is the bind address for the health+metrics listener.
 	HealthHTTPAddr string

--- a/framework/runtime/composition/transport_obs_build_test.go
+++ b/framework/runtime/composition/transport_obs_build_test.go
@@ -1,0 +1,62 @@
+package composition
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ghbvf/gocell/framework/kernel/cell"
+	"github.com/ghbvf/gocell/framework/kernel/wrapper"
+	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
+	"github.com/stretchr/testify/require"
+)
+
+// distinctTracer is a non-Noop wrapper.Tracer used to prove Build threads the
+// SAME tracer instance from SharedDeps.Tracer into the minted bundle.
+type distinctTracer struct{}
+
+func (distinctTracer) Start(ctx context.Context, name string, attrs ...wrapper.Attr) (context.Context, wrapper.Span) {
+	return wrapper.NoopTracer{}.Start(ctx, name, attrs...)
+}
+
+func nopRuntimeOpts([]cell.Cell) ([]bootstrap.Option, error) { return nil, nil }
+
+// TestBuild_PopulatesTransportObs_ThreadsTracer asserts Build mints the
+// cross-cell observability bundle into SharedDeps.TransportObs AND threads
+// SharedDeps.Tracer into it — the single-source guarantee (#2251 P1.3): the
+// remote transport gets the SAME tracer bootstrap wires, not a forgotten nil.
+func TestBuild_PopulatesTransportObs_ThreadsTracer(t *testing.T) {
+	ctx := context.Background()
+
+	shared := minimalSharedDeps(t)
+	tr := distinctTracer{}
+	shared.Tracer = tr
+
+	m1 := &fakeCellModule{id: "mod1", cell: stubCell("mod1")}
+	_, err := New("mod1").With(m1).Build(ctx, shared, nopRuntimeOpts)
+	require.NoError(t, err)
+
+	if shared.TransportObs.Metrics() == nil {
+		t.Error("Build did not mint transport metrics into TransportObs")
+	}
+	if shared.TransportObs.Tracer() != tr {
+		t.Errorf("Build did not thread SharedDeps.Tracer into TransportObs: got %T", shared.TransportObs.Tracer())
+	}
+}
+
+// TestBuild_TransportObs_NilTracerDegradesToNoop asserts the default (no tracer
+// configured) path: the bundle carries a NoopTracer, not a nil — so a remote
+// DoContract never panics on a nil tracer. Seam-only: production stays NoopTracer
+// until a composition root sets SharedDeps.Tracer.
+func TestBuild_TransportObs_NilTracerDegradesToNoop(t *testing.T) {
+	ctx := context.Background()
+
+	shared := minimalSharedDeps(t) // Tracer unset (nil)
+
+	m1 := &fakeCellModule{id: "mod1", cell: stubCell("mod1")}
+	_, err := New("mod1").With(m1).Build(ctx, shared, nopRuntimeOpts)
+	require.NoError(t, err)
+
+	if _, ok := shared.TransportObs.Tracer().(wrapper.NoopTracer); !ok {
+		t.Errorf("nil SharedDeps.Tracer must degrade bundle to NoopTracer, got %T", shared.TransportObs.Tracer())
+	}
+}

--- a/framework/runtime/composition/transport_obs_build_test.go
+++ b/framework/runtime/composition/transport_obs_build_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ghbvf/gocell/framework/kernel/cell"
 	"github.com/ghbvf/gocell/framework/kernel/wrapper"
 	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
-	"github.com/stretchr/testify/require"
 )
 
 // distinctTracer is a non-Noop wrapper.Tracer used to prove Build threads the

--- a/framework/runtime/transport/crosscellobs.go
+++ b/framework/runtime/transport/crosscellobs.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ghbvf/gocell/framework/kernel/wrapper"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/validation"
 )
 
 // CrossCellObs is the sealed cross-cell observability bundle: the metrics +
@@ -23,11 +24,15 @@ type CrossCellObs struct {
 	tracer  wrapper.Tracer
 }
 
-// NewCrossCellObs mints a bundle. A nil tracer is normalized to
+// NewCrossCellObs mints a bundle. A nil OR typed-nil tracer is normalized to
 // wrapper.NoopTracer{} (same contract as [NewRemoteHTTP]) so a minted bundle
-// never carries a nil tracer. A nil metrics is preserved (records nothing).
+// never carries a tracer that would panic on Start. The typed-nil case (a
+// non-nil wrapper.Tracer interface wrapping a nil pointer) is caught by
+// validation.IsNilInterface — a bare `tracer == nil` would miss it and ship the
+// typed-nil into the remote transport (#2251 review F2). A nil metrics is
+// preserved (records nothing).
 func NewCrossCellObs(metrics *Metrics, tracer wrapper.Tracer) CrossCellObs {
-	if tracer == nil {
+	if validation.IsNilInterface(tracer) {
 		tracer = wrapper.NoopTracer{}
 	}
 	return CrossCellObs{metrics: metrics, tracer: tracer}

--- a/framework/runtime/transport/crosscellobs.go
+++ b/framework/runtime/transport/crosscellobs.go
@@ -36,9 +36,13 @@ func NewCrossCellObs(metrics *Metrics, tracer wrapper.Tracer) CrossCellObs {
 // Metrics returns the shared transport metrics (may be nil → no recording).
 func (o CrossCellObs) Metrics() *Metrics { return o.metrics }
 
-// Tracer returns the bundle's tracer. It is non-nil for any bundle produced by
-// [NewCrossCellObs]; a zero-value bundle returns nil (consumers degrade nil to
-// NoopTracer).
+// Tracer returns the bundle's tracer. Two cases, by construction path:
+//   - a bundle minted by [NewCrossCellObs] always returns a non-nil tracer (nil
+//     input was normalized to wrapper.NoopTracer{} at mint time) — this is the
+//     production path (composition.Builder always mints via NewCrossCellObs).
+//   - a zero-value CrossCellObs{} (test-only "no observability" input) returns
+//     nil; the sole consumer [NewRemoteHTTP] degrades a nil tracer to NoopTracer,
+//     so a zero-value bundle is functionally equivalent to NewCrossCellObs(nil, nil).
 func (o CrossCellObs) Tracer() wrapper.Tracer { return o.tracer }
 
 // msgEndpointDialInvalid — MESSAGE-CONST-LITERAL-01.

--- a/framework/runtime/transport/crosscellobs.go
+++ b/framework/runtime/transport/crosscellobs.go
@@ -1,0 +1,67 @@
+package transport
+
+import (
+	"net"
+
+	"github.com/ghbvf/gocell/framework/kernel/wrapper"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+)
+
+// CrossCellObs is the sealed cross-cell observability bundle: the metrics +
+// tracer a remote [CellTransport] needs, carried as ONE value (#2251 P1.3).
+//
+// It exists to make the asymmetric "wired metrics but forgot the tracer" state
+// unrepresentable at the celltransport.Resolve boundary: both observability
+// deps travel together, minted ONCE by composition.Builder from a single source
+// (SharedDeps.Tracer + the shared transport metrics), so the remote transport
+// gets the SAME tracer bootstrap wires for in-process calls instead of the
+// previously hard-coded nil. The fields are unexported; the only minting path is
+// [NewCrossCellObs]. A zero-value bundle is a valid "no observability" input
+// (nil metrics → no recording; nil tracer → consumers degrade to NoopTracer).
+type CrossCellObs struct {
+	metrics *Metrics
+	tracer  wrapper.Tracer
+}
+
+// NewCrossCellObs mints a bundle. A nil tracer is normalized to
+// wrapper.NoopTracer{} (same contract as [NewRemoteHTTP]) so a minted bundle
+// never carries a nil tracer. A nil metrics is preserved (records nothing).
+func NewCrossCellObs(metrics *Metrics, tracer wrapper.Tracer) CrossCellObs {
+	if tracer == nil {
+		tracer = wrapper.NoopTracer{}
+	}
+	return CrossCellObs{metrics: metrics, tracer: tracer}
+}
+
+// Metrics returns the shared transport metrics (may be nil → no recording).
+func (o CrossCellObs) Metrics() *Metrics { return o.metrics }
+
+// Tracer returns the bundle's tracer. It is non-nil for any bundle produced by
+// [NewCrossCellObs]; a zero-value bundle returns nil (consumers degrade nil to
+// NoopTracer).
+func (o CrossCellObs) Tracer() wrapper.Tracer { return o.tracer }
+
+// msgEndpointDialInvalid — MESSAGE-CONST-LITERAL-01.
+const msgEndpointDialInvalid = "transport: endpoint is not a valid host:port dial target"
+
+// EndpointDialTarget resolves a topology endpoint to a "host:port" suitable for
+// a readiness TCP dial (#2251 P2.7). It reuses [parseEndpoint] (the single
+// endpoint parser shared with rewriteToAbsolute) and supplies the scheme's
+// default port when the authority omits one (http→80, https→443). A bare
+// "host:port" is returned unchanged; an unparseable endpoint returns KindInternal
+// (a static wiring error, not a transient network condition).
+func EndpointDialTarget(endpoint string) (string, error) {
+	scheme, host, ok := parseEndpoint(endpoint)
+	if !ok {
+		return "", errcode.New(errcode.KindInternal, errcode.ErrInternal, msgEndpointDialInvalid,
+			errcode.WithInternal(errcode.InternalAttr("endpoint", endpoint)))
+	}
+	if _, _, err := net.SplitHostPort(host); err == nil {
+		return host, nil // already host:port
+	}
+	port := "80"
+	if scheme == "https" {
+		port = "443"
+	}
+	return net.JoinHostPort(host, port), nil
+}

--- a/framework/runtime/transport/crosscellobs_test.go
+++ b/framework/runtime/transport/crosscellobs_test.go
@@ -1,0 +1,101 @@
+package transport
+
+import (
+	"testing"
+
+	"github.com/ghbvf/gocell/framework/kernel/wrapper"
+)
+
+// TestNewCrossCellObs_RetainsBoth asserts the sealed cross-cell observability
+// bundle carries the metrics and tracer it was minted with (#2251 P1.3). The
+// bundle is the single-source carrier so a split-topology remote call gets the
+// SAME tracer bootstrap wires, never a forgotten nil.
+func TestNewCrossCellObs_RetainsBoth(t *testing.T) {
+	t.Parallel()
+
+	m, _ := newTestMetrics(t)
+	rec := &recordingTracer{}
+
+	obs := NewCrossCellObs(m, rec)
+
+	if obs.Metrics() != m {
+		t.Errorf("Metrics() = %p, want %p", obs.Metrics(), m)
+	}
+	if obs.Tracer() != rec {
+		t.Errorf("Tracer() = %v, want the recording tracer", obs.Tracer())
+	}
+}
+
+// TestNewCrossCellObs_NilTracerDegradesToNoop asserts a nil tracer is normalized
+// to wrapper.NoopTracer{} at construction (same contract as NewRemoteHTTP), so a
+// bundle never carries a nil tracer that would panic on Start.
+func TestNewCrossCellObs_NilTracerDegradesToNoop(t *testing.T) {
+	t.Parallel()
+
+	obs := NewCrossCellObs(nil, nil)
+
+	if obs.Metrics() != nil {
+		t.Errorf("Metrics() = %p, want nil (no recording)", obs.Metrics())
+	}
+	if _, ok := obs.Tracer().(wrapper.NoopTracer); !ok {
+		t.Errorf("Tracer() = %T, want wrapper.NoopTracer for a nil input", obs.Tracer())
+	}
+}
+
+// TestCrossCellObs_ZeroValue documents that a zero-value bundle is a valid
+// "no observability" input: nil metrics (no recording) and nil tracer (the
+// NewRemoteHTTP / probe consumers degrade nil to NoopTracer). This keeps the
+// resolve_test fixtures lightweight without forcing the constructor.
+func TestCrossCellObs_ZeroValue(t *testing.T) {
+	t.Parallel()
+
+	var obs CrossCellObs
+	if obs.Metrics() != nil {
+		t.Errorf("zero-value Metrics() = %p, want nil", obs.Metrics())
+	}
+	if obs.Tracer() != nil {
+		t.Errorf("zero-value Tracer() = %v, want nil", obs.Tracer())
+	}
+}
+
+// TestEndpointDialTarget covers the shared endpoint → host:port parser the
+// readiness probe TCP-dials (#2251 P2.7). It is the single source reused by
+// rewriteToAbsolute so probe and request rewrite never drift.
+func TestEndpointDialTarget(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		endpoint string
+		want     string
+		wantErr  bool
+	}{
+		{"bare host:port", "127.0.0.1:9090", "127.0.0.1:9090", false},
+		{"http with port", "http://configcore:8080", "configcore:8080", false},
+		{"https with port", "https://configcore:8443", "configcore:8443", false},
+		{"http no port defaults 80", "http://configcore", "configcore:80", false},
+		{"https no port defaults 443", "https://configcore", "configcore:443", false},
+		{"empty", "", "", true},
+		{"http with path", "http://configcore:8080/x", "", true},
+		{"bare with path", "configcore:9090/x", "", true},
+		{"bare with query", "configcore:9090?a=b", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := EndpointDialTarget(tc.endpoint)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("EndpointDialTarget(%q): expected error, got %q", tc.endpoint, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("EndpointDialTarget(%q): unexpected error %v", tc.endpoint, err)
+			}
+			if got != tc.want {
+				t.Errorf("EndpointDialTarget(%q) = %q, want %q", tc.endpoint, got, tc.want)
+			}
+		})
+	}
+}

--- a/framework/runtime/transport/crosscellobs_test.go
+++ b/framework/runtime/transport/crosscellobs_test.go
@@ -26,19 +26,38 @@ func TestNewCrossCellObs_RetainsBoth(t *testing.T) {
 	}
 }
 
-// TestNewCrossCellObs_NilTracerDegradesToNoop asserts a nil tracer is normalized
-// to wrapper.NoopTracer{} at construction (same contract as NewRemoteHTTP), so a
-// bundle never carries a nil tracer that would panic on Start.
+// TestNewCrossCellObs_NilTracerDegradesToNoop asserts a nil OR typed-nil tracer
+// is normalized to wrapper.NoopTracer{} at construction (same contract as
+// NewRemoteHTTP), so a minted bundle never carries a tracer that would panic on
+// Start. The typed-nil case (a non-nil wrapper.Tracer interface wrapping a nil
+// *recordingTracer) is the #2251 review F2 regression: a bare `tracer == nil`
+// check misses it and ships the typed-nil into the remote transport, which then
+// panics at DoContract's t.tracer.Start. validation.IsNilInterface catches both.
 func TestNewCrossCellObs_NilTracerDegradesToNoop(t *testing.T) {
 	t.Parallel()
 
-	obs := NewCrossCellObs(nil, nil)
+	var typedNil *recordingTracer // typed-nil: non-nil wrapper.Tracer wrapping a nil pointer
 
-	if obs.Metrics() != nil {
-		t.Errorf("Metrics() = %p, want nil (no recording)", obs.Metrics())
+	cases := []struct {
+		name   string
+		tracer wrapper.Tracer
+	}{
+		{"bare nil", nil},
+		{"typed nil", typedNil},
 	}
-	if _, ok := obs.Tracer().(wrapper.NoopTracer); !ok {
-		t.Errorf("Tracer() = %T, want wrapper.NoopTracer for a nil input", obs.Tracer())
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			obs := NewCrossCellObs(nil, tc.tracer)
+
+			if obs.Metrics() != nil {
+				t.Errorf("Metrics() = %p, want nil (no recording)", obs.Metrics())
+			}
+			if _, ok := obs.Tracer().(wrapper.NoopTracer); !ok {
+				t.Errorf("Tracer() = %T, want wrapper.NoopTracer for a %s input", obs.Tracer(), tc.name)
+			}
+		})
 	}
 }
 

--- a/framework/runtime/transport/remote.go
+++ b/framework/runtime/transport/remote.go
@@ -158,7 +158,7 @@ func (t *RemoteHTTPTransport) DoContract(ctx context.Context, contractID string,
 	// The request host was rewritten from the resolver's endpoint, which derives
 	// from the operator-configured (sealed) deployment topology — not user input.
 	// This is the intended cross-cell dial, not an SSRF sink.
-	resp, err := t.client.Do(req.WithContext(ctx)) //nolint:gosec // G704: see rationale above (operator-configured endpoint)
+	resp, err := t.client.Do(req.WithContext(ctx)) //nolint:gosec // G107: sealed-topology endpoint, not user input (see above)
 	if err != nil {
 		dialErr := classifyDialError(contractID, t.targetCellID, err)
 		t.metrics.Record(ctx, modeRemote, dialOutcome(err))

--- a/framework/runtime/transport/remote.go
+++ b/framework/runtime/transport/remote.go
@@ -65,8 +65,9 @@ type RemoteHTTPTransport struct {
 //   - resolver nil → panicregister.Approved("remote-transport-nil-resolver")
 //   - client nil → panicregister.Approved("remote-transport-nil-client")
 //
-// metrics and tracer are optional: nil metrics records nothing; nil tracer
-// degrades to wrapper.NoopTracer{}.
+// metrics and tracer are optional: nil metrics records nothing; a nil or
+// typed-nil tracer degrades to wrapper.NoopTracer{} (via validation.IsNilInterface,
+// so a non-nil interface wrapping a nil pointer never reaches t.tracer.Start).
 func NewRemoteHTTP(
 	clk clock.Clock,
 	targetCellID string,
@@ -95,7 +96,7 @@ func NewRemoteHTTP(
 			errcode.Assertion(msgRemoteNilClient),
 		))
 	}
-	if tracer == nil {
+	if validation.IsNilInterface(tracer) {
 		tracer = wrapper.NoopTracer{}
 	}
 	return &RemoteHTTPTransport{

--- a/framework/runtime/transport/remote.go
+++ b/framework/runtime/transport/remote.go
@@ -192,40 +192,43 @@ func (t *RemoteHTTPTransport) DoContract(ctx context.Context, contractID string,
 // Returns KindInternal on an unparseable endpoint (a static wiring error, not
 // a transient network condition).
 func rewriteToAbsolute(req *http.Request, endpoint string) error {
-	rewriteErr := func() error {
+	scheme, host, ok := parseEndpoint(endpoint)
+	if !ok {
 		return errcode.New(errcode.KindInternal, errcode.ErrInternal, msgRemoteURLRewriteFail,
 			errcode.WithInternal(errcode.InternalAttr("endpoint", endpoint)))
 	}
+	req.URL.Scheme = scheme
+	req.URL.Host = host
+	return nil
+}
+
+// parseEndpoint splits a topology endpoint into its (scheme, authority) parts.
+// It is the SINGLE source shared by [rewriteToAbsolute] (request URL rewrite) and
+// [EndpointDialTarget] (readiness TCP dial) so the two can never drift (#2251 P2.7).
+//
+// Accepted forms (ok=true):
+//   - "http(s)://host[:port]" → (u.Scheme, u.Host).
+//   - bare "host:port" → ("http", endpoint); TLS enforcement is US6 #1964.
+//
+// Any path (beyond an optional root "/"), query, or fragment, or an empty
+// endpoint, is rejected (ok=false) rather than silently truncated (#1966 review
+// P2.9; netutil.IsValidNetworkAddress already rejects these at config time — this
+// is defense-in-depth, aligned on the same root-"/" tolerance).
+func parseEndpoint(endpoint string) (scheme, host string, ok bool) {
 	if strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://") {
 		u, err := url.Parse(endpoint)
 		if err != nil {
-			return rewriteErr()
+			return "", "", false
 		}
-		// Endpoints are scheme+host[:port] only. A path (beyond an optional root
-		// "/")/query/fragment would be silently dropped here (only Scheme+Host are
-		// copied), so reject it rather than truncate (#1966 review P2.9;
-		// netutil.IsValidNetworkAddress already rejects these at config time — this
-		// is defense-in-depth, aligned on the same root-"/" tolerance).
 		if (u.Path != "" && u.Path != "/") || u.RawQuery != "" || u.Fragment != "" {
-			return rewriteErr()
+			return "", "", false
 		}
-		req.URL.Scheme = u.Scheme
-		req.URL.Host = u.Host
-		return nil
+		return u.Scheme, u.Host, true
 	}
-	// Bare host:port — default to http (TLS enforcement is US6 #1964).
-	// Security note: postgres topology bare host:port walks over plaintext HTTP,
-	// so bearer/principal headers are confidential only within a private network.
-	// MAC (X-Gocell-ServiceToken) ensures integrity but NOT confidentiality;
-	// mTLS confidentiality is wired by US6 #1964.
-	// A bare endpoint carrying a path/query/fragment (e.g. "host:port/foo") would
-	// likewise be truncated, so reject it (#1966 review P2.9, defense-in-depth).
-	if strings.ContainsAny(endpoint, "/?#") {
-		return rewriteErr()
+	if endpoint == "" || strings.ContainsAny(endpoint, "/?#") {
+		return "", "", false
 	}
-	req.URL.Scheme = "http"
-	req.URL.Host = endpoint
-	return nil
+	return "http", endpoint, true
 }
 
 // classifyDialError wraps a client.Do transport-level error (no HTTP response

--- a/framework/runtime/transport/remote_test.go
+++ b/framework/runtime/transport/remote_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/wrapper"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/framework/runtime/transport"
 )
@@ -20,6 +21,47 @@ type stubResolver struct {
 
 func (s *stubResolver) Resolve(_ context.Context, _ string) (string, error) {
 	return s.endpoint, s.err
+}
+
+// derefTracer is a wrapper.Tracer whose pointer-receiver Start dereferences its
+// receiver. A typed-nil *derefTracer in a wrapper.Tracer interface is non-nil at
+// the interface level but panics the moment Start is invoked on the nil receiver
+// — the exact #2251 review F2 failure mode the constructor must normalize away.
+type derefTracer struct{ calls int }
+
+func (d *derefTracer) Start(ctx context.Context, _ string, _ ...wrapper.Attr) (context.Context, wrapper.Span) {
+	d.calls++ // nil-receiver dereference → panic when the typed-nil is not normalized
+	return ctx, nil
+}
+
+// TestNewRemoteHTTP_TypedNilTracerDegradesToNoop asserts a typed-nil tracer
+// passed to NewRemoteHTTP is normalized to wrapper.NoopTracer{} (via
+// validation.IsNilInterface), so DoContract does not panic at t.tracer.Start.
+// Pre-fix (bare `tracer == nil`) the typed-nil *derefTracer slips through and
+// DoContract panics on the nil-receiver Start (#2251 review F2).
+func TestNewRemoteHTTP_TypedNilTracerDegradesToNoop(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	var typedNil *derefTracer // typed-nil wrapper.Tracer wrapping a nil pointer
+	resolver := &stubResolver{endpoint: srv.URL}
+	tr := transport.NewRemoteHTTP(
+		clock.Real(), "configcore", resolver, srv.Client(), nil, typedNil,
+	)
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://ignored/internal/v1/x", nil)
+	resp, err := tr.DoContract(context.Background(), "http.config.internal.get.v1", req)
+	if err != nil {
+		t.Fatalf("DoContract: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
+	}
 }
 
 // TestRemoteHTTPTransport_HappyPath verifies that a successful round-trip

--- a/tools/archtest/crosscellobs_minter_funnel_test.go
+++ b/tools/archtest/crosscellobs_minter_funnel_test.go
@@ -1,0 +1,210 @@
+//go:build archtest
+
+// crosscellobs_minter_funnel_test.go — locks the SOLE sanctioned minter of the
+// sealed transport.CrossCellObs cross-cell observability bundle (#2251 P1.3,
+// epic #1423).
+//
+// INVARIANT: CROSSCELLOBS-MINTER-FUNNEL-01
+//
+// # What this guards
+//
+// transport.CrossCellObs bundles the metrics + tracer a remote CellTransport
+// needs into ONE value, so that celltransport.Resolve receives a single pre-built
+// param and the asymmetric "wired metrics but forgot the tracer" state is
+// unrepresentable at that boundary (the Resolve sealed-param seal is Hard). The
+// SECONDARY guarantee — the bundle's tracer is the SAME source composition.Builder
+// threads into in-process spans via bootstrap.WithTracer, so remote and in-proc
+// spans never diverge (ADR 202606131142-1423 D4) — depends on composition.Builder
+// being the ONLY place that mints the bundle. transport.NewCrossCellObs is an
+// exported constructor, so any package could mint its own bundle with a divergent
+// tracer; the type system cannot express "only composition may mint" across module
+// boundaries.
+//
+// This archtest pins every production reference of transport.NewCrossCellObs to
+// the sole sanctioned minter, framework/runtime/composition (Builder.Build), which
+// mints it from the single-source SharedDeps.Tracer + shared transport metrics.
+// Modules receive the pre-built bundle via composition.SharedDeps.TransportObs;
+// they never call the constructor themselves.
+//
+// # AI-robust rating (charter §"Funnel 双向锁评级")
+//
+//   - Downstream (sealed construction): HARD — CrossCellObs's fields are
+//     unexported, so a bundle cannot be struct-literal-forged out-of-package; the
+//     only mint path is the constructor.
+//   - Upstream (only composition.Builder mints): MEDIUM — this caller-allowlist
+//     archtest, a deliberately accepted permanent ceiling, not a deferred TODO.
+//     CrossCellObs lives in framework/runtime/transport so celltransport (root
+//     module) can consume its accessors; the minter is framework/runtime/
+//     composition; the consumer is cellmodules/celltransport — three packages
+//     across two modules with unexported fields owned by transport. A sealed mint
+//     token from composition would be a cross-module import cycle, so Go visibility
+//     cannot express "only composition may mint". Same Go/module ceiling documented
+//     for EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01, the RowScopeAll minter,
+//     COMMAND-ASYNC-EMIT-CALLER-01, OUTBOX-RECONSTRUCTION-CALLER-01
+//     (#851/#893/#1282). No fake Hard-upgrade issue is opened.
+//
+// # Detection is type-aware (not string scanning)
+//
+// The scan visits every ast.SelectorExpr and resolves it via ResolvePackageRef to
+// runtime/transport.NewCrossCellObs (alias- and dot-import-proof). It is a
+// SelectorExpr-level (reference) scan, NOT a CallExpr.Fun-only scan, so it catches
+// both a direct call (transport.NewCrossCellObs()) AND a function-value reference
+// (mint := transport.NewCrossCellObs; mint()) — the latter would evade a
+// CallExpr.Fun scan because the resulting call's Fun is a local ident.
+//
+// # Tool blind spots (charter §"强制盲区自检")
+//
+//  1. A bundle minted through a function value (mint := transport.NewCrossCellObs;
+//     mint()) IS caught: the assignment's RHS is the SelectorExpr
+//     transport.NewCrossCellObs, which the SelectorExpr-level scan resolves
+//     directly (regression-tested by the fixture's ForgeViaFuncValue RED case).
+//  2. _test.go files are out of scope (Production scope, Tests:false): test helpers
+//     mint bundles to exercise the constructor; a bundle minted in a test never
+//     reaches production wiring.
+//  3. The RED fixture is build-tagged (archtest_fixture), excluded from the
+//     default-tags Production scan, so it cannot pollute the production result.
+//  4. Reflection-based construction is out of scope (theoretical, same posture as
+//     EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01).
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// crossCellObsMinterName is the sealed bundle minter on the transport package.
+// runtimeTransportModule (the transport import path) is reused from
+// celltransport_select_funnel.go (same archtest package).
+const crossCellObsMinterName = "NewCrossCellObs"
+
+// crossCellObsMinterPkgPath is the SOLE sanctioned caller package:
+// framework/runtime/composition, whose Builder.Build mints the bundle from the
+// single-source SharedDeps.Tracer + shared transport metrics.
+const crossCellObsMinterPkgPath = PlatformFrameworkModulePath + "/runtime/composition"
+
+// crossCellObsMintFixturePkg is the build-tagged RED fixture exercised by the
+// reverse self-check.
+const crossCellObsMintFixturePkg = "./tools/archtest/internal/crosscellobsmintfixture"
+
+// isNewCrossCellObsRef reports whether sel references transport.NewCrossCellObs
+// (alias/dot-import-proof via ResolvePackageRef). Resolving the SelectorExpr (not
+// a CallExpr.Fun) catches BOTH a direct call (transport.NewCrossCellObs()) and a
+// function-value reference (mint := transport.NewCrossCellObs; mint()).
+func isNewCrossCellObsRef(p *Pass, sel *ast.SelectorExpr) bool {
+	pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, sel)
+	return ok && pkgPath == runtimeTransportModule && name == crossCellObsMinterName
+}
+
+// TestCrossCellObsMinterFunnel01 asserts every production reference of
+// transport.NewCrossCellObs sits in framework/runtime/composition, and that
+// composition actually mints it (anti-vacuity).
+func TestCrossCellObsMinterFunnel01(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var observed, observedInFunnel bool
+	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		inFunnel := p.Pkg.Path() == crossCellObsMinterPkgPath
+		var d []Diagnostic
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+				if !isNewCrossCellObsRef(p, sel) {
+					return
+				}
+				observed = true
+				if inFunnel {
+					observedInFunnel = true
+					return // composition.Builder is the sanctioned minter
+				}
+				pos := p.Fset.Position(sel.Pos())
+				d = append(d, Diagnostic{
+					Rel:  rel,
+					Line: pos.Line,
+					Message: fmt.Sprintf(
+						"CROSSCELLOBS-MINTER-FUNNEL-01: %s references transport.NewCrossCellObs "+
+							"(direct call OR function-value reference) outside the sole sanctioned minter "+
+							"framework/runtime/composition.Builder. The CrossCellObs bundle binds the remote "+
+							"transport's tracer to the SAME source composition threads into in-process spans via "+
+							"bootstrap.WithTracer; minting it elsewhere can pair a divergent tracer with remote "+
+							"calls, breaking the single-source span invariant (ADR 202606131142-1423 D4). Receive "+
+							"the pre-built bundle from composition.SharedDeps.TransportObs instead; or, if this is "+
+							"a genuinely new sanctioned minter, widen the funnel allowlist with a rationale.",
+						rel),
+				})
+			})
+		}
+		return d
+	})
+
+	// Anti-vacuity: composition must actually mint the bundle, else the funnel
+	// guards nothing (the minter was removed/renamed or the scanner regressed).
+	if !observed {
+		diags = append(diags, Diagnostic{
+			Message: "CROSSCELLOBS-MINTER-FUNNEL-01 anti-vacuity: no production reference to " +
+				"transport.NewCrossCellObs() was observed anywhere. composition.Builder.Build must mint it — " +
+				"either the minter was removed/renamed or the scanner regressed; the funnel guards nothing.",
+		})
+	}
+	// Second anti-vacuity: the observed mint must occur INSIDE the sanctioned
+	// minter package, exercising the allowlist GREEN path. If observed==true but
+	// observedInFunnel==false, the only mint is somewhere else and the funnel's
+	// suppression branch was never taken (the composition pkgPath drifted or the
+	// minter moved out) — a silent regression of the funnel's anchor.
+	if observed && !observedInFunnel {
+		diags = append(diags, Diagnostic{
+			Message: "CROSSCELLOBS-MINTER-FUNNEL-01 anti-vacuity: transport.NewCrossCellObs() is minted in " +
+				"production but NOT inside " + crossCellObsMinterPkgPath + "; the sanctioned-minter (GREEN) " +
+				"path was never exercised. Either the minter moved out of composition.Builder or " +
+				"crossCellObsMinterPkgPath drifted.",
+		})
+	}
+
+	Report(t, "CROSSCELLOBS-MINTER-FUNNEL-01", diags)
+}
+
+// TestCrossCellObsMinterFunnel01_RedFixture verifies the scanner fires against a
+// package that references transport.NewCrossCellObs outside composition — BOTH as
+// a direct call (ForgeBundle) AND as a function-value reference (ForgeViaFuncValue)
+// — and does NOT flag the SafeOtherCtor (NewInProcess) GREEN control. found==0
+// means the scanner is fail-open (anti-vacuity for the detector itself); found==1
+// would mean the function-value reference still evades.
+func TestCrossCellObsMinterFunnel01_RedFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var found int
+	_ = Run(t, Fixture(FixtureOpts{Tests: false}, []string{crossCellObsMintFixturePkg}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		// The fixture package path is not framework/runtime/composition, so any
+		// NewCrossCellObs reference there is a violation; NewInProcess (the GREEN
+		// control) must not be counted.
+		for _, file := range p.Files {
+			EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+				if isNewCrossCellObsRef(p, sel) {
+					found++
+				}
+			})
+		}
+		return nil
+	})
+
+	assert.Equal(t, 2, found,
+		"CROSSCELLOBS-MINTER-FUNNEL-01 RED fixture self-check FAILED: expected exactly 2 violations from "+
+			"crosscellobsmintfixture (ForgeBundle's direct call + ForgeViaFuncValue's function-value reference; "+
+			"the SafeOtherCtor NewInProcess control must NOT be flagged); got %d. found==1 means a function-value "+
+			"reference still evades the scan; found==0 means the scanner is fail-open — check ResolvePackageRef "+
+			"resolves SelectorExpr under the archtest_fixture tag.", found)
+}

--- a/tools/archtest/internal/crosscellobsmintfixture/fixture.go
+++ b/tools/archtest/internal/crosscellobsmintfixture/fixture.go
@@ -1,0 +1,46 @@
+//go:build archtest_fixture
+
+// Package crosscellobsmintfixture is the RED fixture for
+// CROSSCELLOBS-MINTER-FUNNEL-01.
+//
+// It references transport.NewCrossCellObs — the sealed cross-cell observability
+// bundle minter — from OUTSIDE framework/runtime/composition (the sole sanctioned
+// minter) two ways: a direct call (ForgeBundle) and a function-value reference
+// (ForgeViaFuncValue, the func-value blind spot a CallExpr.Fun-only scan would
+// miss). Both are the forge the funnel must flag: a package that mints its own
+// CrossCellObs can pair the remote transport with a DIFFERENT tracer than the one
+// composition.Builder threads into in-process spans via bootstrap.WithTracer,
+// breaking the "remote and in-proc spans share one tracer" single-source invariant
+// (ADR 202606131142-1423 D4).
+//
+// SafeOtherCtor is the GREEN control: it constructs a DIFFERENT transport value
+// (NewInProcess), which the scanner must NOT flag — the funnel keys on the
+// NewCrossCellObs symbol, not on any transport selector.
+//
+// DO NOT use this package in production code.
+package crosscellobsmintfixture
+
+import "github.com/ghbvf/gocell/framework/runtime/transport"
+
+// ForgeBundle mints a CrossCellObs outside composition via a direct call — the
+// violation the funnel must catch.
+func ForgeBundle() transport.CrossCellObs {
+	return transport.NewCrossCellObs(nil, nil)
+}
+
+// ForgeViaFuncValue launders the minter through a function value before calling
+// it: the call expression's Fun is the local `mint`, so a CallExpr.Fun-only scan
+// would MISS this. The funnel's SelectorExpr-level scan resolves the
+// transport.NewCrossCellObs reference on the assignment RHS, so it is still
+// flagged. Regression guard for the func-value blind spot.
+func ForgeViaFuncValue() transport.CrossCellObs {
+	mint := transport.NewCrossCellObs
+	return mint(nil, nil)
+}
+
+// SafeOtherCtor constructs a different transport value (NewInProcess) — the GREEN
+// control the scanner must leave unflagged (it keys on NewCrossCellObs, not any
+// transport selector).
+func SafeOtherCtor() {
+	_ = transport.NewInProcess(nil)
+}

--- a/tools/archtest/shareddeps_fieldset_frozen_test.go
+++ b/tools/archtest/shareddeps_fieldset_frozen_test.go
@@ -49,7 +49,7 @@
 // ## Symbol inventory (lives here, not in ai-robust.md per the charter)
 //
 //   - Frozen type: github.com/ghbvf/gocell/framework/runtime/composition.SharedDeps
-//   - Frozen golden: sharedDepsFrozenExportedFields (23 exported fields)
+//   - Frozen golden: sharedDepsFrozenExportedFields (25 exported fields)
 //
 // Relationship: advances #1412 (SharedDeps Hard-ization) by covering the
 // field-set dimension. The unexported sealed-construction marker (valid) is
@@ -95,6 +95,8 @@ var sharedDepsFrozenExportedFields = map[string]string{
 	"PrimaryHTTPAddr":      "string",
 	"InternalHTTPAddr":     "string",
 	"InProcessTransport":   "*transport.InProcessTransport",
+	"Tracer":               "wrapper.Tracer",
+	"TransportObs":         "transport.CrossCellObs",
 	"HealthHTTPAddr":       "string",
 	"MetricsToken":         "string",
 	"VerboseToken":         "string",

--- a/tools/archtest/shareddeps_fieldset_frozen_test.go
+++ b/tools/archtest/shareddeps_fieldset_frozen_test.go
@@ -171,9 +171,10 @@ func TestSharedDepsFieldSetFrozen01_DetectorRejectsPerturbation(t *testing.T) {
 
 	// (c) Same field NAMES but one field RETYPED: proves that type-string drift is
 	// caught at constant field count, not just count drift. Clock is retyped from
-	// clock.Clock → string; all other 20 field names are preserved. This red case
-	// demonstrates that exportedFieldTypeStrings detects type-string divergence,
-	// not just field-set membership divergence.
+	// clock.Clock → string; all other 24 field names (the full golden set) are
+	// preserved so the ONLY divergence is Clock's type. This red case demonstrates
+	// that exportedFieldTypeStrings detects type-string divergence, not just
+	// field-set membership divergence.
 	type sharedDepsRetypedClock struct {
 		Clock                string // was clock.Clock — intentional type perturbation
 		Topology             string
@@ -192,6 +193,8 @@ func TestSharedDepsFieldSetFrozen01_DetectorRejectsPerturbation(t *testing.T) {
 		PrimaryHTTPAddr      string
 		InternalHTTPAddr     string
 		InProcessTransport   string
+		Tracer               string
+		TransportObs         string
 		HealthHTTPAddr       string
 		MetricsToken         string
 		VerboseToken         string
@@ -201,7 +204,7 @@ func TestSharedDepsFieldSetFrozen01_DetectorRejectsPerturbation(t *testing.T) {
 	}
 	retyped := exportedFieldTypeStrings(reflect.TypeOf(sharedDepsRetypedClock{}))
 	assert.NotEqual(t, sharedDepsFrozenExportedFields, retyped,
-		"%s anti-vacuity (type drift): a struct with the same 23 field names but Clock "+
+		"%s anti-vacuity (type drift): a struct with the same 25 field names but Clock "+
 			"retyped to string must NOT match the golden — proves type-string drift detection, "+
 			"not just field-set membership detection", ruleSharedDepsFieldSetFrozen01)
 


### PR DESCRIPTION
## Summary

给 cross-cell remote transport 补两个可观测/Ops 收尾：remote 调用的 trace span 单源接线（关闭 ADR D4 span 半缺口，P1.3）+ 远端 peer 的 readiness probe 闭环（split topology 下远端不可达可摘流量，P2.7）。

## Why / 背景

承接 PR #2228（#1966 US5 sync remote transport）review 拆出的两条 follow-up（#2251）：

- **P1.3（Observability）**：此前 `accesscore` 给 `celltransport.Resolve(..., shared.TransportMetrics, nil)` 传 **nil tracer** → remote 调用退化为 `NoopTracer`，远端调用不产 span（ADR `202606131142-1423` D4 要求 trace 也区分 in_proc/remote，metrics 已闭、span 半残留）。
- **P2.7（Ops）**：remote endpoint 未进 readiness 闭环——split topology 下远端 cell 不可达时本 cell `/readyz` 仍 200，运维无法据此摘流量。

**做法（含激进自审产出的 Hard 化）**：

- **P1.3 → sealed `transport.CrossCellObs` 单源（Resolve sealed-param Hard + minter Medium funnel）**：tracer + metrics 收敛进一个 sealed 捆绑（unexported 字段，唯一 minter = `composition.Builder`）。`SharedDeps` 以输入 `Tracer` + 派生 `TransportObs` **替换**松散的 `TransportMetrics` 字段；`Builder` 同时 `bootstrap.WithTracer`（router/in-proc/event-router）并注入捆绑（remote），故 remote 与 in-proc span **同源**。`celltransport.Resolve` 收**一个**预建捆绑参——边界上没有可省略/可 nil 的 tracer 参数，「接 metrics 忘 tracer」在 Resolve 边界**类型级不可表达**（Hard sealed-param）。**minter 评级修正（#2260 review F1 闭合）**：原把「唯一 minter = `composition.Builder`」整体标 Hard 是 overclaim——`NewCrossCellObs` 是跨模块 exported 构造器；下游 `CrossCellObs` sealed 字段不可伪造（Hard），但上游「只 composition mint」只能靠 caller-funnel `CROSSCELLOBS-MINTER-FUNNEL-01`（Medium，type-aware AST scan + build-tagged RED fixture），同 `EVENT-TRANSPORT-KIND-MINTER-FUNNEL-01` 族永久 Go/module 天花板。范围 **seam-only**：`SharedDeps.Tracer` 可 nil（降级 NoopTracer），生产暂不接真 otel（见下 EPIC）。
- **P2.7 → TCP-dial readiness probe（cascade-safe）**：`celltransport.Resolve` 的 remote 分支经 `ModuleResult.Resources` 注册 `<cell>_remote_ready`（typed `healthz.RemoteCellReadyProbeName`）。probe 只对 resolved endpoint 做 **TCP dial**（`transport.EndpointDialTarget` 解析，与 `rewriteToAbsolute` 同源），**不**打远端 `/readyz`——避免 A↔B 互探 readiness 级联雪崩。peer down → 本 cell `/readyz` 降级（摘流量），只进 readiness aggregator、**不** kill liveness。

**对标**：readiness 降级而非 liveness kill 对齐 k8s readiness gate / controller-runtime 的依赖收敛语义（概念对标，无新增外部源码 fetch）。

**范围切割 → EPIC（已建，见 Refs）**：本 PR 只做 TCP-dial 基线；更丰富的 peer health（HTTP `/readyz` 深度探测 + 远端 health-listener 地址发现、多副本 endpoint、liveness/readiness 编排、依赖环检测）归独立 EPIC「类 k8s cell 运行时管理」。

## Refs

- Closes #2251
- EPIC（范围切割）：见本 PR 评论中 `pm:oos` / 自动建单
- ADR：`docs/architecture/202606131142-1423-adr-cell-deployment-topology.md` §#2251 Amendment（span 半闭合 + readiness 威胁矩阵补全 + golden drift 修复）

## Risk / 兼容性

- **无 wire / 契约扇出**：纯 runtime/observability + composition 接线，无 contract schema / generated / slice / proto 变更，无新 `transport_mode`/`outcome` 枚举值。
- **不向后兼容（按项目约定，无外部消费方）**：`celltransport.Resolve` 签名变更（`(…, metrics, tracer)` → `(…, obs)`，+返回 `[]ManagedResource`），单一 in-repo 生产调用方（accesscore）随本 PR 原子更新；`SharedDeps.TransportMetrics` 字段移除（换 `Tracer`+`TransportObs`），无 shim/别名/双路径。
- **顺带修复 base 上的 golden drift**：`SHAREDDEPS-FIELDSET-FROZEN-01` golden 此前漏更 #1966 加的 `TransportMetrics` 字段（base 已红，该 archtest 不在 PR CI lane）；本 PR 同步 golden 归绿。
- **已知 pre-existing 失败（与本 PR 无关，不在范围）**：`TestAdaptersExportedTypesManagedResourceOrOptOut` 因 `adapters/softca.*`（#1895 新增类型未登记 opt-out）在 base 即红；本 PR 不触 adapters，不修复。

## Test plan

- [x] `go build ./framework/... ./cellmodules/... ./cmd/... ./examples/...` 本地通过（多模块 go.work）
- [x] `go test ./framework/... ./cellmodules/...` 全绿（含 TDD RED→GREEN：CrossCellObs / Resolve obs+probe / EndpointDialTarget / RemoteCellReadyProbeName / TCP-dial cascade-safe / builder 单源）
- [x] `go test -tags=archtest ./tools/archtest/...`：`SHAREDDEPS-FIELDSET-FROZEN-01`（修复归绿）、`PROBENAME-SEALED-FUNNEL-01`、`CELLTRANSPORT-SELECT-FUNNEL-01` 绿；仅 softca pre-existing 失败（见上）
- [x] `golangci-lint run`（framework / cellmodules 改动包 + tools/archtest --build-tags=archtest）0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

