### PR TITLE
docs(topology): #1423 ADR §#1967 amendment + 「彻底拆分」mini-epic 任务细化 [PR-0]

### DIFF
--- a/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
+++ b/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
@@ -459,8 +459,9 @@ kubernetes `cmd/kube-controller-manager` ControllerDescriptor；spring-projects/
 **D1 amendment — topology 载体增 `groups`（全图），取代单进程 `colocated/remote` authoring**：
 - assembly.yaml `topology.groups: [{role, cells, endpoint}]` 声明**完整部署分区图**（每组的 cell 集 + 对端可达
   endpoint）；`ValidateTopologyStructure` 重写为 groups 的**穷尽 + 互斥分区**校验（每 cell 恰在一组、role 唯一、
-  endpoint 合法）。**删除**现有 `TopologyMeta.{Colocated,Remote}` **authoring** 字段 + 单进程视图校验 +
-  `ClassifyCell` 单视图分支（#1962 引入，生产零 assembly 使用，pre-GA 窗口允许原地删除，无 shim/双 schema）。
+  endpoint 合法）。**PR-1 删除**现有 `TopologyMeta.{Colocated,Remote}` **authoring** 字段 + 单进程视图校验 +
+  `ClassifyCell` 单视图分支（本 amendment 是决策记录，删除动作在 PR-1 落地，非本 docs PR 已执行；#1962 引入，
+  生产零 assembly 使用，pre-GA 窗口允许原地删除，无 shim/双 schema）。
 - 启动期 role 选择器 `GOCELL_CELL_ROLE`（WriteOnce）由 groups 派生本进程 `bootstrap.DeploymentTopologySpec`
   （colocated = 本组 cells，remote = 其余组 cells × 各自 endpoint）——**运行期 `DeploymentTopologySpec{Colocated,
   Remote}` 作派生形态保留**（仍被 `celltransport.Resolve` 消费，#1966 接线不变，喂入值变真）。未设 role + 多 group
@@ -475,11 +476,13 @@ kubernetes `cmd/kube-controller-manager` ControllerDescriptor；spring-projects/
   「枚举全部、实例化 enabled 子集」/ Akka role-match-or-proxy）；`validateClosedSet` 代码不变（仍校验 New==With，
   在 role 过滤后 New/With 同为 colocated，双射天然成立）。
 - **新增** bootstrap-phase 守卫 `MOUNTED-EQUALS-COLOCATED`：本进程已挂 cell 集 == active topology colocated 集
-  ∧ **remote cell 一律不得被挂载**，违反 fail-fast。配单一 sealed 入口 `composition.NewForRole(topo, role,
-  allModules...)`（内部 filter+New+With+封 spec，happy-path 下「挂 remote cell」经 funnel 不可表达）作 downstream
-  收紧。**AI-robust 评级 Medium**（运行期 bijection 守卫；cellID 是运行期字符串，Hard 不可达——同 M12a /
-  broker-mandatory闸 的诚实天花板）；funnel 双向 = `NewForRole` 单入口（downstream，包内 sealed）+ phase guard
-  （upstream backstop，捕获绕过入口的直挂）。red/green fixture + anti-vacuity。
+  ∧ **remote cell 一律不得被挂载**，违反 fail-fast。配 `composition.NewForRole(topo, role, allModules...)`
+  收口派生+挂载（内部 filter+New+With+封 spec）。**funnel 强度分层**：`NewForRole` 是 **exported 跨包构造器**
+  （`cmd/corebundle` 调用），Go 可见性不可表达「只本 root mint」，故 caller-funnel 仅 **Medium** archtest（同
+  `CELLTRANSPORT-SELECT-FUNNEL-01` / `CROSSCELLOBS-MINTER-FUNNEL-01` 族的文档化 Go 天花板，非 Hard 包内 sealed）；
+  **真正的 fail-closed enforcement = `MOUNTED-EQUALS-COLOCATED` phase guard**（不依赖调用方走 funnel，捕获任何绕过
+  入口的直挂——upstream backstop）。`MOUNTED-EQUALS-COLOCATED` **AI-robust 评级 Medium**（运行期 bijection 守卫；
+  cellID 运行期字符串，Hard 不可达——同 M12a / broker-mandatory闸 诚实天花板）+ red/green fixture + anti-vacuity。
 
 **缺失依赖启动期闸（SC-002 sync 维补全）**：消费 contract 的 provider cell ∉ colocated ∪ remote map → fail-fast
 （区分「本地依赖缺失」vs「拓扑漏声明」）+ `gocell validate` 静态 arm。**注**：该静态检查原属 US2 T011（计划但未落地）

--- a/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
+++ b/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
@@ -440,7 +440,7 @@ US7（#1967）把 SC-001 验收信号「可执行化」时暴露一个**模型�
 「assembly 声明拓扑 → 进程只挂 colocated 子集 → 其余当 remote」这条桥接接上。本 amendment 裁定**把该能力
 做进生产**（用户裁定「彻底拆分」，非另造测试 harness——后者是平行结构），并细化 D1/D4。
 
-**开源对标深化（13 框架，写入对标库索引）**：「一份代码 + 配置驱动子集部署 + 位置透明调用」的共识模式 =
+**开源对标深化（13 框架，对标索引节已写入 `docs/references/framework-comparison.md` §「Cell 部署拓扑 / 可重定位」，指回本节）**：「一份代码 + 配置驱动子集部署 + 位置透明调用」的共识模式 =
 **枚举全部组件 → 本进程只实例化 colocated 子集 → 其余给位置透明 client**。代表实现：Service Weaver
 `component.local` `WriteOnce[bool]`（`internal/weaver/remoteweavelet.go`，deployer 启动期决定）；**Akka
 ClusterSharding** `init()` 在所有节点调用、role 匹配建真 `ShardRegion`/不匹配建 proxy（`.withRole()`）；

--- a/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
+++ b/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
@@ -431,6 +431,84 @@ relay 到 broker），此部分追踪在 **#2152** 中；在该 issue 落地前�
 进程内 per-cell publisher/subscriber 扇出（即在同一 broker 连接上为每个 cell 派生独立的 exchange /
 routing-key 命名空间）属于 per-cell relay 扇出范畴，与 per-cell DB relay 一起追踪在 **#2152** 中。
 
+### #1967 Amendment — 「彻底拆分」能力落地：groups/role 子集挂载 + 双拓扑验收（2026-06-17）
+
+US7（#1967）把 SC-001 验收信号「可执行化」时暴露一个**模型缺口**（非疏忽）：所有拆分 seam（US2-US6/US8）
+均已 ship，但**没有任何端到端「以子集运行 + 把对端当 remote」的接线**——生产 `corebundle`
+`generatedCellModules()` 无条件挂载**全部** `asm.Cells`，`generatedDeploymentTopology()` 恒空。根因：epic
+按 seam 拆分并假定「subset 部署 = 写一个子集 composition root」（`composition.With`，#1081），从未把
+「assembly 声明拓扑 → 进程只挂 colocated 子集 → 其余当 remote」这条桥接接上。本 amendment 裁定**把该能力
+做进生产**（用户裁定「彻底拆分」，非另造测试 harness——后者是平行结构），并细化 D1/D4。
+
+**开源对标深化（13 框架，写入对标库索引）**：「一份代码 + 配置驱动子集部署 + 位置透明调用」的共识模式 =
+**枚举全部组件 → 本进程只实例化 colocated 子集 → 其余给位置透明 client**。代表实现：Service Weaver
+`component.local` `WriteOnce[bool]`（`internal/weaver/remoteweavelet.go`，deployer 启动期决定）；**Akka
+ClusterSharding** `init()` 在所有节点调用、role 匹配建真 `ShardRegion`/不匹配建 proxy（`.withRole()`）；
+kube-controller-manager `NewControllerDescriptors()` 枚举全部 + `--controllers=` 子集实例化；Orleans
+`[SiloRoleBasedPlacement]` + silo metadata role；Helm `{{ if .Values.x.enabled }}`；Spring
+`@ConditionalOnProperty`。事件传输 swap（in-mem↔broker）+ in-mem 不跨进程 fail-fast：Spring Modulith
+`@Externalized` / MassTransit `UsingInMemory` vs `UsingRabbitMq`（均已对应 #1965）。静态边界校验：Spring
+Modulith `ApplicationModules.verify()`（对应缺失依赖闸）。多拓扑测试 gold standard = Service Weaver
+`weavertest.Local`/`.Multi` 同 test 双 runner（对应 US7 双拓扑 journey）。**核心借鉴 = Akka 节点角色模型**：
+一份制品、静态 role 配置选 role；与 ADR D1「拓扑静态声明在 assembly.yaml」一致（role 选择是启动期 env，
+仍 WriteOnce、非 Dapr 式运行期协商）。
+ref: ServiceWeaver/weaver `internal/weaver/remoteweavelet.go`；akka/akka cluster-sharding `withRole`；
+kubernetes `cmd/kube-controller-manager` ControllerDescriptor；spring-projects/spring-modulith
+`ApplicationModules.verify`。
+
+**D1 amendment — topology 载体增 `groups`（全图），取代单进程 `colocated/remote` authoring**：
+- assembly.yaml `topology.groups: [{role, cells, endpoint}]` 声明**完整部署分区图**（每组的 cell 集 + 对端可达
+  endpoint）；`ValidateTopologyStructure` 重写为 groups 的**穷尽 + 互斥分区**校验（每 cell 恰在一组、role 唯一、
+  endpoint 合法）。**删除**现有 `TopologyMeta.{Colocated,Remote}` **authoring** 字段 + 单进程视图校验 +
+  `ClassifyCell` 单视图分支（#1962 引入，生产零 assembly 使用，pre-GA 窗口允许原地删除，无 shim/双 schema）。
+- 启动期 role 选择器 `GOCELL_CELL_ROLE`（WriteOnce）由 groups 派生本进程 `bootstrap.DeploymentTopologySpec`
+  （colocated = 本组 cells，remote = 其余组 cells × 各自 endpoint）——**运行期 `DeploymentTopologySpec{Colocated,
+  Remote}` 作派生形态保留**（仍被 `celltransport.Resolve` 消费，#1966 接线不变，喂入值变真）。未设 role + 多 group
+  → fail-fast；未设 + 单/无 group → 全 colocated（零迁移默认不变）；role ∉ 声明集 → fail-fast。
+- codegen：`generatedDeploymentTopology()`（恒空单 spec）替换为 `generatedTopologyGroups()`（全图）+ golden。
+- 备选 (i) 多 assembly（每 tier 一 assembly + 各自二进制）与 (ii') 纯运行期 env 拓扑均拒（见 Rejected alternatives）。
+
+**D4 amendment — M12a 闭集语义精化 + 新增 `MOUNTED-EQUALS-COLOCATED` 守卫**：
+- M12a（`validateClosedSet`，#1093）守的是 `New==With` 双射，**不是** `mounted==colocated`——若把未过滤全量模块喂
+  `New(allCells).With(allMods)`，M12a 通过但拆分被破坏（remote cell 仍被本地挂载，静默双挂）。故闭集**语义**由
+  「assembly 声明的全部 cell」精化为「本进程 host 的 colocated cell」（对标 controller-runtime ControllerDescriptor
+  「枚举全部、实例化 enabled 子集」/ Akka role-match-or-proxy）；`validateClosedSet` 代码不变（仍校验 New==With，
+  在 role 过滤后 New/With 同为 colocated，双射天然成立）。
+- **新增** bootstrap-phase 守卫 `MOUNTED-EQUALS-COLOCATED`：本进程已挂 cell 集 == active topology colocated 集
+  ∧ **remote cell 一律不得被挂载**，违反 fail-fast。配单一 sealed 入口 `composition.NewForRole(topo, role,
+  allModules...)`（内部 filter+New+With+封 spec，happy-path 下「挂 remote cell」经 funnel 不可表达）作 downstream
+  收紧。**AI-robust 评级 Medium**（运行期 bijection 守卫；cellID 是运行期字符串，Hard 不可达——同 M12a /
+  broker-mandatory闸 的诚实天花板）；funnel 双向 = `NewForRole` 单入口（downstream，包内 sealed）+ phase guard
+  （upstream backstop，捕获绕过入口的直挂）。red/green fixture + anti-vacuity。
+
+**缺失依赖启动期闸（SC-002 sync 维补全）**：消费 contract 的 provider cell ∉ colocated ∪ remote map → fail-fast
+（区分「本地依赖缺失」vs「拓扑漏声明」）+ `gocell validate` 静态 arm。**注**：该静态检查原属 US2 T011（计划但未落地）
++ US3 T030（event 维，已由 #1965 broker 闸覆盖）；本 amendment 把 sync 维补全并加运行期闸。对标 Spring Modulith
+`ApplicationModules.verify()` 的 allowed-dependencies。sync 维（本闸）+ event 维（#1965）合起来 = 无静默死路由。
+
+**威胁矩阵重评（AI-robust 章程：amendment 必须同步重评）**：本 amendment 使 split **真实端到端可发生**（此前
+seam 齐全但无接线）。关键前置已落地——「共享 HMAC keyring」缺口经 **#2153（per-cell HKDF 子密钥 + master 缺席）
+在 split 下 CLOSED**（见 §#2153 Amendment）；「无 mTLS」defer **#2263**（与 token 层身份正交）；remote 操作约束
+（私网部署 + 共享 `GOCELL_SERVICE_SECRET` + `RequireCallerCell` allowlist）见 §#1966 review Amendment，groups 多
+进程部署沿用之。本 amendment **不新增**安全缺口——它把既已可达的 remote 路径从「单进程内不触发」变为「双拓扑验收
+触发」，威胁画像不变（MAC 完整性 Hard + per-cell 身份 #2153 + 私网/mTLS-#2263）。
+
+**PR 分解（mini-epic 收口，逐个独立 review，TDD RED→GREEN 在各 feature PR 内；能力 = US9 #2278，验收 = US7 #1967）**：
+- **PR-0（本 PR）**：本 amendment + `specs/069 tasks.md` US7 细化 + sibling issues。**docs-only、全绿**（不携 RED stub——
+  独立可合并 PR 不挂失败测试；TDD RED→GREEN 落各 feature PR 内）。
+- **PR-1**：`topology.groups` schema（取代 colocated/remote authoring）+ 重写 `ValidateTopologyStructure` + codegen
+  golden（Hard golden + Medium validate）。
+- **PR-2**：role 选择器 + `NewForRole` 子集挂载 + `MOUNTED-EQUALS-COLOCATED` 守卫（Medium）。
+- **PR-3**：缺失依赖启动期闸 + `gocell validate` 静态 arm + archtest red/green（Medium）。
+- **PR-4（= #1967 验收）**：`corebundle` assembly.yaml `topology.groups`（accesstier/configtier）+ `tests/e2e/` split
+  compose（同 image 2 进程 + broker + PG）+ 双拓扑参数化 journey 一致性断言 + CI 接入（对标 weavertest Local/Multi）。
+
+AI-robust 新机制评级：groups codegen golden = **Hard**；groups 校验 / role fail-fast / `MOUNTED-EQUALS-COLOCATED`
+/ 缺失依赖闸 = **Medium**（拓扑/role/cellID 均运行期数据，Hard 不可达，诚实天花板，无 Soft）。
+
+**范围切割（显式 backlog，不静默）**：外部 cell（ssobff 等）双拓扑覆盖（epic 验收第二条）→ 新 backlog issue；
+per-cell relay 扇出 → 已 #2152；mTLS → 已 #2263。
+
 ## Rejected alternatives
 
 | 方案 | 拒因 |
@@ -440,6 +518,8 @@ routing-key 命名空间）属于 per-cell relay 扇出范畴，与 per-cell DB 
 | 运行时动态 routing（Dapr placement）| GoCell 拓扑静态；动态协商引入控制面，越出「嵌入式库」形态 |
 | sidecar 进程（Dapr）| GoCell 是 library-form，无独立进程；与 §3.2「经接口注入」模型冲突 |
 | go-micro 三层 Registry/Selector/Client | 对 GoCell 过重；最小 Resolver+CellTransport 即足 |
+| 子集挂载方案 (i)：每 tier 一 assembly + 各自二进制（#1967 amendment）| N tier = N 个 cmd 二进制 + 各 assembly.yaml 重复列全 cell 分区；与「单 image 部署期可拆分」诉求不符，不如 groups/role 单制品优雅（对标 Akka 单 jar 多 role）|
+| 子集挂载方案 (ii')：纯运行期 env 拓扑（无 assembly.yaml 声明，#1967 amendment）| 拓扑变运行期输入、绕过 `gocell validate` 静态门，削弱 SC-002「100% 静态/启动期拒绝非法组合」；违 D1「拓扑静态声明」。groups（静态可验证）+ role 选择器（启动期 WriteOnce）是 ADR-faithful 折中 |
 
 ## Boundaries with sibling epics & trigger gates
 

--- a/docs/references/framework-comparison.md
+++ b/docs/references/framework-comparison.md
@@ -193,6 +193,29 @@ goal:      外部 Cell 仓库 go get + import 跑平台不变量（M3 #1084）�
 ref PR:    M3 PR-1（refactor/archtest-external-library，#1084）
 ```
 
+### framework/runtime/transport + composition — Cell 部署拓扑 / 可重定位（location-transparent transport）
+
+```
+primary:   ServiceWeaver/weaver → internal/weaver/remoteweavelet.go（component.local WriteOnce，deployer
+                                   启动期决定 local vs remote-stub）；weavertest Local/Multi（同 test 双 runner 验收）
+           akka/akka            → cluster-sharding withRole（role 匹配建真 ShardRegion / 不匹配建 proxy，
+                                   一份 jar + 静态 akka.cluster.roles 选 role）← 核心借鉴：单 image + role 选择
+secondary: kubernetes/kubernetes → cmd/kube-controller-manager（NewControllerDescriptors 枚举全部 +
+                                   IsControllerEnabled/--controllers 子集实例化）；dapr（appId 逻辑寻址 +
+                                   nameresolution.Resolver）；spring-projects/spring-modulith
+                                   （ApplicationModules.verify 结构边界校验 ← 缺失依赖闸对标）；
+                                   spring-modulith @Externalized / MassTransit UsingInMemory↔UsingRabbitMq
+                                   （事件传输 swap，in-mem 不跨进程 → 已对应 #1965 broker 闸）
+goal:      共识模式 =「枚举全部组件 → 本进程只挂 colocated 子集 → 其余给位置透明 client」；拓扑静态声明在
+           assembly.yaml（groups）+ 启动期 role 选择器 WriteOnce（非 Dapr 运行期协商）；exported 收口构造器
+           仅算 Medium caller-funnel，真正 fail-closed = MOUNTED-EQUALS-COLOCATED phase guard
+deviations:
+  - 偏离 Service Weaver method-level RPC stub → contract-level HTTP（CellTransport.DoContract），保 contract 治理边界
+  - 偏离 Dapr 运行时 placement 协商 / sidecar → 拓扑静态、library-form，无控制面
+权威详情（13 框架完整对标表 + 教训 + Rejected alternatives）见 ADR
+docs/architecture/202606131142-1423-adr-cell-deployment-topology.md §#1967 Amendment
+```
+
 ## Go 标准库参考（问题修复用）
 
 | 领域 | 标准库参考 | 关注点 |

--- a/specs/069-cell-deploy-topology/tasks.md
+++ b/specs/069-cell-deploy-topology/tasks.md
@@ -58,7 +58,7 @@
 
 - [ ] T050 [US6] `runtime/capability` per-cell DB 凭据/连接注入 seam（单 cell assembly 独立凭据；缺失 fail-fast 不静默共享）
 - [ ] T051 [US6] broker 连接 per-cell 注入点（与 #1940 funnel 对齐）
-- [ ] T052 [US6] per-cell HMAC keyring / cell 身份颁发的安全模型评估（mTLS 缺口登记，threat matrix 进 US1 ADR amendment）
+- [x] T052 [US6] per-cell HMAC keyring / cell 身份颁发的安全模型评估（→ #1964 评估 + **#2153 已实现** token 层 per-cell HKDF 子密钥/ProvisionedKeyring；mTLS 对等认证 deferred **#2263**；threat matrix 见 US1 ADR §#2153 amendment）
 
 ## Phase 4: 「彻底拆分」能力 + 验收收口（ADR §#1967 Amendment）
 
@@ -77,7 +77,9 @@
   `generatedDeploymentTopology()` → `generatedTopologyGroups()` + golden（Hard）。synthetic red case（非法 groups）。
 - [ ] T091 [US9·PR-2] 启动期 role 选择器 `GOCELL_CELL_ROLE`（WriteOnce）由 groups 派生 `DeploymentTopologySpec`
   （未设+多 group→fail-fast / 未设+单/无 group→全 colocated / role∉声明集→fail-fast）；`composition.NewForRole(topo,
-  role, allModules...)` 单 sealed 入口（filter+New+With+封 spec）；`cmd/corebundle/{run,shared_deps}.go` 改走之。
+  role, allModules...)` **exported 收口入口**（filter+New+With+封 spec；exported 跨包构造器 → caller-funnel 仅
+  **Medium** archtest，**非** Hard 包内 sealed，同 `CELLTRANSPORT-SELECT-FUNNEL-01` 族）；`cmd/corebundle/{run,shared_deps}.go`
+  改走之。**真正 fail-closed enforcement = T092 的 `MOUNTED-EQUALS-COLOCATED` phase guard**（不依赖调用方走 funnel）。
 - [ ] T092 [US9·PR-2] **新增** bootstrap-phase 守卫 `MOUNTED-EQUALS-COLOCATED`（mounted==colocated ∧ remote∉mounted，
   违反 fail-fast，Medium）；M12a（New==With，#1093）代码不动、语义精化为「本进程 host 的 cell」（ADR D4 amendment）。
   双子集 boot 集成测试（accesscore+auditcore host、configcore remote 调通）+ 守卫 red/green fixture + anti-vacuity。

--- a/specs/069-cell-deploy-topology/tasks.md
+++ b/specs/069-cell-deploy-topology/tasks.md
@@ -60,13 +60,41 @@
 - [ ] T051 [US6] broker 连接 per-cell 注入点（与 #1940 funnel 对齐）
 - [ ] T052 [US6] per-cell HMAC keyring / cell 身份颁发的安全模型评估（mTLS 缺口登记，threat matrix 进 US1 ADR amendment）
 
-## Phase 4: 验收收口
+## Phase 4: 「彻底拆分」能力 + 验收收口（ADR §#1967 Amendment）
 
-### US7 — 双拓扑 journey 验收基建（P2）→ #1967（blocked-by #1965 + #1966）
+> **模型缺口（#1967 探索结论）**：US2-US6/US8 的拆分 seam 全 ship，但**无端到端「以子集运行 + 把对端当
+> remote」的接线**——生产 `corebundle` `generatedCellModules()` 挂全部 cell、`generatedDeploymentTopology()`
+> 恒空。US7 验收「可执行化」需先补该能力（US9），再做双拓扑验收（US7）。能力做进生产（groups/role 单制品，
+> Akka 模型），非另造测试 harness（平行结构）。机制/评级/对标见 ADR §#1967 Amendment。
 
-- [ ] T060 [US7] 拆分拓扑 fixture：compose（多 cell-进程 + broker + PG）+ split assembly 双形态声明
-- [ ] T061 [US7] 同一 journey 参数化双形态运行（run-journey 接入），结果一致性断言
-- [ ] T062 [US7] CI integration job 接入（`.github/workflows/_build-lint.yml`）
+### US9 — 「彻底拆分」生产能力：groups/role 子集挂载（P2）→ #2278（blocked-by #1962 + #1963 + #1966 + #2153，均已 ship）
+
+> 拆为 3 个独立 review 的 PR（PR-1/2/3）。
+
+- [ ] T090 [US9·PR-1] `topology.groups` schema（`kernel/metadata/assembly_topology.go` + `schemas/assembly.schema.json`）
+  **取代** 单进程 `colocated/remote` authoring：重写 `ValidateTopologyStructure`（穷尽+互斥分区 / role 唯一 /
+  endpoint 合法）；删 `ClassifyCell` 单视图分支（生产零使用，pre-GA 原地删，无双 schema）。codegen
+  `generatedDeploymentTopology()` → `generatedTopologyGroups()` + golden（Hard）。synthetic red case（非法 groups）。
+- [ ] T091 [US9·PR-2] 启动期 role 选择器 `GOCELL_CELL_ROLE`（WriteOnce）由 groups 派生 `DeploymentTopologySpec`
+  （未设+多 group→fail-fast / 未设+单/无 group→全 colocated / role∉声明集→fail-fast）；`composition.NewForRole(topo,
+  role, allModules...)` 单 sealed 入口（filter+New+With+封 spec）；`cmd/corebundle/{run,shared_deps}.go` 改走之。
+- [ ] T092 [US9·PR-2] **新增** bootstrap-phase 守卫 `MOUNTED-EQUALS-COLOCATED`（mounted==colocated ∧ remote∉mounted，
+  违反 fail-fast，Medium）；M12a（New==With，#1093）代码不动、语义精化为「本进程 host 的 cell」（ADR D4 amendment）。
+  双子集 boot 集成测试（accesscore+auditcore host、configcore remote 调通）+ 守卫 red/green fixture + anti-vacuity。
+- [ ] T093 [US9·PR-3] 缺失依赖启动期闸：消费 contract provider ∉ colocated ∪ remote → fail-fast（**补全 US2 T011 未落地
+  的 sync 维静态检查** + 加运行期闸；event 维已由 US3 #1965 覆盖）+ `gocell validate` arm + archtest red/green（Medium）。
+
+### US7 — 双拓扑 journey 验收（P2）→ #1967（blocked-by US9）
+
+> 对标 Service Weaver `weavertest.Local`/`.Multi` 双 runner：同一 journey 跑单进程 ∧ split 两形态，断言一致。
+
+- [ ] T060 [US7·PR-4] `corebundle` assembly.yaml 加 `topology.groups`（accesstier=accesscore+auditcore /
+  configtier=configcore+syscore）+ `tests/e2e/` split compose（**同一 corebundle image 跑 2 进程**，
+  `GOCELL_CELL_ROLE=accesstier`/`configtier` + RabbitMQ + PG，沿用既有 compose/Dockerfile 形态）
+- [ ] T061 [US7·PR-4] 同一 journey 参数化双形态运行（**Go 集成测试 `t.Run` 双形态，沿用 `gocell verify journey`
+  → checkRef 模式，不新建 run-journey CLI**），结果一致性断言（事件经 broker / sync 经 remote；断言 `transport_mode=remote`）
+- [ ] T062 [US7·PR-4] CI integration/e2e job 接入（`.github/workflows/_build-lint.yml`，testcontainers/compose 惯例）
+- [ ] T063 [US7·backlog] 外部 cell（ssobff 等）双拓扑覆盖（epic 验收第二条「内部+外部同等」）→ #2279，非本轮
 
 ### US8 — 跨 cell 直连禁制 archtest 收口（P2）→ #1961（无 blocker，no-regret 可立即开工）
 
@@ -76,10 +104,10 @@
 ## Dependencies & Execution Order
 
 ```
-US8 ──────────────────────────────┐（无依赖，立即可做）
-US1(ADR) ─┬─ US2 ─┬─ US3 ←─ #1940 │
-          │       └─ US5 ←─ US4   ├─→ US7（收口）
-          ├─ US4 ─────┘           │
+US8 ──────────────────────────────────────────┐（无依赖，立即可做）
+US1(ADR) ─┬─ US2 ─┬─ US3 ←─ #1940 │             │
+          │       └─ US5 ←─ US4   ├─ US9 ─→ US7（收口）
+          ├─ US4 ─────┘           │（子集挂载能力）
           └─ US6 ─────────────────┘
 ```
 
@@ -87,11 +115,14 @@ US1(ADR) ─┬─ US2 ─┬─ US3 ←─ #1940 │
 |------|-------|------|
 | 1 | US1 #1960、US8 #1961、#1940 | 裁决 + no-regret，立即并行（先 #1960） |
 | 2 | US2 #1962、US4 #1963、US6 #1964 | seam 主干，ADR 后并行（先 #1962，拓扑判定是消费源） |
-| 3 | US3 #1965、US5 #1966 | 拆分形态，依赖 Wave 2 |
-| 4 | US7 #1967 | epic 验收收口 |
+| 3 | US3 #1965、US5 #1966、US6 #2153 | 拆分形态 + per-cell 身份，依赖 Wave 2 |
+| 4a | **US9（新）= PR-1/2/3** | 「彻底拆分」生产能力：groups/role 子集挂载（ADR §#1967 Amendment 暴露的模型缺口收口） |
+| 4b | US7 #1967 = PR-4 | epic 验收收口（双拓扑 journey，blocked-by US9） |
+| — | PR-0（本 PR） | ADR amendment + 本 tasks 细化 + sibling issues（docs-only） |
 
 ## Notes
 
 - 每 story 一个 issue、一个（或一簇）PR，各自走 `/ship`（worktree + TDD + 内置 review）。
 - event broker funnel 不建新单：由 #1940 承载（US3 blocked-by）。
-- 运行时动态 placement / sidecar / mTLS 全链 out of scope（归 #303 / 后续 threat-matrix 裁决）。
+- 运行时动态 placement / sidecar out of scope（归 #303）；mTLS 对等认证 → **#2263**（与 token 层 per-cell 身份正交，#2153 已落 token 层隔离）。
+- **US9（新）拆 3 个独立 review PR**（PR-1 schema/codegen、PR-2 role 选择器+子集挂载+`MOUNTED-EQUALS-COLOCATED`、PR-3 缺失依赖闸）；US7 #1967 = PR-4 验收，blocked-by US9。PR-0（ADR + 本 tasks + sibling issues）docs-only、先行。各 feature PR 内 TDD RED→GREEN（PR-0 不携 RED stub）。


### PR DESCRIPTION
## Summary

PR-0（docs-only）：amend ADR `202606131142-1423`（Cell 部署拓扑）+ 细化 `specs/069` 任务，规划 #1423「彻底拆分」收口 mini-epic——把「同一份 cell 代码、仅改 topology wiring 即可单进程/子集/多进程」从 seam 齐全但**无接线**，推进到生产可拆分 + 双拓扑验收。

## Why / 背景

`/ship #1967` 探索发现：US2-US6/US8 的拆分 seam（celltransport in-proc/remote、broker-mandatory 闸、DeploymentTopology、跨进程 principal MAC、per-cell 身份 #2153、subset 组合 API）全 ship 并测过，**但没有任何端到端「以子集运行 + 把对端当 remote」的接线**——生产 `corebundle` `generatedCellModules()` 无条件挂载全部 cell、`generatedDeploymentTopology()` 恒空。根因是 epic 假定「subset 部署 = 写子集 composition root」，从未把「assembly 声明拓扑 → 进程只挂 colocated 子集」桥接上。用户裁定**彻底拆分**：做进生产（单 image + groups/role 选择器，Akka 节点角色模型），非另造测试 harness（平行结构）。

本 PR 把决策与任务先落地（用户要求「先把任务和 ADR 完成」）。13 框架开源对标（Service Weaver / Akka ClusterSharding / Orleans / Dapr / controller-runtime / Helm / Spring Modulith / .NET Aspire / MassTransit 等）共识 = 「枚举全部组件 → 本进程只挂 colocated 子集 → 其余给位置透明 client」，核心借鉴 Akka 节点角色（一份制品 + 静态 role 配置）。

## Refs

- Refs #1423（epic 收口）、#1967（US7 验收，re-scope 为 PR-4，blocked-by 能力）
- Creates #2278（US9 生产能力：groups/role 子集挂载，PR-1/2/3）、#2279（外部 cell 双拓扑覆盖 backlog）
- ref: ServiceWeaver/weaver `internal/weaver/remoteweavelet.go`（component.local WriteOnce）；ServiceWeaver `weavertest` Local/Multi；akka/akka cluster-sharding `withRole`（role-match/proxy）；kubernetes `cmd/kube-controller-manager` ControllerDescriptor（--controllers 子集）；spring-projects/spring-modulith `ApplicationModules.verify`（缺失依赖闸对标）

## Risk / 兼容性

- 本 PR **无代码 / wire / schema 变更**（docs-only：ADR markdown + specs/069 tasks.md）。
- 下游形态锁定：ADR D1 amendment（`topology.groups` 取代单进程 `colocated/remote` authoring）+ D4 amendment（M12a 语义精化 + 新增 `MOUNTED-EQUALS-COLOCATED` 守卫）。authoring schema 的破坏式删除在 PR-1（#2278）落地，pre-GA wire 破坏窗口允许原地删（生产零 assembly 使用）。
- 威胁矩阵已同步重评（AI-robust 章程要求）：split 真实可发生的前置「共享 HMAC keyring」缺口经 #2153（per-cell HKDF）在 split 下 CLOSED；mTLS → #2263；本 amendment 不新增安全缺口。

## Test plan

- [x] docs-only（ADR + specs markdown），无 Go 变更 → `go build/test` + `golangci-lint` N/A
- [x] sibling issues 四轴 label 经 `hack/automation/issue-labels.sh validate` 通过
- [x] ADR/tasks 内 issue 引用（#2278/#2279）回填一致
