### PR TITLE
refactor(eventrouter): handlers slice→map（运行时增删地基，行为等价）[303-US9] (#2231)

### DIFF
--- a/framework/runtime/eventrouter/add_contract_handler_test.go
+++ b/framework/runtime/eventrouter/add_contract_handler_test.go
@@ -93,6 +93,22 @@ func okHandler() outbox.EntryHandler {
 	}
 }
 
+// soleHandlerCfg returns the single registered handlerConfig, failing the test
+// if the count is not exactly 1. Replaces direct r.handlers[0] indexing now
+// that the container is a map keyed by (topic, consumerGroup).
+func soleHandlerCfg(tb testing.TB, r *Router) handlerConfig {
+	tb.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.handlers) != 1 {
+		tb.Fatalf("expected exactly 1 handler, got %d", len(r.handlers))
+	}
+	for _, rh := range r.handlers {
+		return rh.cfg
+	}
+	return handlerConfig{}
+}
+
 // --- Guard tests ---
 
 func TestAddContractHandler_NilHandler_ReturnsError(t *testing.T) {
@@ -140,7 +156,7 @@ func TestAddContractHandler_RegistersBusinessHandler(t *testing.T) {
 	assert.Equal(t, 1, r.HandlerCount())
 
 	// Router stores the business handler; bootstrap-owned middleware wraps it.
-	res := r.handlers[0].handler(context.Background(), outbox.Entry{})
+	res := soleHandlerCfg(t, r).handler(context.Background(), outbox.Entry{})
 	assert.Equal(t, outbox.DispositionAck, res.Disposition)
 }
 
@@ -162,8 +178,7 @@ func TestAddContractHandler_HandlerConfigShape(t *testing.T) {
 	t.Parallel()
 	r := New(wrap(&blockingSubscriber{}), clock.Real())
 	require.NoError(t, r.AddContractHandler(configEntryUpsertedSpec(), okHandler(), "accesscore", "accesscore"))
-	require.Equal(t, 1, len(r.handlers))
-	cfg := r.handlers[0]
+	cfg := soleHandlerCfg(t, r)
 	assert.Equal(t, "event.config.entry-upserted.v1", cfg.topic, "topic derived from spec.Topic")
 	assert.Equal(t, "accesscore", cfg.consumerGroup, "consumerGroup preserved")
 	assert.NotNil(t, cfg.handler, "handler stored")
@@ -187,8 +202,38 @@ func TestAddContractHandler_OwnerCellIDDistinctFromConsumerGroup(t *testing.T) {
 	const consumerGroup = "accesscore-rbac-session-sync"
 	const ownerCellID = "accesscore"
 	require.NoError(t, r.AddContractHandler(configEntryUpsertedSpec(), okHandler(), consumerGroup, ownerCellID))
-	require.Equal(t, 1, len(r.handlers))
-	sub := r.handlers[0].subscription()
+	sub := soleHandlerCfg(t, r).subscription()
 	assert.Equal(t, consumerGroup, sub.ConsumerGroup, "ConsumerGroup must be preserved as-is")
 	assert.Equal(t, ownerCellID, sub.CellID, "CellID must be ownerCellID, not consumerGroup")
+}
+
+// --- Duplicate-key fail-fast (map container) ---
+
+// TestAddContractHandler_DuplicateKey_ReturnsError verifies that a second
+// registration with the same (topic, consumerGroup) is rejected. That pair is
+// the broker's subscription identity (runtime/eventbus keys by
+// ConsumerGroup|Topic), so two handlers on it would be competing consumers
+// splitting one stream — a misconfiguration the old slice silently accepted.
+// The second call uses a *different* ownerCellID to lock in that cellID is NOT
+// part of the key: subscription identity is (topic, group) only.
+func TestAddContractHandler_DuplicateKey_ReturnsError(t *testing.T) {
+	t.Parallel()
+	r := New(wrap(&blockingSubscriber{}), clock.Real())
+	require.NoError(t, r.AddContractHandler(configEntryUpsertedSpec(), okHandler(), "accesscore", "accesscore"))
+
+	err := r.AddContractHandler(configEntryUpsertedSpec(), okHandler(), "accesscore", "othercell")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate")
+	assert.Equal(t, 1, r.HandlerCount(), "duplicate registration must not grow the handler set")
+}
+
+// TestAddContractHandler_SameTopicDistinctGroup_BothRegister verifies the key
+// includes consumerGroup: the same topic under a different group is a distinct
+// subscription and registers independently.
+func TestAddContractHandler_SameTopicDistinctGroup_BothRegister(t *testing.T) {
+	t.Parallel()
+	r := New(wrap(&blockingSubscriber{}), clock.Real())
+	require.NoError(t, r.AddContractHandler(configEntryUpsertedSpec(), okHandler(), "groupA", "accesscore"))
+	require.NoError(t, r.AddContractHandler(configEntryUpsertedSpec(), okHandler(), "groupB", "accesscore"))
+	assert.Equal(t, 2, r.HandlerCount())
 }

--- a/framework/runtime/eventrouter/router.go
+++ b/framework/runtime/eventrouter/router.go
@@ -122,6 +122,28 @@ type handlerConfig struct {
 	brokerDelaySchedule []time.Duration // #1458: per-attempt webhook retry delays (empty for ordinary subscriptions).
 }
 
+// handlerKey identifies a subscription by its broker-level identity:
+// (topic, consumerGroup). This mirrors the runtime/eventbus keying
+// (ConsumerGroup|Topic) — two handlers on one key would be competing consumers
+// splitting a single stream, so the key is the duplicate-detection unit.
+// cellID/sliceID are observability metadata and intentionally excluded.
+type handlerKey struct {
+	topic         string
+	consumerGroup string
+}
+
+// runningHandler is the per-handler container unit stored in Router.handlers.
+// US9 holds only cfg; runtime lifecycle fields (per-handler cancel, started,
+// done) land in US10 when runtime add/remove subscriptions are wired
+// (specs/070-runtime-contract-registry US10). The pointer value gives US10 a
+// stable, mutable per-handler home and self-removal from the map.
+//
+// ref: ThreeDotsLabs/watermill message/router.go@master — map[string]*handler
+// container + delete-on-exit.
+type runningHandler struct {
+	cfg handlerConfig
+}
+
 // Router manages event subscription lifecycle. It is populated from
 // RegistrySnapshot.Subscriptions drained by bootstrap phase6, and provides
 // Run/Close for the execution phase.
@@ -140,7 +162,7 @@ type handlerConfig struct {
 // not a generic middleware list: the router owns the composition.
 type Router struct {
 	subscriber   *outbox.SubscriberWithMiddleware
-	handlers     []handlerConfig
+	handlers     map[handlerKey]*runningHandler
 	validators   []cell.SubscriptionValidator
 	mu           sync.Mutex
 	readyTimeout time.Duration
@@ -173,6 +195,7 @@ func New(sub *outbox.SubscriberWithMiddleware, clk clock.Clock, opts ...Option) 
 	clock.MustHaveClock(clk, "eventrouter.New")
 	r := &Router{
 		subscriber:   sub,
+		handlers:     make(map[handlerKey]*runningHandler),
 		readyTimeout: DefaultReadyTimeout,
 		running:      make(chan struct{}),
 		clock:        clk,
@@ -203,8 +226,10 @@ func New(sub *outbox.SubscriberWithMiddleware, clk clock.Clock, opts ...Option) 
 // metadata at codegen time (HARD contract).
 //
 // Returns a non-nil error when handler is nil, consumerGroup is empty,
-// ownerCellID is empty, or the spec is malformed; callers should propagate
-// the error to the bootstrap phase6 subscription walker.
+// ownerCellID is empty, the spec is malformed, or a handler for the same
+// (topic, consumerGroup) — the broker subscription identity — is already
+// registered; callers should propagate the error to the bootstrap phase6
+// subscription walker.
 //
 // ref: ThreeDotsLabs/watermill router.AddHandler handlerName / NATS subscription metadata.
 // ref: ADR docs/architecture/202605111000-adr-subscription-cellid-mandatory.md
@@ -269,7 +294,11 @@ func (r *Router) AddContractHandler(
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.handlers = append(r.handlers, handlerConfig{
+	key := handlerKey{topic: spec.Topic, consumerGroup: consumerGroup}
+	if _, exists := r.handlers[key]; exists {
+		return fmt.Errorf("eventrouter: duplicate handler for topic %q consumerGroup %q", spec.Topic, consumerGroup)
+	}
+	r.handlers[key] = &runningHandler{cfg: handlerConfig{
 		topic:               spec.Topic,
 		handler:             handler,
 		consumerGroup:       consumerGroup,
@@ -277,7 +306,7 @@ func (r *Router) AddContractHandler(
 		sliceID:             req.SliceID,
 		contract:            spec,
 		brokerDelaySchedule: req.BrokerDelaySchedule,
-	})
+	}}
 	return nil
 }
 
@@ -319,9 +348,15 @@ func (r *Router) Run(ctx context.Context) error {
 		return errAlreadyRunning
 	}
 
+	// Snapshot the registered handlers into a slice under the lock. The map is
+	// the storage (dedup + US10 runtime add/remove prerequisite); the 4-phase
+	// startup below is a one-shot batch over this snapshot, so iteration order
+	// is irrelevant (each Setup/Subscribe/Ready is per independent subscription).
 	r.mu.Lock()
-	handlers := make([]handlerConfig, len(r.handlers))
-	copy(handlers, r.handlers)
+	handlers := make([]handlerConfig, 0, len(r.handlers))
+	for _, rh := range r.handlers {
+		handlers = append(handlers, rh.cfg)
+	}
 	r.mu.Unlock()
 
 	runCtx, cancel := context.WithCancel(ctx)

--- a/framework/runtime/eventrouter/router.go
+++ b/framework/runtime/eventrouter/router.go
@@ -231,6 +231,15 @@ func New(sub *outbox.SubscriberWithMiddleware, clk clock.Clock, opts ...Option) 
 // registered; callers should propagate the error to the bootstrap phase6
 // subscription walker.
 //
+// Lifecycle boundary: Run snapshots the handler set once at entry, so a handler
+// registered after Run has started is stored in the map but is NOT picked up by
+// the in-flight Run. This is the reserved seam for US10 runtime add/remove
+// (specs/070-runtime-contract-registry); today bootstrap completes all
+// registration before Run, so the case does not arise. Validators run outside
+// the store lock, so two concurrent registrations of the same key may both
+// validate before either inserts — the duplicate check under the final lock
+// still fails the loser closed.
+//
 // ref: ThreeDotsLabs/watermill router.AddHandler handlerName / NATS subscription metadata.
 // ref: ADR docs/architecture/202605111000-adr-subscription-cellid-mandatory.md
 func (r *Router) AddContractHandler(
@@ -324,7 +333,7 @@ func (r *Router) AddSubscriptionValidator(v cell.SubscriptionValidator) {
 }
 
 // errAlreadyRunning is returned if Run is called more than once.
-var errAlreadyRunning = fmt.Errorf("eventrouter: Run called more than once")
+var errAlreadyRunning = errors.New("eventrouter: Run called more than once")
 
 // Run starts all registered subscriptions and blocks until ctx is canceled
 // or an unrecoverable subscription error occurs.


### PR DESCRIPTION
## Summary

`eventrouter.Router` 的 handler 容器从 `[]handlerConfig` 改为 `map[handlerKey]*runningHandler`（key=`(topic, consumerGroup)`），行为等价、零功能变更——US10 运行时增删订阅的数据结构地基。

## Why / 背景

epic #303（runtime contract registry）US9。当前 slice 容器无法支持运行时增删，且对同 `(topic, consumerGroup)` 重复注册会静默 `append` 出两个 handler → 同一 broker 订阅身份上两个竞争消费者（消息流被非确定地拆分），是隐性 bug。对标 watermill `message/router.go` 的 `map[string]*handler`（O(1) 增删 + 退出自删）。

本 PR：
- `handlers map[handlerKey]*runningHandler` + 新增 `handlerKey{topic, consumerGroup}` / `runningHandler{cfg}`。key 选 `(topic, consumerGroup)` 与 broker 订阅身份一致（`runtime/eventbus` 按 `ConsumerGroup|Topic` keying），cellID/sliceID 是可观测元数据、不入 key。
- `AddContractHandler` 同 key 重复 → 返回 error（不 panic，对齐 `error-handling.md`），顺带把上述隐性双订阅 bug 修成 fail-fast。
- `Run` 在锁内把 map 展开为 `[]handlerConfig` 快照，4 阶段启动 helper（Setup/Subscribe/Ready）与其行为完全不变；map 迭代非确定序对 one-shot 批量启动无影响（各订阅独立）。
- `runningHandler` US9 仅持 `cfg`；per-handler `cancel/started/done` 等运行时生命周期字段在 US10 接线时再加（避免死字段 + `unused` lint）。指针 wrapper 已满足 US10「可变 per-handler 状态 + 自删」前提。

`HandlerCount` / 公开 API 签名不变，调用方零改动。

## Refs

- Closes #2231
- Epic #303 · `specs/070-runtime-contract-registry/{spec.md US9, research.md §3.1, tasks.md T010/T011}`
- ref: ThreeDotsLabs/watermill message/router.go@master — `map[string]*handler` container + delete-on-exit

## Risk / 兼容性

- 无外部 wire / 契约影响：纯包内数据结构重构，公开 API 签名不变。
- 行为差异仅在此前**未定义**的重复注册路径：旧 slice 静默接受同 `(topic, consumerGroup)` 双注册（双订阅），新 map fail-fast 返回 error。in-repo 全部注册路径（webhook dispatch / cell subscription / projection）均用各自稳定 consumerGroup，无合法同 key 碰撞；三处调用方本就 error-returning，错误会冒泡到 bootstrap。
- AI-robust：`(topic,group)` 唯一性由 map 结构 = **Hard**（共存不可表达）；碰撞 reject = **Medium**（启动期 fail-fast guard + 单测红用例）。包内防御性校验，载体为单测、不立 archtest。

## Test plan

- [x] `go build ./framework/...` + `go build -tags=integration ./...` 本地通过
- [x] `go test ./runtime/eventrouter/... ./runtime/bootstrap/...` 本地通过（含新 duplicate-key / distinct-group 用例，零回归）
- [x] `golangci-lint run ./...`（framework 模块）0 issues（无 `unused` 字段告警）
- [x] eventrouter 包覆盖率 95.4%（≥80%）
