### PR TITLE
docs(command): sync command bus completion docs

### DIFF
--- a/docs/architecture/202606040550-1044-adr-command-bus-dispatch-funnel.md
+++ b/docs/architecture/202606040550-1044-adr-command-bus-dispatch-funnel.md
@@ -6,7 +6,7 @@
 - 关联：`docs/plans/framework-capability-gaps/202605131500-004-capability-gap-analysis.md` 缺口 4 / `…/202605162100-005-framework-capability-roadmap-plan.md` W3
 - 对标：Watermill `components/cqrs/{command_bus,command_processor}.go`（ref 见 §6）
 
-> **真值边界**：本 ADR 是 command-bus 设计决策的概念单源。各 enforcement 的符号清单 / 盲区 / 反向自检活在对应 archtest 的 package godoc（`tools/archtest/command_dispatch_funnel_test.go`）与 governance 实现（`kernel/governance/rules_command.go`），本文件只汇总决策 + 评级矩阵，不复制。PR-1 只交付**同步核心**；④ async outbox 桥 / ⑤ idempotency 桥落地时 **amend 本 ADR**（§5 演进路径 + §4 评级矩阵逐行重评）。
+> **真值边界**：本 ADR 是 command-bus 设计决策的概念单源。各 enforcement 的符号清单 / 盲区 / 反向自检活在对应 archtest 的 package godoc（`tools/archtest/command_dispatch_funnel_test.go`）与 governance 实现（`kernel/governance/rules_command.go`），本文件只汇总决策 + 评级矩阵，不复制。PR-1 最初只交付**同步核心**；后续 amendment 已把 ④ async outbox 桥、⑤ idempotency / Claimer 桥、command-entry value validation、consistencyLevel governance、真实 async producer / relay wiring、HTTP async bridge 和 generated producer wrapper 纳入本 ADR，并在对应 amendment 中逐行重评 §4 评级矩阵。
 
 ---
 
@@ -59,9 +59,9 @@ issue 立项门要「上游 Hard + 下游 Hard」。**闭环 funnel 由两条 in
 
 ---
 
-## 5. 演进路径（④/⑤ 落地时 amend 本 ADR）
+## 5. 演进路径与落地状态
 
-PR-1 同步核心是 W3 的第一片。`Registry` map signature 与生成码 funnel 为后续保持**前向兼容的 seam**（不预设字段，需要时加）：
+PR-1 同步核心是 W3 的第一片。`Registry` map signature 与生成码 funnel 为后续保持**前向兼容的 seam**（不预设字段，需要时加）。截至 2026-06-15，④/⑤ 及其必要 follow-up 已在下列 amendment 中落地；仍未覆盖的后续 archetype（如 saga step→command）按各自 issue 独立交付：
 
 - **④ async outbox 桥（#1667，已落地——见 §Amendment 2026-06-06）**：codegen 派生单态 `DispatchAsync(ctx, reg, entry)`（从 `entry.Payload()` JSON unmarshal 回 typed `*Request` → `LookupHandler` → 复用同一 `Handler`，丢弃 `*Response` 回 `error`）；relay 按 routing-topic 在 composition-root 注入的 dispatcher-map 中匹配 command → 在进程内触发 `DispatchAsync`，否则发 broker。JSON marshal 在 outbox 边界发生（D4 同步 type-assert 路径不变）。**判别器 = routing-topic + dispatcher-map 成员，未改 sealed `Entry` wire envelope、未引入 metadata 约定 → 未触发 contract-fanout 5 载体**（原文「携带 command kind——触及 sealed Entry wire envelope 或 topic 约定，触发 contract-fanout」+「relay 消费按 command id LookupHandler」实现为：command entry 即 `eventType = command id` 的普通 entry，`LookupHandler` 留在生成 `DispatchAsync` 体内、relay 不直接调）。
 - **⑤ idempotency 桥（#1669 映射半 + #1698 消费半，已落地）**：HTTP Idempotency-Key ↔ command_id 映射（复用 `runtime/http/idempotency` 派生 key + `kernel/idempotency.Claimer` 两阶段）。**映射原语半已落地（#1669 PR-A）**：`runtime/http/idempotency` sealed funnel 扩第二构造器 `DeriveCommandKey(tenant, subject, command_id)`——纯编译期形态，产同一 sealed `IdempotencyKey`、流同一 `Store.Claim` sink（详见 ADR-1449 §Amendment 2026-06-07）；#1610 cross-cell 同槽路由消费它。**Claimer-wrap 消费半已落地（#1698 PR-B，见 §Amendment 2026-06-08）**：`kernel/idempotency.Claimer` 两阶段包裹 relay 命令分发 + 三态生命周期；sealed-key→Claimer string-key 经新增 `IdempotencyKey.Flat()` 扁平化（node-agnostic）；per-instance 身份经 `outbox.Entry` 的 `AggregateID(subject)` + business-metadata（command_id）承载，随真实 devicecell 异步 command producer 一并落地。**§4 评级矩阵新增「命令幂等身份双向锁 funnel」行（见 §Amendment 2026-06-08）**，无 ✅→⚠️/❌ 降格。
@@ -111,7 +111,7 @@ amend 时须回到 §4 矩阵逐行重评（ai-robust.md ADR amendment 必查）
    - **可信边界**：sync `Dispatch` 的调用方是 **in-process 第一方 Go 代码**（派发 cell），非不可信 wire 输入。JSON-schema 值约束是 untrusted-JSON 的 wire 卫生规则；在 in-process typed 调用上重复执行是对编程错误的 defense-in-depth，非安全/正确性边界。
    - **D4 = 零序列化 fast-path**：`schemavalidate.Validator.Validate(ctx, body []byte)` 是 **JSON-bytes 校验器**；在 **sync** 路径复用它必须先把 typed `*Request` marshal 回 JSON——正是 D4 拒绝的 round-trip，故 sync `Dispatch` **不**复用 validator。**注意此论据只约束 sync 路径**：async `DispatchAsync` 的输入 `entry.Payload()` 本就是入站 JSON bytes，对它直接 `Validate` 不产生任何 marshal round-trip，故 async 边界复用同一 validator 与 D4 不矛盾（见 §Amendment 2026-06-08）。
 
-3. **value-validation 归属不可信 command-entry 边界**（= §5 演进路径的 ④/⑤）：HTTP→command（handler 在入 cell 前已校验 untrusted JSON）、async outbox→command（D4 已注明 JSON marshal 在 outbox 边界发生）。这些边界落地时，request schema 的值约束在**该处**执行——schemaRef 因此最终*被*执行，只是不在 in-process fast-path 上冗余重检。command-entry validation funnel 设计与 ④ async 共同落地，跟踪为 **#1588**（`Discovered via /fix #1578 F5`）——**async outbox→command 边界已交付（见 §Amendment 2026-06-08）**；HTTP→command 边界今日无 wiring，落地时复用 HTTP handler 既有 validator（sync `Dispatch` 前已校验 untrusted body）。
+3. **value-validation 归属不可信 command-entry 边界**（= §5 演进路径的 ④/⑤）：HTTP→command（handler 在入 cell 前已校验 untrusted JSON）、async outbox→command（D4 已注明 JSON marshal 在 outbox 边界发生）。这些边界落地时，request schema 的值约束在**该处**执行——schemaRef 因此最终*被*执行，只是不在 in-process fast-path 上冗余重检。command-entry validation funnel 设计与 ④ async 共同落地，跟踪为 **#1588**（`Discovered via /fix #1578 F5`）——**async outbox→command 边界已交付（见 §Amendment 2026-06-08）**；HTTP async bridge 已通过 `http.device.command.enqueue-async.v1` → generated HTTP validation → `Service.EnqueueAsync` → generated `EmitAsyncFromIdempotencyKey` → relay `DispatchAsync` 落地（见 §Amendment 2026-06-15 / #1610）。
 
 **§4 评级矩阵逐行重评（ai-robust.md ADR amendment 必查）**：本 amendment **不改 §4 任一格**。§4 双向锁矩阵约束的是 *dispatch/register funnel*（typed Handler/Register/Dispatch 仅由 codegen 派生 + raw `RegisterHandler`/`LookupHandler` 调用方收口），与 *request value-validation* 正交——后者既不放宽前者的上游/下游 Hard，也不新增伪造面。D4（golden 锁 sync 形态）、D6（codegen fail-closed 上游 Hard + governance Medium）评级不变；无 ✅→⚠️/❌ 降格，无需补偿措施。
 

--- a/docs/guides/command-bus.md
+++ b/docs/guides/command-bus.md
@@ -1,11 +1,15 @@
 # Command Bus Guide
 
-The **synchronous command bus** lets one in-process, first-party caller invoke a
-typed business operation owned by a cell, by a stable command id, without an HTTP
-round-trip. A `contract.yaml` of `kind: command` (with `codegen: true`) is the
-single source: codegen derives a typed `Handler` interface plus `Register` /
-`Dispatch` functions, and the cell implements the `Handler` and registers it into
-a process-wide `command.Registry`.
+The **command bus** lets first-party code route a typed business operation owned
+by a cell through a stable command id. The synchronous fast-path calls a
+registered handler in-process, without an HTTP round-trip. The async path writes a
+command outbox entry and lets the relay invoke the generated dispatcher under the
+same registry.
+
+A `contract.yaml` of `kind: command` is the single source: codegen derives a
+typed `Handler` interface plus `Register`, `Dispatch`, `DispatchAsync`,
+`EmitAsync`, and `EmitAsyncFromIdempotencyKey` functions. The cell implements the
+`Handler` and registers it into a process-wide `command.Registry`.
 
 > Design authority: ADR
 > [`docs/architecture/202606040550-1044-adr-command-bus-dispatch-funnel.md`](../architecture/202606040550-1044-adr-command-bus-dispatch-funnel.md).
@@ -19,38 +23,45 @@ a process-wide `command.Registry`.
 | An external client to call an endpoint over the network | `kind: http` | Untrusted boundary: auth, JSON validation, status codes. |
 | To react to something that already happened, decoupled, at-least-once | `kind: event` (subscribe) | Async fan-out; producer and consumer are independent. |
 | To run a multi-step, cross-cell workflow with compensation | `kind: saga` (orchestrate) | Durable state machine + reverse-idempotent compensation. |
-| One in-process caller to invoke a typed cell operation by command id, synchronously | **`kind: command`** | Typed, in-process, registry-routed; no wire, no serialization. |
+| First-party code to invoke one typed cell operation by command id | **`kind: command`** | Typed registry route; sync is in-process, async goes through outbox relay. |
 
 The command bus is **not** a second HTTP layer and **not** an event bus:
 
-- It is **synchronous and in-process** — `Dispatch` calls the registered handler
-  directly (no JSON round-trip, no broker). Per ADR §D4/§D6, the request schema
-  *sources the typed `*Request` signature*; it is **not** re-validated at runtime
-  on the sync path (the caller is trusted first-party code). Value validation
-  belongs at the untrusted entry points that *front* the command bus (HTTP→command,
-  async outbox→command) — those bridges are later PRs.
+- Its sync fast-path is **synchronous and in-process** — `Dispatch` calls the
+  registered handler directly (no JSON round-trip, no broker). Per ADR §D4/§D6,
+  the request schema *sources the typed `*Request` signature*; it is **not**
+  re-validated at runtime on the sync path (the caller is trusted first-party
+  code). Value validation belongs at untrusted entry points: generated HTTP
+  handlers validate incoming bodies before service calls, and generated
+  `DispatchAsync` validates outbox entry payload bytes before invoking the
+  handler.
 - It is **one handler per command id** (`Register` rejects a duplicate with
   `ErrConflict`), unlike event fan-out where every consumer group gets a copy.
+- Its async path is **outbox-backed and relay-routed** — generated `EmitAsync`
+  writes a command entry whose routing topic is the command `DispatchID`; the
+  relay's `WithCommandDispatch` map routes matching entries to the generated
+  `DispatchAsync` instead of publishing them to the broker.
 
 ## The three-step flow
 
-### 1. Declare the contract (`kind: command`, `codegen: true`)
+### 1. Declare the contract (`kind: command`)
 
 ```yaml
 # examples/iotdevice/contracts/command/devicecommand/enqueue/v1/contract.yaml
 id: command.devicecommand.enqueue.v1
 kind: command
-codegen: true          # emits command_gen.go (Handler / Register / Dispatch)
 ownerCell: devicecell
 consistencyLevel: L4
 lifecycle: active
 endpoints:
   handler: devicecell
-  invokers: []
+  invokers: [devicecell]
 schemaRefs:
   request: request.schema.json    # sources the typed *Request DTO
   response: response.schema.json   # sources the typed *Response DTO
 ```
+
+`codegen` defaults to enabled; set `codegen: false` only to opt out explicitly.
 
 `gocell generate contract` (run `go run ./cmd/gocell generate contract --all`)
 derives, into `generated/contracts/command/devicecommand/enqueue/v1/`:
@@ -64,13 +75,22 @@ type Handler interface {
 
 func Register(reg *command.Registry, h Handler) error
 func Dispatch(ctx context.Context, reg *command.Registry, req *Request) (*Response, error)
+func DispatchAsync(ctx context.Context, reg *command.Registry, entry outbox.Entry) error
+func EmitAsync(ctx context.Context, clk clock.Clock, emitter outbox.Emitter,
+    subject, commandID string, req *Request, opts ...command.EmitOption) error
+func EmitAsyncFromIdempotencyKey(ctx context.Context, clk clock.Clock,
+    emitter outbox.Emitter, subject string, req *Request,
+    opts ...command.EmitOption) error
 ```
 
-The typed `Handler` is the **sole** sanctioned target of `Register`/`Dispatch`;
-hand-writing an equivalent trio elsewhere is rejected by archtest
+The typed `Handler` and generated free functions are the sanctioned command
+surface. Hand-writing an equivalent funnel elsewhere is rejected by archtest
 `COMMAND-GEN-FUNNEL-SOLE-EMITTER-01`. Calling `command.Registry.RegisterHandler`
 directly (bypassing the generated `Register`) is rejected by
-`COMMAND-DISPATCH-REGISTER-CALLER-01`.
+`COMMAND-DISPATCH-REGISTER-CALLER-01`; wiring relay command dispatch with anything
+other than the generated `DispatchID`/`DispatchAsync` pair is rejected by
+`COMMAND-ASYNC-DISPATCH-CALLER-01`; bypassing the generated emit wrappers is
+rejected by `COMMAND-ASYNC-EMIT-CALLER-01`.
 
 ### 2. Implement the generated `Handler` in a cell slice
 
@@ -99,7 +119,7 @@ func (a EnqueueCommandAdapter) HandleEnqueue(
 cell type implementing its generated `Handler` — an unimplemented codegen command
 is CI-red, not dead-but-compiles.
 
-### 3. Wire the registry: cell option + `Register` in `Init`, registry in the root
+### 3. Wire the registry and relay
 
 The cell holds a **required** `*command.Registry`, injected via a `With*` option,
 and calls the generated `Register` during `Init`:
@@ -140,6 +160,20 @@ The registry is **required, not optional** — an `if registry != nil { Register
 skip would let the funnel silently regress to dead-but-compiles. An assembly that
 forgets to wire it fails fast in `Init`.
 
+The async path also wires the generated dispatcher into the outbox relay:
+
+```go
+// examples/iotdevice/run.go
+relay.WithCommandDispatch(commandReg, map[commandruntime.CommandID]commandruntime.AsyncDispatchFunc{
+    cmdenqueue.DispatchID: cmdenqueue.DispatchAsync,
+}, claimer)
+```
+
+The map key and value must come from the same generated command package. The
+required `claimer` wraps command dispatch in `Claim`/`Commit`/`Release`, using the
+entry's tenant, aggregate subject, and command instance id to deduplicate async
+redelivery.
+
 ## Dispatching
 
 A trusted in-process caller invokes the operation through the same registry:
@@ -163,21 +197,26 @@ resp, err := cmdenqueue.Dispatch(ctx, commandReg, &cmdenqueue.Request{
 > parameter (mapped to the HTTP `Request.ID`), not a body field. A bridge that
 > translates HTTP→command must extract the path param and set `DeviceID`.
 
-> **⚠️ Authz and validation are the caller's job — the sync path runs neither.**
+> **Authz and validation are the caller's job on the sync path.**
 > Per ADR §D8, `Dispatch` does **not** authenticate, authorize, or value-validate
-> the request: the registered handler delegates straight to the domain service
-> (the devicecommand handler runs with **no role check** — the role gate
-> `auth.AnyRole(admin, operator)` only exists on the HTTP enqueue *handler*, not on
-> the command path). Any production front-end for this command bus (HTTP→command,
-> async outbox→command) **MUST**, before calling `Dispatch`: (a) authenticate +
-> authorize the caller, including device-ownership/IDOR checks, and (b) validate
-> request values (e.g. non-empty `commandType`) against the request schema. When a
-> bridge lands, populate the contract's `endpoints.invokers` so callers are
-> accountable.
+> the request: the registered handler delegates straight to the domain service.
+> A sync production caller must enforce authn/authz, ownership/IDOR checks, and
+> request value constraints before calling `Dispatch`.
 
-As of this writing there is **no production `Dispatch` caller** for devicecommand
-enqueue: the production entry points that front the command bus — an
-HTTP→command bridge and an async outbox→command relay — are planned future work described in ADR `docs/architecture/202606040550-1044-adr-command-bus-dispatch-funnel.md` §5. The wiring is exercised end-to-end by `examples/iotdevice/cells/devicecell/command_wiring_test.go`.
+There is still no production code that directly calls synchronous
+`cmdenqueue.Dispatch`; that path is exercised by wiring tests. Production command
+traffic for device enqueue is async:
+
+- HTTP `http.device.command.enqueue-async.v1` validates the incoming request and
+  calls `Service.EnqueueAsync`, which emits through
+  `cmdenqueue.EmitAsyncFromIdempotencyKey`.
+- `devicebootstrap` reacts to `event.device-registered.v1` and emits the generated
+  command with `cmdenqueue.EmitAsync`.
+- `devicecertrenewal` uses the same generated emit path for reconcile-driven
+  certificate rotation commands.
+- the relay dispatches matching command entries through `cmdenqueue.DispatchAsync`,
+  which validates the outbox payload bytes before restoring context and invoking
+  the registered `Handler`.
 
 ## How it differs from saga and event consumers
 
@@ -186,7 +225,7 @@ HTTP→command bridge and an async outbox→command relay — are planned future
 | Invocation | synchronous, in-process, by command id | async, broker-delivered | durable workflow steps |
 | Registration | `<gen>.Register(reg, h)` (hand-written today) | `reg.Subscribe(...)` derived by cellgen from `role: subscribe` | saga definition + step funcs |
 | Multiplicity | exactly one handler per command id | one per consumer group; fan-out across groups | one coordinator per saga |
-| Idempotency | caller's responsibility (sync, no retry) | `ConsumerBase` Claim/Commit/Release | journal + lease CAS |
+| Idempotency | caller responsibility on sync; relay Claimer wraps async entries | `ConsumerBase` Claim/Commit/Release | journal + lease CAS |
 | Failure | error returned to caller | Ack / Requeue / Reject → DLX | compensation (reverse, idempotent) |
 | Validation | typed struct only (sync path); JSON-schema at the fronting boundary | consumer decodes + validates payload | step output schema |
 
@@ -200,13 +239,15 @@ See ADR `docs/architecture/202606040550-1044-adr-command-bus-dispatch-funnel.md`
 
 ## Checklist
 
-- [ ] `contract.yaml`: `kind: command`, `codegen: true`, `ownerCell`, both `schemaRefs`.
+- [ ] `contract.yaml`: `kind: command`, `ownerCell`, handler/invoker endpoints, both `schemaRefs`.
 - [ ] `go run ./cmd/gocell generate contract --all` and commit the generated package.
 - [ ] Implement the generated `Handler` in a cell slice (adapter → domain service).
 - [ ] Cell holds a required `*command.Registry`; `Init` calls `<gen>.Register`.
 - [ ] Composition root constructs `command.NewRegistry()` and injects it via `With*`.
+- [ ] Async command producers use generated `<gen>.EmitAsync` or
+      `<gen>.EmitAsyncFromIdempotencyKey`; the relay wires
+      `<gen>.DispatchID: <gen>.DispatchAsync` through `WithCommandDispatch`.
 - [ ] `slice.yaml` `verify.contract` has `contract.<id>.handle`; add an executable test.
 - [ ] `go run ./cmd/gocell validate` + the command archtests pass.
-- [ ] (When the first production `Dispatch` caller / bridge lands) the bridge
-      enforces authz + value validation before `Dispatch`; populate
-      `endpoints.invokers`; update this guide to drop the "no production caller" caveat.
+- [ ] Sync `Dispatch` callers enforce authz + value validation before dispatch;
+      async HTTP entry points rely on generated HTTP validation before emitting.


### PR DESCRIPTION
## Summary

同步 Command Bus guide 与 ADR 的完成状态，移除 #1044 review 后发现的陈旧 future-work / no-production-bridge 口径。

## Why / 背景

#2272 跟踪 #1044 六路完成情况 review 的收尾问题：代码侧未发现明确逻辑 bug，但 `docs/guides/command-bus.md` 仍把 async outbox→command relay、HTTP idempotency bridge、generated producer wrappers 描述成未来工作，且 #1044 早期的泛型 API / 全 Hard 口径容易误导后续判断。

本 PR 将 consumer guide 对齐当前事实：sync `Dispatch` 仍是可信 in-process fast path；生产命令流量目前走 generated `EmitAsync` / `EmitAsyncFromIdempotencyKey` → outbox relay → generated `DispatchAsync`；enforcement 口径按 ADR 的 Hard/Medium 组合闭环记录。

## Refs

Closes #2272
Refs #1044
ref: watermill components/cqrs/command_bus.go

## Risk / 兼容性

无代码逻辑、wire schema、migration 或生成产物变更。风险集中在文档表述准确性：保留“当前无生产代码直接调用同步 `cmdenqueue.Dispatch`”边界，并明确只声明 `command.devicecommand.enqueue.v1` 已进入 generated command bus 路径，不声称所有 device command contract 都已 codegen。

## Test plan

- [x] `go test ./framework/runtime/command -run 'Test(EmitAsync|ClaimKeyFromEntry|EmitAsyncFromIdempotencyKey)'`
- [x] `go test ./framework/runtime/outbox -run 'Test(PublishBatch_CommandDispatch|PollOnce_CommandDispatch|WithCommandDispatch|DispatchCommand)'`
- [x] `go test ./examples/iotdevice -run 'TestCommandBus_Enqueue|TestCommandRelay_'`
- [x] `go test ./examples/iotdevice/cells/devicecell -run 'TestDeviceCell_CommandBus|TestCommandBus|TestCertRenewal|Test.*Command'`
- [x] `go test ./examples/iotdevice/cells/devicecell/slices/devicebootstrap -run 'TestHandleDeviceRegistered'`
- [x] `go test ./examples/iotdevice/cells/devicecell/slices/devicecertrenewal -run 'Test(Reconciler_|RotateCommandID)'`
- [x] `go test ./examples/iotdevice/cells/devicecell/internal/devicecmd -run 'TestEnqueueAsync'`
- [x] `go test ./framework/kernel/governance -run 'TestCOMMANDCONTRACT(SCHEMAREF01|CONSISTENCYLEVEL01)'`
- [x] `go test -tags=archtest ./tools/archtest -run 'TestCommand(DispatchRegisterCaller01|GenFunnelSoleEmitter01|AsyncDispatchCaller01|AsyncEmitFunnel01|AsyncEmitCaller01)'`
- [x] `go run ./cmd/gocell validate --strict` (0 errors; 2 existing journey lifecycle warnings)
- [x] `go build ./framework/... ./examples/iotdevice/... ./tools/... ./cmd/gocell/...`
- [x] `golangci-lint run ./framework/... ./examples/iotdevice/... ./cmd/gocell/...` (0 issues; root no-go.mod gomodguard warning only)
- [x] `go build ./...` checked: not applicable at repository root because the go.work root is not itself a module (`directory prefix . does not contain modules listed in go.work`)
