### PR TITLE
fix(reconcile): harden system identity guard

### DIFF
--- a/adapters/redis/reconcile_leader.go
+++ b/adapters/redis/reconcile_leader.go
@@ -23,11 +23,15 @@ var _ reconcile.LeaderElector = (*RedisReconcileElector)(nil)
 const reconcileEpochKeyTTL = 30 * 24 * time.Hour
 
 func reconcileEpochKeyTTLSeconds() (int64, error) {
-	if reconcileEpochKeyTTL < time.Second {
+	return reconcileEpochKeyTTLSecondsFor(reconcileEpochKeyTTL)
+}
+
+func reconcileEpochKeyTTLSecondsFor(ttl time.Duration) (int64, error) {
+	if ttl < time.Second {
 		return 0, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
 			"redis reconcile elector: epoch key TTL must be at least 1s")
 	}
-	return int64(reconcileEpochKeyTTL / time.Second), nil
+	return int64(ttl / time.Second), nil
 }
 
 // reconcileAcquireScript atomically acquires the leader lease and returns

--- a/adapters/redis/reconcile_leader.go
+++ b/adapters/redis/reconcile_leader.go
@@ -22,6 +22,14 @@ var _ reconcile.LeaderElector = (*RedisReconcileElector)(nil)
 // truly stale.
 const reconcileEpochKeyTTL = 30 * 24 * time.Hour
 
+func reconcileEpochKeyTTLSeconds() (int64, error) {
+	if reconcileEpochKeyTTL < time.Second {
+		return 0, errcode.New(errcode.KindInternal, errcode.ErrCellInvalidConfig,
+			"redis reconcile elector: epoch key TTL must be at least 1s")
+	}
+	return int64(reconcileEpochKeyTTL / time.Second), nil
+}
+
 // reconcileAcquireScript atomically acquires the leader lease and returns
 // {acquired, epoch}. The monotonic epoch (KEYS[2]) is INCR'd only when the holder
 // key (KEYS[1]) is free — i.e. on a real holder change (free / TTL-expired /
@@ -186,9 +194,13 @@ func (e *RedisReconcileElector) epochKey(reconcilerID string) string {
 // AcquireLease implements reconcile.LeaderElector.
 func (e *RedisReconcileElector) AcquireLease(ctx context.Context, reconcilerID string) (reconcile.LeaseToken, error) {
 	now := e.clk.Now()
+	epochTTLSeconds, err := reconcileEpochKeyTTLSeconds()
+	if err != nil {
+		return reconcile.LeaseToken{}, err
+	}
 	res, err := e.rdb.Eval(ctx, reconcileAcquireScript,
 		[]string{e.holderKey(reconcilerID), e.epochKey(reconcilerID)},
-		e.holderID, e.lease.Milliseconds(), int64(reconcileEpochKeyTTL.Seconds())).Slice()
+		e.holderID, e.lease.Milliseconds(), epochTTLSeconds).Slice()
 	if err != nil {
 		return reconcile.LeaseToken{}, classifyRedisError(err, ErrAdapterRedisSet, "redis reconcile elector acquire")
 	}
@@ -213,9 +225,13 @@ func (e *RedisReconcileElector) AcquireLease(ctx context.Context, reconcilerID s
 // epoch-key TTL here is what keeps the monotonic counter alive under a long-held
 // leader. Returns ErrReconcileLeaseLost when no longer the holder.
 func (e *RedisReconcileElector) RenewLease(ctx context.Context, token reconcile.LeaseToken) error {
+	epochTTLSeconds, err := reconcileEpochKeyTTLSeconds()
+	if err != nil {
+		return err
+	}
 	held, err := e.rdb.Eval(ctx, reconcileRenewScript,
 		[]string{e.holderKey(token.ReconcilerID), e.epochKey(token.ReconcilerID)},
-		e.holderID, e.lease.Milliseconds(), int64(reconcileEpochKeyTTL.Seconds())).Int64()
+		e.holderID, e.lease.Milliseconds(), epochTTLSeconds).Int64()
 	if err != nil {
 		return classifyRedisError(err, ErrAdapterRedisSet, "redis reconcile elector renew")
 	}

--- a/adapters/redis/reconcile_leader_test.go
+++ b/adapters/redis/reconcile_leader_test.go
@@ -130,6 +130,11 @@ func (m *reconcileMockCmdable) readEpoch(epochKey string) int64 {
 // integration-tagged file can share it without a duplicate declaration.
 const reconcileTestLeaseTTL = 30 * time.Second
 
+const (
+	reconcileTestSubsecondEpochTTL  = 500 * time.Millisecond
+	reconcileTestFractionalEpochTTL = 1500 * time.Millisecond
+)
+
 // mustLease builds the shared test LeaseTTL from the package-level literal const
 // (electors now take a validated reconcile.LeaseTTL, not a raw time.Duration —
 // sub-ms truncation is foreclosed at NewLeaseTTL, see kernel/reconcile/leasettl.go).
@@ -295,7 +300,7 @@ func TestReconcileEpochKeyTTLSecondsFor(t *testing.T) {
 	t.Parallel()
 
 	t.Run("rejects_subsecond_ttl", func(t *testing.T) {
-		_, err := reconcileEpochKeyTTLSecondsFor(500 * time.Millisecond)
+		_, err := reconcileEpochKeyTTLSecondsFor(reconcileTestSubsecondEpochTTL)
 		require.Error(t, err)
 		var ec *errcode.Error
 		require.ErrorAs(t, err, &ec)
@@ -303,7 +308,7 @@ func TestReconcileEpochKeyTTLSecondsFor(t *testing.T) {
 	})
 
 	t.Run("truncates_to_whole_seconds", func(t *testing.T) {
-		got, err := reconcileEpochKeyTTLSecondsFor(1500 * time.Millisecond)
+		got, err := reconcileEpochKeyTTLSecondsFor(reconcileTestFractionalEpochTTL)
 		require.NoError(t, err)
 		require.Equal(t, int64(1), got)
 	})

--- a/adapters/redis/reconcile_leader_test.go
+++ b/adapters/redis/reconcile_leader_test.go
@@ -291,6 +291,24 @@ func TestParseAcquireResult(t *testing.T) {
 	})
 }
 
+func TestReconcileEpochKeyTTLSecondsFor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects_subsecond_ttl", func(t *testing.T) {
+		_, err := reconcileEpochKeyTTLSecondsFor(500 * time.Millisecond)
+		require.Error(t, err)
+		var ec *errcode.Error
+		require.ErrorAs(t, err, &ec)
+		require.Equal(t, errcode.ErrCellInvalidConfig, ec.Code)
+	})
+
+	t.Run("truncates_to_whole_seconds", func(t *testing.T) {
+		got, err := reconcileEpochKeyTTLSecondsFor(1500 * time.Millisecond)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), got)
+	})
+}
+
 // TestReconcileElector_AcquireScriptContent golden-locks the acquire Lua so an
 // accidental edit (which the mock would not catch) fails at unit-test time.
 func TestReconcileElector_AcquireScriptContent(t *testing.T) {

--- a/docs/architecture/202606101200-1821-adr-reconcile-system-producer-identity.md
+++ b/docs/architecture/202606101200-1821-adr-reconcile-system-producer-identity.md
@@ -88,6 +88,22 @@ D **does not widen** that threat surface:
 - The actual ctxkeys writes are added to the existing
   CTXKEYS-PRINCIPAL-WRITE-CALLER-01 allowlist as a sanctioned writer file.
 
+### #1955 amendment (function-level callsite guard)
+
+#1955 upgrades the downstream grain from the original file-level
+`CTXKEYS-PRINCIPAL-WRITE-CALLER-01` admission to a reconcile-specific callsite
+invariant: `RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01`. The ctxkeys allowlist
+still identifies `kernel/reconcile/identity.go` as a sanctioned writer file, but
+the new invariant closes the same-file blind spot by requiring:
+
+- every principal ctx-key setter reference in package `kernel/reconcile` to live
+  inside `installSystemProducerIdentity`; and
+- every reference to `installSystemProducerIdentity` to originate from
+  `(*reconcile.Loop).process`.
+
+Threat matrix delta: no new surface. This is a pure enforcement-grain upgrade
+over the same identity boundary defined in this ADR.
+
 Threat matrix delta vs. before this change: **none added.** A reconcile producer
 previously emitted under an empty/ambient identity (a latent inheritance risk); it now
 emits under a fixed, recognizable, auditable `"system"` identity. The change reduces
@@ -127,18 +143,13 @@ and the pre-existing cross-tenant key-collision threat is downgraded, not widene
   There is no exported surface to gate.
 - **Downstream Hard**: the ctxkeys writes are caller-allowlisted by
   CTXKEYS-PRINCIPAL-WRITE-CALLER-01 (go/types object resolution; alias/dot-import safe).
-  **Granularity note**: that allowlist is **file-level** (key
-  `kernel/reconcile/identity.go`), NOT the **function/callsite-level** lock of
-  PROJECTION-SYSTEM-PRINCIPAL-INSTALL-CALLER-01. The two are both Hard, but not
-  identical in grain — a second function added to `identity.go` could call the
-  setters without tripping the archtest. That is the accepted same-file residual
-  blind spot below, not an equivalence with the projection funnel.
-- **Residual blind spot (honest)**: a different function inside `kernel/reconcile`
-  (or a second function in `identity.go` writing the setters directly) could install a
-  system identity without the archtest firing. Accepted — the package is small trusted
-  framework code and the threat model is external producers, not in-package framework
-  code; a same-package / function-level caller-allowlist would be disproportionate
-  machinery here.
+  #1955 adds `RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01`, which pins the
+  reconcile-specific grain to function/callsite level: only
+  `installSystemProducerIdentity` may reference the setters inside
+  `kernel/reconcile`, and only `Loop.process` may reference the installer.
+- **Residual blind spot (honest)**: build-tag-gated production files under
+  non-default tags are outside the default production archtest scan. No such
+  reconcile system-identity writer exists today.
 
 ## Consequences
 

--- a/framework/kernel/reconcile/doc.go
+++ b/framework/kernel/reconcile/doc.go
@@ -157,6 +157,11 @@
 //     command-id obligation to be a conscious declaration (was a Soft godoc MUST
 //     before #1954). The archtest freezes only the stance VALUE SET (Medium); the
 //     sealing + required-param are type/compile Hard. See the Tenancy godoc.
+//   - RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01 (#1955): the system producer
+//     identity installer is callsite-frozen to Loop.process, and the package's
+//     principal ctx-key setter references are callsite-frozen to
+//     installSystemProducerIdentity. This is the reconcile-specific function-level
+//     backstop layered over CTXKEYS-PRINCIPAL-WRITE-CALLER-01.
 //
 // Leader election (PR-A6) is whole-loop: when a LeaderElector is wired only the
 // lease holder dispatches Reconcile; a lost lease cancels the lease-scoped ctx to
@@ -189,8 +194,9 @@
 // code fact, never inheriting or being changed by an ambient lifecycle-ctx
 // identity (#1808 F5). Enforcement is two-axis Hard: the installer is unexported
 // (Go visibility — only Loop.process reaches it) and its ctxkeys writes are
-// caller-allowlisted by CTXKEYS-PRINCIPAL-WRITE-CALLER-01. A multi-tenant
-// reconciler must add its own tenant dimension (the system identity is
+// caller-allowlisted by CTXKEYS-PRINCIPAL-WRITE-CALLER-01, with the in-package
+// callsite grain pinned by RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01. A
+// multi-tenant reconciler must add its own tenant dimension (the system identity is
 // deliberately tenantless); this obligation is machine-enforced at construction by
 // the required sealed Tenancy stance on reconcile.New (RECONCILE-TENANCY-DECLARED-01,
 // #1954) — see the ADR.

--- a/framework/kernel/reconcile/identity.go
+++ b/framework/kernel/reconcile/identity.go
@@ -90,18 +90,14 @@ const systemProducerActor = "system"
 //   - Downstream Hard: the actual ctxkeys writes below are caller-allowlisted by
 //     CTXKEYS-PRINCIPAL-WRITE-CALLER-01 (go/types object resolution); this file is
 //     a sanctioned principal writer alongside the auth bridge, the outbox consumer
-//     restore, and the projection system-principal carrier. Granularity note: that
-//     allowlist is FILE-level (key = "kernel/reconcile/identity.go"), NOT the
-//     function/callsite-level lock of PROJECTION-SYSTEM-PRINCIPAL-INSTALL-CALLER-01
-//     — so a second function added to THIS file could call the setters without
-//     tripping the archtest. That is the accepted same-file residual blind spot
-//     below, not an equivalence claim with the projection funnel.
+//     restore, and the projection system-principal carrier. The reconcile-specific
+//     RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01 invariant closes the remaining
+//     grain: within kernel/reconcile, these four setter references may appear only
+//     in this function, and this function may be referenced only by Loop.process.
 //
-// Residual blind spot (honest self-check): another function inside
-// kernel/reconcile could call this unexported installer. That is accepted — the
-// package is small trusted framework code and the threat model is external
-// producers, not in-package framework code; a same-package caller-allowlist would
-// be disproportionate.
+// Residual blind spot (honest self-check): build-tag-gated production files under
+// non-default tags are outside the default production archtest scan. No such
+// reconcile system-identity writer exists today.
 func installSystemProducerIdentity(ctx context.Context) context.Context {
 	ctx = ctxkeys.WithActorID(ctx, systemProducerActor)
 	ctx = ctxkeys.WithSubjectID(ctx, systemProducerActor)

--- a/framework/kernel/reconcile/leader.go
+++ b/framework/kernel/reconcile/leader.go
@@ -9,9 +9,10 @@ import (
 
 // LeaderElector is the leader-election seam a multi-replica reconcile deployment
 // wires into a Loop. The interface is declared in kernel/reconcile and
-// implemented in adapters (adapters/redis SETNX+EXPIRE, adapters/postgres
-// pg_try_advisory_lock) — the kernel-declares / adapter-implements layering that
-// mirrors outbox.Emitter and persistence.CellTxManager.
+// implemented in adapters (adapters/redis SETNX+EXPIRE + epoch key,
+// adapters/postgres row-TTL CAS in reconcile_leases) — the kernel-declares /
+// adapter-implements layering that mirrors outbox.Emitter and
+// persistence.CellTxManager.
 //
 // CRITICAL — leader election is NOT fencing. client-go's own
 // tools/leaderelection documents: "This implementation does not guarantee that
@@ -22,6 +23,10 @@ import (
 // window (single dispatcher in steady state + lost-lease ctx cancel). Cross-replica
 // correctness is the job of the monotonic LeaseToken.Epoch fed into a
 // FencedWriter (see fenced.go) plus consumer idempotency — never the lease.
+// Adapter choice matters for the epoch provenance: Redis keeps the epoch in an
+// evictable key and is best-effort under allkeys-* eviction, while Postgres keeps
+// the epoch in a durable row and is the strong-fencing adapter when eviction
+// residuals are unacceptable.
 //
 // A nil LeaderElector on a Loop means single-process mode: the Loop is always
 // the leader, Epoch is 0, and no fencing is applied (the single-replica

--- a/framework/kernel/reconcile/loop.go
+++ b/framework/kernel/reconcile/loop.go
@@ -932,10 +932,9 @@ func (l *Loop) process(runCtx context.Context, req Request, dispatcher reconcile
 	// fencing). runCtx is the lease-scoped ctx in leader-elect mode, so a lost
 	// lease cancels this Reconcile's ctx mid-write.
 	//
-	// Note: single-process mode binds Epoch 0 (always-accept, no fencing). A store
-	// seeded from a prior leader-elect run (lastEpoch≥1) would reject epoch-0
-	// writes. Do NOT point a single-process Loop at a store shared with a
-	// leader-elect deployment — use distinct stores or a fresh store.
+	// Build() rejects WithFencedRepo without WithLeader, so a FencedRepository
+	// user cannot accidentally bind Epoch 0 in single-process mode. The nil-leader
+	// / nil-fencedRepo path remains the explicit single-process, no-fencing mode.
 	reconcileCtx := runCtx
 	if l.fencedRepo != nil {
 		reconcileCtx = withFencedWriter(runCtx, newFencedWriter(l.fencedRepo, l.currentEpoch()))

--- a/framework/kernel/reconcile/reconciletest/conformance.go
+++ b/framework/kernel/reconcile/reconciletest/conformance.go
@@ -306,7 +306,7 @@ const (
 	confShortInterval = 20 * time.Millisecond  // loop interval for fast requeue
 	confEventualWait  = 3 * time.Second        // budget for require.Eventually-style polls
 	confPollTick      = 5 * time.Millisecond   // polling frequency inside wait loops
-	confQuietPeriod   = 80 * time.Millisecond  // quiet-period check for PermanentError
+	confQuietPeriod   = 200 * time.Millisecond // quiet-period check for PermanentError
 	confLeaderRenew   = 10 * time.Millisecond  // fast renew cadence for leader tests
 	confBarrierWait   = 2 * time.Second        // barrier wait for concurrency test
 	confBackoffMax    = confShortInterval * 10 // panic-recovery backoff cap (TEST-TIME-LITERAL-01)
@@ -476,9 +476,12 @@ func confPermanentError(t *testing.T, newHarness HarnessFactory) {
 		return count.Load() >= 1
 	}, confEventualWait, confPollTick, "PermanentError: Reconcile never called")
 
-	// Quiet period: no further invocation expected after dead-letter. This is a
-	// genuine sleep (asserting the ABSENCE of an event cannot be polled-for) —
-	// not synchronous polling, so testwait does not apply.
+	// Quiet period: no further invocation expected after dead-letter. This bounded
+	// sleep asserts the ABSENCE of an event, which cannot be polled-for. Skip it
+	// under -short to avoid spending wall-clock budget on a negative assertion.
+	if testing.Short() {
+		t.Skip("skipping quiet-period absence assertion in -short mode")
+	}
 	snapshot := count.Load()
 	time.Sleep(confQuietPeriod) //archtest:allow:test-sleep quiet-period asserts no re-run after dead-letter (absence cannot be polled)
 	if after := count.Load(); after != snapshot {

--- a/framework/kernel/reconcile/reconciletest/fake.go
+++ b/framework/kernel/reconcile/reconciletest/fake.go
@@ -32,7 +32,7 @@ const defaultFakeLeaseTTL = 30 * time.Second
 // for one lease — that is how the conformance suite simulates a multi-replica
 // handoff. The monotonic epoch increments on every holder change (acquire of a
 // free/expired lease) and is kept on an idempotent same-holder re-acquire of a
-// still-live lease, mirroring the redis SETNX+INCR and postgres advisory-lock
+// still-live lease, mirroring the redis SETNX+INCR and postgres row-TTL CAS
 // adapters.
 type FakeLeaseBackend struct {
 	mu     sync.Mutex

--- a/framework/kernel/reconcile/recovery.go
+++ b/framework/kernel/reconcile/recovery.go
@@ -2,6 +2,7 @@ package reconcile
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -56,8 +57,8 @@ func classify(err error) resultLabel {
 func recoverReconcile(ctx context.Context, rec Reconciler, req Request, logger *slog.Logger, reconcilerID string) (res Result, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			safe := redaction.RedactString(fmt.Sprintf("%v", r))
-			err = fmt.Errorf("reconcile: recovered panic in Reconcile(entity=%q): %s", req.EntityID, safe)
+			panicValue := structuredPanicValue(r)
+			err = fmt.Errorf("reconcile: recovered panic in Reconcile(entity=%q): %v", req.EntityID, panicValue)
 			res = Result{}
 			// Log at Error: a reconciler panic is a correctness bug, not ordinary
 			// transient noise. The entity will be requeued (transient semantics), but
@@ -65,9 +66,50 @@ func recoverReconcile(ctx context.Context, rec Reconciler, req Request, logger *
 			logger.ErrorContext(ctx, "reconcile: reconciler panicked (BUG); entity requeued as transient",
 				slog.String("reconciler", reconcilerID),
 				slog.String("entity", req.EntityID),
-				redaction.RedactSlogAttr(slog.Any("panic_value", r)),
+				slog.Any("panic_value", panicValue),
 				slog.Any("error", err))
 		}
 	}()
 	return rec.Reconcile(ctx, req)
+}
+
+func structuredPanicValue(v any) any {
+	switch v.(type) {
+	case nil, error, fmt.Stringer, string:
+		return redaction.RedactAny(v)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return redaction.RedactAny(v)
+	}
+	var decoded any
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		return redaction.RedactAny(v)
+	}
+	return redactDecodedPanicValue(decoded)
+}
+
+func redactDecodedPanicValue(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, val := range x {
+			if redaction.IsSensitiveKey(k) {
+				out[k] = redaction.Mask
+				continue
+			}
+			out[k] = redactDecodedPanicValue(val)
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, val := range x {
+			out[i] = redactDecodedPanicValue(val)
+		}
+		return out
+	case string:
+		return redaction.RedactString(x)
+	default:
+		return x
+	}
 }

--- a/framework/kernel/reconcile/recovery.go
+++ b/framework/kernel/reconcile/recovery.go
@@ -73,7 +73,13 @@ func recoverReconcile(ctx context.Context, rec Reconciler, req Request, logger *
 	return rec.Reconcile(ctx, req)
 }
 
-func structuredPanicValue(v any) any {
+func structuredPanicValue(v any) (out any) {
+	defer func() {
+		if recover() != nil {
+			out = safeRedactPanicFallback(v)
+		}
+	}()
+
 	switch v.(type) {
 	case nil, error, fmt.Stringer, string:
 		return redaction.RedactAny(v)
@@ -87,6 +93,15 @@ func structuredPanicValue(v any) any {
 		return redaction.RedactAny(v)
 	}
 	return redactDecodedPanicValue(decoded)
+}
+
+func safeRedactPanicFallback(v any) (out any) {
+	defer func() {
+		if recover() != nil {
+			out = redaction.Mask
+		}
+	}()
+	return redaction.RedactAny(v)
 }
 
 func redactDecodedPanicValue(v any) any {

--- a/framework/kernel/reconcile/recovery.go
+++ b/framework/kernel/reconcile/recovery.go
@@ -65,6 +65,7 @@ func recoverReconcile(ctx context.Context, rec Reconciler, req Request, logger *
 			logger.ErrorContext(ctx, "reconcile: reconciler panicked (BUG); entity requeued as transient",
 				slog.String("reconciler", reconcilerID),
 				slog.String("entity", req.EntityID),
+				redaction.RedactSlogAttr(slog.Any("panic_value", r)),
 				slog.Any("error", err))
 		}
 	}()

--- a/framework/kernel/reconcile/recovery_test.go
+++ b/framework/kernel/reconcile/recovery_test.go
@@ -22,6 +22,12 @@ func (p panicReconciler) Reconcile(_ context.Context, _ Request) (Result, error)
 	panic(p.payload)
 }
 
+type panicMarshaler struct{}
+
+func (panicMarshaler) MarshalJSON() ([]byte, error) {
+	panic("marshal panic")
+}
+
 // successReconciler always returns a fixed Result and nil error.
 type successReconciler struct{ result Result }
 
@@ -155,6 +161,19 @@ func TestRecovery_PanicValueRedactsSensitiveFields(t *testing.T) {
 	assert.Equal(t, "bad-state", panicValue["code"])
 	assert.Equal(t, redaction.Mask, panicValue["password"])
 	assert.NotContains(t, buf.String(), "hunter2")
+}
+
+func TestRecovery_PanicValueMarshalPanicStillConvertsToError(t *testing.T) {
+	t.Parallel()
+	rec := panicReconciler{payload: panicMarshaler{}}
+	req := Request{EntityID: "marshal-panic-entity"}
+
+	require.NotPanics(t, func() {
+		res, err := recoverReconcile(context.Background(), rec, req, slog.Default(), "test_reconciler")
+		require.Error(t, err)
+		assert.Equal(t, Result{}, res)
+		assert.Equal(t, resultTransient, classify(err))
+	})
 }
 
 func TestStructuredPanicValue_RedactsNestedArraysAndStrings(t *testing.T) {

--- a/framework/kernel/reconcile/recovery_test.go
+++ b/framework/kernel/reconcile/recovery_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -100,6 +101,33 @@ func TestRecovery_PanicLogsAtErrorLevel(t *testing.T) {
 	assert.Contains(t, logOutput, `"level":"ERROR"`, "panic must be logged at Error level")
 	assert.Contains(t, logOutput, "panicking-entity", "log must include entity ID")
 	assert.Contains(t, logOutput, "my_reconciler", "log must include reconciler ID")
+}
+
+// TestRecovery_PanicLogsStructuredPanicValue verifies that structured panic
+// payloads remain inspectable in logs instead of being flattened only into the
+// synthesized error string.
+func TestRecovery_PanicLogsStructuredPanicValue(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	logger := testLogger(&buf)
+
+	type panicPayload struct {
+		Code string `json:"code"`
+		ID   int    `json:"id"`
+	}
+
+	rec := panicReconciler{payload: panicPayload{Code: "bad-state", ID: 42}}
+	req := Request{EntityID: "structured-panic-entity"}
+
+	_, err := recoverReconcile(context.Background(), rec, req, logger, "my_reconciler")
+	require.Error(t, err)
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry), "panic log must be valid JSON")
+	panicValue, ok := entry["panic_value"].(map[string]any)
+	require.True(t, ok, "panic log must include a structured panic_value object")
+	assert.Equal(t, "bad-state", panicValue["code"])
+	assert.Equal(t, float64(42), panicValue["id"])
 }
 
 // TestClassify verifies the classify helper's full table:

--- a/framework/kernel/reconcile/recovery_test.go
+++ b/framework/kernel/reconcile/recovery_test.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/ghbvf/gocell/framework/pkg/redaction"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -128,6 +130,31 @@ func TestRecovery_PanicLogsStructuredPanicValue(t *testing.T) {
 	require.True(t, ok, "panic log must include a structured panic_value object")
 	assert.Equal(t, "bad-state", panicValue["code"])
 	assert.Equal(t, float64(42), panicValue["id"])
+}
+
+func TestRecovery_PanicValueRedactsSensitiveFields(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	logger := testLogger(&buf)
+
+	type panicPayload struct {
+		Code     string `json:"code"`
+		Password string `json:"password"`
+	}
+
+	rec := panicReconciler{payload: panicPayload{Code: "bad-state", Password: "hunter2"}}
+	req := Request{EntityID: "sensitive-panic-entity"}
+
+	_, err := recoverReconcile(context.Background(), rec, req, logger, "my_reconciler")
+	require.Error(t, err)
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry), "panic log must be valid JSON")
+	panicValue, ok := entry["panic_value"].(map[string]any)
+	require.True(t, ok, "panic log must include a structured panic_value object")
+	assert.Equal(t, "bad-state", panicValue["code"])
+	assert.Equal(t, redaction.Mask, panicValue["password"])
+	assert.NotContains(t, buf.String(), "hunter2")
 }
 
 // TestClassify verifies the classify helper's full table:

--- a/framework/kernel/reconcile/recovery_test.go
+++ b/framework/kernel/reconcile/recovery_test.go
@@ -157,6 +157,37 @@ func TestRecovery_PanicValueRedactsSensitiveFields(t *testing.T) {
 	assert.NotContains(t, buf.String(), "hunter2")
 }
 
+func TestStructuredPanicValue_RedactsNestedArraysAndStrings(t *testing.T) {
+	t.Parallel()
+
+	got, ok := structuredPanicValue(map[string]any{
+		"code": "bad-state",
+		"items": []any{
+			map[string]any{"token": "secret-token"},
+			"password=hunter2",
+		},
+	}).(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "bad-state", got["code"])
+
+	items, ok := got["items"].([]any)
+	require.True(t, ok)
+	require.Len(t, items, 2)
+
+	first, ok := items[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, redaction.Mask, first["token"])
+	assert.Equal(t, "password="+redaction.Mask, items[1])
+}
+
+func TestStructuredPanicValue_Fallbacks(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, structuredPanicValue(nil))
+	assert.Equal(t, "token="+redaction.Mask, structuredPanicValue("token=secret-token"))
+	assert.Contains(t, structuredPanicValue(make(chan int)), "0x")
+}
+
 // TestClassify verifies the classify helper's full table:
 //   - nil → resultSuccess
 //   - PermanentError(x) → resultPermanent

--- a/tools/archtest/ctxkeys_principal_write_caller.go
+++ b/tools/archtest/ctxkeys_principal_write_caller.go
@@ -54,14 +54,11 @@ package archtest
 //     tenantless system identity for every reconciler's emit instead of inheriting
 //     whatever the lifecycle ctx happens to carry. The installer is UNEXPORTED, so
 //     no producer OUTSIDE kernel/reconcile can reach it (Go visibility bars only
-//     package-external callers). This allowlist entry is FILE-level (key =
-//     "kernel/reconcile/identity.go"), so it is the Hard downstream lock on the
-//     ctxkeys write itself but does NOT pin the in-package callsite the way the
-//     function-level PROJECTION-SYSTEM-PRINCIPAL-INSTALL-CALLER-01 does: today only
-//     Loop.process calls the installer, but a second function added to that same
-//     file could write the setters without tripping this archtest. That is the
-//     accepted same-file residual blind spot (see the installSystemProducerIdentity
-//     godoc) — not a Go-visibility guarantee that "only Loop.process can reach it".
+//     package-external callers). The file-level CTXKEYS allowlist admits the
+//     sanctioned writer file; the finer-grained
+//     RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01 invariant then pins the in-package
+//     callsites: only installSystemProducerIdentity may reference the setters, and
+//     only Loop.process may reference the installer.
 //
 // No producer (cells/* or examples/*) can write a principal ctx key. Together
 // with OUTBOX-RECONSTRUCTION-CALLER-01 (the reconstruction-funnel lock), this

--- a/tools/archtest/reconcile_system_identity_install_caller_test.go
+++ b/tools/archtest/reconcile_system_identity_install_caller_test.go
@@ -1,0 +1,234 @@
+//go:build archtest
+
+// INVARIANT: RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01
+//
+// RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01 pins the reconcile system
+// producer identity to one chokepoint:
+//
+//   - installSystemProducerIdentity may be referenced only from
+//     (*kernel/reconcile.Loop).process.
+//   - The principal ctx-key setters inside package kernel/reconcile may be
+//     referenced only from installSystemProducerIdentity.
+//
+// This closes the former file-level blind spot in
+// CTXKEYS-PRINCIPAL-WRITE-CALLER-01 where a second function added to
+// kernel/reconcile/identity.go could write principal ctx keys without tripping
+// the file allowlist.
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	reconcileSystemIdentityPkg               = PlatformFrameworkModulePath + "/kernel/reconcile"
+	reconcileSystemIdentityInstallFunc       = "installSystemProducerIdentity"
+	reconcileSystemIdentityAllowedInstallRef = "(*" + reconcileSystemIdentityPkg + ".Loop).process"
+	reconcileSystemIdentityAllowedSetterRef  = reconcileSystemIdentityPkg + "." + reconcileSystemIdentityInstallFunc
+)
+
+var reconcileSystemIdentitySetters = []string{
+	"WithActorID",
+	"WithSubjectID",
+	"WithTenantID",
+	"WithSessionID",
+}
+
+type reconcileSystemIdentityObserved struct {
+	installerCallers map[string]struct{}
+	setterCallers    map[string]map[string]struct{}
+}
+
+func newReconcileSystemIdentityObserved() *reconcileSystemIdentityObserved {
+	return &reconcileSystemIdentityObserved{
+		installerCallers: map[string]struct{}{},
+		setterCallers:    map[string]map[string]struct{}{},
+	}
+}
+
+func TestReconcileSystemIdentityInstallCaller01(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	observed := newReconcileSystemIdentityObserved()
+	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		return scanReconcileSystemIdentityInstallCaller01(p, observed)
+	})
+	diags = append(diags, staleReconcileSystemIdentityDiags(observed)...)
+	Report(t, "RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01", diags)
+}
+
+func TestReconcileSystemIdentityInstallCaller01_RedFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	root := filepath.Join(findModuleRoot(t), "tools", "archtest", "testdata", "reconcile_system_identity_violate")
+	observed := newReconcileSystemIdentityObserved()
+	var found int
+	_ = Run(t, StandaloneModule(root, TypedOpts{}, []string{"./..."}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		found += len(scanReconcileSystemIdentityInstallCaller01(p, observed))
+		return nil
+	})
+	assert.Equal(t, 2, found,
+		"RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01 RED fixture must report exactly "+
+			"two violations: one non-Loop.process installer reference and one same-package "+
+			"principal setter reference outside installSystemProducerIdentity")
+}
+
+func scanReconcileSystemIdentityInstallCaller01(
+	p *Pass,
+	observed *reconcileSystemIdentityObserved,
+) []Diagnostic {
+	if p.Pkg == nil || p.Pkg.Path() != reconcileSystemIdentityPkg {
+		return nil
+	}
+	var diags []Diagnostic
+	diags = append(diags, scanReconcileSystemIdentityInstallerRefs(p, observed)...)
+	diags = append(diags, scanReconcileSystemIdentitySetterRefs(p, observed)...)
+	return diags
+}
+
+func scanReconcileSystemIdentityInstallerRefs(
+	p *Pass,
+	observed *reconcileSystemIdentityObserved,
+) []Diagnostic {
+	var diags []Diagnostic
+	for _, file := range p.Files {
+		rel := p.Rel(file)
+		EachInSubtree[ast.Ident](file, func(id *ast.Ident) {
+			if id.Name != reconcileSystemIdentityInstallFunc {
+				return
+			}
+			fn, ok := p.TypesInfo.Uses[id].(*types.Func)
+			if !ok || fn.Pkg() == nil || fn.Pkg().Path() != reconcileSystemIdentityPkg {
+				return
+			}
+			line := p.Fset.Position(id.Pos()).Line
+			caller, ok := ResolveEnclosingFunc(p.TypesInfo, file, id)
+			if !ok {
+				diags = append(diags, Diagnostic{
+					Rel:  rel,
+					Line: line,
+					Message: "RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01: " +
+						"installSystemProducerIdentity is referenced outside any FuncDecl; " +
+						"move the reference into (*kernel/reconcile.Loop).process.",
+				})
+				return
+			}
+			callerID := caller.FullName()
+			observed.installerCallers[callerID] = struct{}{}
+			if callerID == reconcileSystemIdentityAllowedInstallRef {
+				return
+			}
+			diags = append(diags, Diagnostic{
+				Rel:  rel,
+				Line: line,
+				Message: fmt.Sprintf(
+					"RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01: "+
+						"installSystemProducerIdentity is referenced from caller %q, which is "+
+						"not sanctioned. The reconcile system producer identity must be installed "+
+						"only at the Loop.process chokepoint so every Reconcile gets the same "+
+						"tenantless system principal boundary.",
+					callerID,
+				),
+			})
+		})
+	}
+	return diags
+}
+
+func scanReconcileSystemIdentitySetterRefs(
+	p *Pass,
+	observed *reconcileSystemIdentityObserved,
+) []Diagnostic {
+	var diags []Diagnostic
+	for _, file := range p.Files {
+		rel := p.Rel(file)
+		EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
+			setter, matched := principalSetterName(p.TypesInfo, sel)
+			if !matched {
+				return
+			}
+			line := p.Fset.Position(sel.Pos()).Line
+			caller, ok := ResolveEnclosingFunc(p.TypesInfo, file, sel)
+			if !ok {
+				diags = append(diags, Diagnostic{
+					Rel:  rel,
+					Line: line,
+					Message: fmt.Sprintf(
+						"RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01: ctxkeys.%s is referenced "+
+							"from package kernel/reconcile outside any FuncDecl; principal ctx-key "+
+							"writes in reconcile must live only in installSystemProducerIdentity.",
+						setter,
+					),
+				})
+				return
+			}
+			callerID := caller.FullName()
+			if observed.setterCallers[setter] == nil {
+				observed.setterCallers[setter] = map[string]struct{}{}
+			}
+			observed.setterCallers[setter][callerID] = struct{}{}
+			if callerID == reconcileSystemIdentityAllowedSetterRef {
+				return
+			}
+			diags = append(diags, Diagnostic{
+				Rel:  rel,
+				Line: line,
+				Message: fmt.Sprintf(
+					"RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01: ctxkeys.%s is referenced "+
+						"from caller %q. The reconcile package may write principal ctx keys only "+
+						"inside installSystemProducerIdentity; adding a second writer would bypass "+
+						"the Loop.process system-principal chokepoint.",
+					setter, callerID,
+				),
+			})
+		})
+	}
+	return diags
+}
+
+func staleReconcileSystemIdentityDiags(observed *reconcileSystemIdentityObserved) []Diagnostic {
+	var diags []Diagnostic
+	if _, seen := observed.installerCallers[reconcileSystemIdentityAllowedInstallRef]; !seen {
+		diags = append(diags, Diagnostic{
+			Message: fmt.Sprintf(
+				"RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01: allowlist entry %q is STALE "+
+					"— no live reference to installSystemProducerIdentity observed from that caller.",
+				reconcileSystemIdentityAllowedInstallRef,
+			),
+		})
+	}
+	setters := append([]string(nil), reconcileSystemIdentitySetters...)
+	sort.Strings(setters)
+	for _, setter := range setters {
+		if _, seen := observed.setterCallers[setter][reconcileSystemIdentityAllowedSetterRef]; seen {
+			continue
+		}
+		diags = append(diags, Diagnostic{
+			Message: fmt.Sprintf(
+				"RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01: allowlist entry %q for "+
+					"ctxkeys.%s is STALE — no live setter reference observed from that caller.",
+				reconcileSystemIdentityAllowedSetterRef, setter,
+			),
+		})
+	}
+	return diags
+}

--- a/tools/archtest/reconcile_system_identity_install_caller_test.go
+++ b/tools/archtest/reconcile_system_identity_install_caller_test.go
@@ -86,10 +86,11 @@ func TestReconcileSystemIdentityInstallCaller01_RedFixture(t *testing.T) {
 		found += len(scanReconcileSystemIdentityInstallCaller01(p, observed))
 		return nil
 	})
-	assert.Equal(t, 2, found,
+	assert.Equal(t, 3, found,
 		"RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01 RED fixture must report exactly "+
-			"two violations: one non-Loop.process installer reference and one same-package "+
-			"principal setter reference outside installSystemProducerIdentity")
+			"three violations: one non-Loop.process installer reference, one selector-form "+
+			"principal setter reference, and one dot-import bare principal setter reference "+
+			"outside installSystemProducerIdentity")
 }
 
 func scanReconcileSystemIdentityInstallCaller01(
@@ -161,13 +162,13 @@ func scanReconcileSystemIdentitySetterRefs(
 	var diags []Diagnostic
 	for _, file := range p.Files {
 		rel := p.Rel(file)
-		EachInSubtree[ast.SelectorExpr](file, func(sel *ast.SelectorExpr) {
-			setter, matched := principalSetterName(p.TypesInfo, sel)
+		EachInSubtree[ast.Ident](file, func(id *ast.Ident) {
+			setter, matched := principalSetterIdentName(p.TypesInfo, id)
 			if !matched {
 				return
 			}
-			line := p.Fset.Position(sel.Pos()).Line
-			caller, ok := ResolveEnclosingFunc(p.TypesInfo, file, sel)
+			line := p.Fset.Position(id.Pos()).Line
+			caller, ok := ResolveEnclosingFunc(p.TypesInfo, file, id)
 			if !ok {
 				diags = append(diags, Diagnostic{
 					Rel:  rel,
@@ -203,6 +204,17 @@ func scanReconcileSystemIdentitySetterRefs(
 		})
 	}
 	return diags
+}
+
+func principalSetterIdentName(info *types.Info, id *ast.Ident) (string, bool) {
+	fn, ok := info.Uses[id].(*types.Func)
+	if !ok || fn.Pkg() == nil || fn.Pkg().Path() != ctxkeysPkgPath {
+		return "", false
+	}
+	if _, isSetter := principalSetterAllowlist[fn.Name()]; !isSetter {
+		return "", false
+	}
+	return fn.Name(), true
 }
 
 func staleReconcileSystemIdentityDiags(observed *reconcileSystemIdentityObserved) []Diagnostic {

--- a/tools/archtest/testdata/reconcile_system_identity_violate/go.mod
+++ b/tools/archtest/testdata/reconcile_system_identity_violate/go.mod
@@ -1,0 +1,3 @@
+module github.com/ghbvf/gocell/framework
+
+go 1.25.11

--- a/tools/archtest/testdata/reconcile_system_identity_violate/kernel/reconcile/dot_import.go
+++ b/tools/archtest/testdata/reconcile_system_identity_violate/kernel/reconcile/dot_import.go
@@ -1,0 +1,11 @@
+package reconcile
+
+import (
+	"context"
+
+	. "github.com/ghbvf/gocell/framework/pkg/ctxkeys" //nolint:revive,staticcheck // RED fixture: dot-import bare identifier is the form under test
+)
+
+func bypassSystemIdentitySetterViaDotImport(ctx context.Context) context.Context {
+	return WithSubjectID(ctx, "bypass")
+}

--- a/tools/archtest/testdata/reconcile_system_identity_violate/kernel/reconcile/identity.go
+++ b/tools/archtest/testdata/reconcile_system_identity_violate/kernel/reconcile/identity.go
@@ -1,0 +1,21 @@
+package reconcile
+
+import (
+	"context"
+
+	"github.com/ghbvf/gocell/framework/pkg/ctxkeys"
+)
+
+const systemProducerActor = "system"
+
+func installSystemProducerIdentity(ctx context.Context) context.Context {
+	ctx = ctxkeys.WithActorID(ctx, systemProducerActor)
+	ctx = ctxkeys.WithSubjectID(ctx, systemProducerActor)
+	ctx = ctxkeys.WithTenantID(ctx, "")
+	ctx = ctxkeys.WithSessionID(ctx, "")
+	return ctx
+}
+
+func bypassSystemIdentitySetter(ctx context.Context) context.Context {
+	return ctxkeys.WithActorID(ctx, "bypass")
+}

--- a/tools/archtest/testdata/reconcile_system_identity_violate/kernel/reconcile/loop.go
+++ b/tools/archtest/testdata/reconcile_system_identity_violate/kernel/reconcile/loop.go
@@ -1,0 +1,13 @@
+package reconcile
+
+import "context"
+
+type Loop struct{}
+
+func (l *Loop) process(ctx context.Context) context.Context {
+	return installSystemProducerIdentity(ctx)
+}
+
+func bypassSystemIdentityInstaller(ctx context.Context) context.Context {
+	return installSystemProducerIdentity(ctx)
+}

--- a/tools/archtest/testdata/reconcile_system_identity_violate/pkg/ctxkeys/ctxkeys.go
+++ b/tools/archtest/testdata/reconcile_system_identity_violate/pkg/ctxkeys/ctxkeys.go
@@ -1,0 +1,11 @@
+package ctxkeys
+
+import "context"
+
+func WithActorID(ctx context.Context, _ string) context.Context { return ctx }
+
+func WithSubjectID(ctx context.Context, _ string) context.Context { return ctx }
+
+func WithTenantID(ctx context.Context, _ string) context.Context { return ctx }
+
+func WithSessionID(ctx context.Context, _ string) context.Context { return ctx }


### PR DESCRIPTION
## Summary

Upgrade reconcile system producer identity from a file-level ctxkeys allowance to a dedicated callsite-level invariant, and clean up reconcile leader/recovery DX notes.

## Why / 背景

#1955 identified that `kernel/reconcile/identity.go` was admitted by `CTXKEYS-PRINCIPAL-WRITE-CALLER-01` at file granularity. A second function in that file could write principal ctx keys without tripping the guard. This PR adds `RECONCILE-SYSTEM-IDENTITY-INSTALL-CALLER-01` so only `installSystemProducerIdentity` may write those ctx keys inside `kernel/reconcile`, and only `Loop.process` may call the installer.

#1958 is included as the adjacent P3 cleanup batch for stale leader-election comments, panic diagnostics, quiet-period reliability, and Redis epoch TTL conversion.

## Refs

Closes #1955
Closes #1958
ref: kubernetes-sigs/controller-runtime pkg/reconcile/reconcile.go
ref: kubernetes/client-go tools/leaderelection/leaderelection.go
ref: docs/architecture/202606101200-1821-adr-reconcile-system-producer-identity.md

## Risk / 兼容性

No public API or wire-contract change. Runtime behavior is unchanged except recovered reconcile panics now also log a structured `panic_value` field, passed through `redaction.RedactSlogAttr`. Redis epoch TTL conversion now goes through a single >=1s guard helper before Lua `EXPIRE` args are built.

## Test plan

- [x] `go -C framework build ./... && go -C framework test ./...`
- [x] `go -C tools build ./... && go -C tools test ./...`
- [x] `go -C adapters/redis build ./... && go -C adapters/redis test ./...`
- [x] `go -C tools test -tags=archtest ./archtest -run 'Test(CtxkeysPrincipalWriteCaller01|ReconcileSystemIdentityInstallCaller01|ProjectionSystemPrincipalInstallCaller01)' -count=1 -timeout=8m`
- [x] `golangci-lint run ./...` in `framework`
- [x] `golangci-lint run --build-tags archtest ./archtest` in `tools`
- [x] `golangci-lint run ./...` in `adapters/redis`

Notes:
- Workspace root `go build ./...`, `go test ./...`, and root `golangci-lint run ./...` are not valid because the repository root is a `go.work` root, not a Go module.
- Full `go -C tools test -tags=archtest ./archtest -count=1 -timeout=15m` currently fails on pre-existing repository-wide archtest findings unrelated to this PR: `TestAdaptersExportedTypesManagedResourceOrOptOut` (`adapters/softca` ManagedResource opt-outs) and `TestInventoryAnchorValidID` (`ci_pinning_test.go` invariant anchor).
- Plain `golangci-lint run ./...` in `tools` currently reports existing unused archtest helper symbols when run without the `archtest` build tag; the relevant archtest-tag lint passes.
