### PR TITLE
feat(registry): #2233 运行时契约注册状态机（sealed state + 不变式 + 投影）[303-US2]

### DIFF
--- a/framework/kernel/registry/doc.go
+++ b/framework/kernel/registry/doc.go
@@ -28,5 +28,9 @@
 // (Hard); the append-only event log is Hard by encapsulation (unexported, no
 // exported mutator deletes events). The runtime transition guard is Medium (Go
 // has no typestate; runtime fail-closed is the ceiling), with the table's edge
-// set and the value set pinned by anti-vacuity freeze tests.
+// set and the value set pinned by anti-vacuity freeze tests. Those freeze tests
+// are package-level unit tests (TestLegalTransitions_Frozen,
+// TestRegistrationState_FrozenRegistry) — not tools/archtest INVARIANT guards,
+// since the state machine is package-internal; if a future story exposes it to
+// out-of-package callers, the freeze tests are the archtest upgrade path.
 package registry

--- a/framework/kernel/registry/doc.go
+++ b/framework/kernel/registry/doc.go
@@ -2,7 +2,31 @@
 // instances, used by kernel/assembly to look up dependencies at init time
 // and by kernel/governance for cross-reference validation.
 //
-// Lifecycle: registries are populated once during assembly bootstrap
-// (phase2 in runtime/bootstrap) and remain immutable afterward. Lookups
-// are concurrent-safe by virtue of immutability, not via locking.
+// # Read-only registries (CellRegistry, ContractRegistry)
+//
+// CellRegistry and ContractRegistry are populated once during assembly
+// bootstrap (phase2 in runtime/bootstrap) and remain immutable afterward.
+// Lookups are concurrent-safe by virtue of immutability, not via locking, and
+// return deep copies so callers cannot alias-mutate the backing data.
+//
+// # Runtime registration state machine (ContractRegistrar, 303-US2 #2233)
+//
+// ContractRegistrar is the runtime, MUTABLE counterpart: it accepts
+// runtime-submitted contracts and drives each through the sealed
+// RegistrationState lifecycle (submitted → probing → conformant →
+// pending-approval → approved → active → retired, with terminal probing→rejected
+// / pending-approval→rejected branches). Unlike the read-only registries above,
+// it is concurrent-safe BY LOCKING: a single sync.Mutex guards an append-only
+// per-registration event log (source of truth for history) and an in-mem
+// projection index (current state), kept consistent in one critical section —
+// the two-truth model of kernel/saga/journal.MemJournal. Transitions are
+// validated against the frozen legalTransitions table before any append, so an
+// illegal transition is fail-closed with no half-write.
+//
+// AI-robust grading: RegistrationState is sealed (unexported field + accessor
+// functions), so forging a state or jumping the machine is a compile error
+// (Hard); the append-only event log is Hard by encapsulation (unexported, no
+// exported mutator deletes events). The runtime transition guard is Medium (Go
+// has no typestate; runtime fail-closed is the ceiling), with the table's edge
+// set and the value set pinned by anti-vacuity freeze tests.
 package registry

--- a/framework/kernel/registry/registrar.go
+++ b/framework/kernel/registry/registrar.go
@@ -52,6 +52,7 @@ func NewContractRegistrar(clk clock.Clock) *ContractRegistrar {
 // if the id already exists. dedup is by registration id only; the
 // (kind,domain,version,owner) uniqueness quadruple is owned by US15/FR-009.
 func (r *ContractRegistrar) Submit(in SubmitInput) (ContractRegistration, error) {
+	in = in.normalized()
 	if err := in.validate(); err != nil {
 		return ContractRegistration{}, err
 	}
@@ -91,6 +92,7 @@ func (r *ContractRegistrar) Submit(in SubmitInput) (ContractRegistration, error)
 // ErrValidationFailed for an empty in.ID or in.Actor (attribution is required).
 // When in.To is approved, in.Actor is recorded as the registration's Approver.
 func (r *ContractRegistrar) Advance(in AdvanceInput) (ContractRegistration, error) {
+	in = in.normalized()
 	if err := in.validate(); err != nil {
 		return ContractRegistration{}, err
 	}

--- a/framework/kernel/registry/registrar.go
+++ b/framework/kernel/registry/registrar.go
@@ -1,0 +1,182 @@
+package registry
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+)
+
+// ContractRegistrar is the runtime, mutable contract-registration state machine
+// (303-US2, #2233). Unlike the read-only ContractRegistry / CellRegistry (which
+// are populated once at bootstrap and immutable thereafter), the registrar
+// accepts runtime-submitted contracts and drives each through the sealed
+// RegistrationState machine via Submit / Advance.
+//
+// It keeps two structures consistent under a single mutex (mirroring
+// kernel/saga/journal.MemJournal's two-truth model): an append-only per-id
+// RegistrationEvent log (source of truth for history) and an in-mem projection
+// index (current state per registration). Advance validates the transition
+// BEFORE appending, so an illegal transition leaves both structures untouched
+// (fail-closed, no half-write). A plain sync.Mutex serializes all access —
+// reads return value copies, so there is no lock-upgrade hazard.
+type ContractRegistrar struct {
+	clk    clock.Clock
+	mu     sync.Mutex
+	events map[string][]RegistrationEvent
+	index  map[string]*ContractRegistration
+}
+
+// NewContractRegistrar builds an empty registrar. clk is a required positional
+// dependency (clock.Clock convention); it stamps event timestamps inside the lock.
+func NewContractRegistrar(clk clock.Clock) *ContractRegistrar {
+	clock.MustHaveClock(clk, "registry.NewContractRegistrar")
+	return &ContractRegistrar{
+		clk:    clk,
+		events: make(map[string][]RegistrationEvent),
+		index:  make(map[string]*ContractRegistration),
+	}
+}
+
+// Submit records a new registration in the submitted state, appending the
+// initial migration event (From = zero sentinel, To = submitted). It returns
+// ErrValidationFailed for missing required fields and ErrRegistrationDuplicate
+// if the id already exists. dedup is by registration id only; the
+// (kind,domain,version,owner) uniqueness quadruple is owned by US15/FR-009.
+func (r *ContractRegistrar) Submit(in SubmitInput) (ContractRegistration, error) {
+	if err := in.validate(); err != nil {
+		return ContractRegistration{}, err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.index[in.ID]; exists {
+		return ContractRegistration{}, errcode.New(errcode.KindConflict, errcode.ErrRegistrationDuplicate,
+			"registry: registration id already exists",
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("id=%q", in.ID))))
+	}
+	now := r.clk.Now()
+	reg := &ContractRegistration{
+		ID:            in.ID,
+		Kind:          in.Kind,
+		PayloadSchema: in.PayloadSchema,
+		Submitter:     in.Submitter,
+		State:         stateSubmitted,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	r.index[in.ID] = reg
+	r.appendLocked(in.ID, RegistrationEvent{
+		From:       RegistrationState{},
+		To:         stateSubmitted,
+		Actor:      in.Submitter,
+		OccurredAt: now,
+	})
+	return *reg, nil
+}
+
+// Advance moves a registration from its current state to `to`, recording one
+// migration event. It returns ErrRegistrationNotFound for an unknown id and
+// ErrRegistrationInvalidTransition for a transition the legalTransitions table
+// forbids (including any transition out of a terminal state, a self-loop, or a
+// forged zero target). The transition is validated before any mutation, so a
+// rejected Advance leaves the projection and event log untouched. When `to` is
+// approved, the actor is recorded as the registration's Approver.
+func (r *ContractRegistrar) Advance(id string, to RegistrationState, actor, reason string) (ContractRegistration, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cur, ok := r.index[id]
+	if !ok {
+		return ContractRegistration{}, errcode.New(errcode.KindNotFound, errcode.ErrRegistrationNotFound,
+			"registry: registration not found",
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("id=%q", id))))
+	}
+	if err := Transition(cur.State, to); err != nil {
+		return ContractRegistration{}, err
+	}
+	now := r.clk.Now()
+	from := cur.State
+	cur.State = to
+	cur.UpdatedAt = now
+	if to == stateApproved {
+		cur.Approver = actor
+	}
+	r.appendLocked(id, RegistrationEvent{
+		From:       from,
+		To:         to,
+		Actor:      actor,
+		Reason:     reason,
+		OccurredAt: now,
+	})
+	return *cur, nil
+}
+
+// appendLocked appends e to id's event stream, assigning the owning id and the
+// 1-based contiguous Seq. Caller must hold r.mu.
+func (r *ContractRegistrar) appendLocked(id string, e RegistrationEvent) {
+	e.RegistrationID = id
+	e.Seq = len(r.events[id]) + 1
+	r.events[id] = append(r.events[id], e)
+}
+
+// Get returns a copy of the registration by id, or (zero, false) if not found.
+// The copy isolates callers from the projection (registration is all value
+// types, so the struct copy is a full deep copy).
+func (r *ContractRegistrar) Get(id string) (ContractRegistration, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	reg, ok := r.index[id]
+	if !ok {
+		return ContractRegistration{}, false
+	}
+	return *reg, true
+}
+
+// ByState returns copies of all registrations currently in the given state,
+// sorted by id. The set is derived by filtering the projection on read (no
+// separate byState index to keep consistent — registration counts are small and
+// the mutable index makes a maintained bucket map a needless correctness risk).
+func (r *ContractRegistrar) ByState(state RegistrationState) []ContractRegistration {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []ContractRegistration
+	for _, reg := range r.index {
+		if reg.State == state {
+			out = append(out, *reg)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// Events returns a deep copy of id's append-only migration event stream (ordered
+// by Seq), or (nil, false) if the id is unknown.
+func (r *ContractRegistrar) Events(id string) ([]RegistrationEvent, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	evs, ok := r.events[id]
+	if !ok {
+		return nil, false
+	}
+	return append([]RegistrationEvent(nil), evs...), true
+}
+
+// Count returns the number of registrations.
+func (r *ContractRegistrar) Count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.index)
+}
+
+// AllIDs returns all registration ids sorted alphabetically.
+func (r *ContractRegistrar) AllIDs() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ids := make([]string, 0, len(r.index))
+	for id := range r.index {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}

--- a/framework/kernel/registry/registrar.go
+++ b/framework/kernel/registry/registrar.go
@@ -20,8 +20,14 @@ import (
 // RegistrationEvent log (source of truth for history) and an in-mem projection
 // index (current state per registration). Advance validates the transition
 // BEFORE appending, so an illegal transition leaves both structures untouched
-// (fail-closed, no half-write). A plain sync.Mutex serializes all access —
-// reads return value copies, so there is no lock-upgrade hazard.
+// (fail-closed, no half-write).
+//
+// Concurrency uses a plain sync.Mutex (not sync.RWMutex), matching
+// kernel/saga/journal.MemJournal: every read returns a value copy under the lock
+// and there are no consumers yet, so a read/write split would be premature
+// optimization that adds a lock-upgrade hazard for no measured benefit. Revisit
+// (RWMutex) only if a downstream read-heavy benchmark — e.g. a ByState polling
+// hot path — demonstrates contention.
 type ContractRegistrar struct {
 	clk    clock.Clock
 	mu     sync.Mutex
@@ -81,32 +87,36 @@ func (r *ContractRegistrar) Submit(in SubmitInput) (ContractRegistration, error)
 // ErrRegistrationInvalidTransition for a transition the legalTransitions table
 // forbids (including any transition out of a terminal state, a self-loop, or a
 // forged zero target). The transition is validated before any mutation, so a
-// rejected Advance leaves the projection and event log untouched. When `to` is
-// approved, the actor is recorded as the registration's Approver.
-func (r *ContractRegistrar) Advance(id string, to RegistrationState, actor, reason string) (ContractRegistration, error) {
+// rejected Advance leaves the projection and event log untouched. It also returns
+// ErrValidationFailed for an empty in.ID or in.Actor (attribution is required).
+// When in.To is approved, in.Actor is recorded as the registration's Approver.
+func (r *ContractRegistrar) Advance(in AdvanceInput) (ContractRegistration, error) {
+	if err := in.validate(); err != nil {
+		return ContractRegistration{}, err
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	cur, ok := r.index[id]
+	cur, ok := r.index[in.ID]
 	if !ok {
 		return ContractRegistration{}, errcode.New(errcode.KindNotFound, errcode.ErrRegistrationNotFound,
 			"registry: registration not found",
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("id=%q", id))))
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("id=%q", in.ID))))
 	}
-	if err := Transition(cur.State, to); err != nil {
+	if err := Transition(cur.State, in.To); err != nil {
 		return ContractRegistration{}, err
 	}
 	now := r.clk.Now()
 	from := cur.State
-	cur.State = to
+	cur.State = in.To
 	cur.UpdatedAt = now
-	if to == stateApproved {
-		cur.Approver = actor
+	if in.To == stateApproved {
+		cur.Approver = in.Actor
 	}
-	r.appendLocked(id, RegistrationEvent{
+	r.appendLocked(in.ID, RegistrationEvent{
 		From:       from,
-		To:         to,
-		Actor:      actor,
-		Reason:     reason,
+		To:         in.To,
+		Actor:      in.Actor,
+		Reason:     in.Reason,
 		OccurredAt: now,
 	})
 	return *cur, nil
@@ -137,7 +147,12 @@ func (r *ContractRegistrar) Get(id string) (ContractRegistration, bool) {
 // sorted by id. The set is derived by filtering the projection on read (no
 // separate byState index to keep consistent — registration counts are small and
 // the mutable index makes a maintained bucket map a needless correctness risk).
+// A forged/zero state is fail-closed: it is not a registered value, so the
+// result is always empty (explicit guard, mirroring the transition table).
 func (r *ContractRegistrar) ByState(state RegistrationState) []ContractRegistration {
+	if !state.isRegistered() {
+		return nil
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	var out []ContractRegistration

--- a/framework/kernel/registry/registrar_test.go
+++ b/framework/kernel/registry/registrar_test.go
@@ -97,6 +97,67 @@ func TestSubmit_EmptyFields(t *testing.T) {
 	assert.Equal(t, 0, r.Count())
 }
 
+// TestSubmit_WhitespaceOnlyFields verifies whitespace-only required fields are
+// rejected (not just byte-empty) — a blank Submitter must not become a phantom
+// identity in the audit trail.
+func TestSubmit_WhitespaceOnlyFields(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	cases := []registry.SubmitInput{
+		{ID: "  ", Kind: "http", Submitter: "cell-a"},
+		{ID: "x", Kind: "\t", Submitter: "cell-a"},
+		{ID: "x", Kind: "http", Submitter: "   "},
+	}
+	for _, in := range cases {
+		_, err := r.Submit(in)
+		errcodetest.AssertCode(t, err, errcode.ErrValidationFailed)
+	}
+	assert.Equal(t, 0, r.Count(), "whitespace-only required fields must not create a registration")
+}
+
+// TestSubmit_TrimsStoredIdentity verifies required identity fields are stored
+// canonicalized (trimmed), so padded values don't drift attribution / dedup.
+func TestSubmit_TrimsStoredIdentity(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	reg, err := r.Submit(registry.SubmitInput{ID: " reg-1 ", Kind: " http ", Submitter: " cell-a "})
+	require.NoError(t, err)
+	assert.Equal(t, "reg-1", reg.ID)
+	assert.Equal(t, "http", reg.Kind)
+	assert.Equal(t, "cell-a", reg.Submitter)
+	_, ok := r.Get("reg-1") // stored under the trimmed id
+	assert.True(t, ok)
+}
+
+// TestAdvance_WhitespaceOnlyActor verifies a whitespace-only actor is rejected
+// and leaves state/events untouched (audit attribution must name a real actor).
+func TestAdvance_WhitespaceOnlyActor(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	mustSubmit(t, r, "reg-1")
+	_, err := advance(r, "reg-1", registry.StateProbing(), "  \t ", "")
+	errcodetest.AssertCode(t, err, errcode.ErrValidationFailed)
+	reg, ok := r.Get("reg-1")
+	require.True(t, ok)
+	assert.Equal(t, registry.StateSubmitted(), reg.State, "whitespace-only actor must not advance state")
+	events, _ := r.Events("reg-1")
+	assert.Len(t, events, 1, "no event appended on rejected whitespace advance")
+}
+
+// TestAdvance_TrimsStoredActor verifies a padded approver is stored trimmed.
+func TestAdvance_TrimsStoredActor(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	mustSubmit(t, r, "reg-1")
+	for _, to := range []registry.RegistrationState{registry.StateProbing(), registry.StateConformant(), registry.StatePendingApproval()} {
+		_, err := advance(r, "reg-1", to, "system", "")
+		require.NoError(t, err)
+	}
+	reg, err := advance(r, "reg-1", registry.StateApproved(), "  admin-9  ", "")
+	require.NoError(t, err)
+	assert.Equal(t, "admin-9", reg.Approver)
+}
+
 func TestAdvance_FullLifecycle(t *testing.T) {
 	t.Parallel()
 	r, _ := newRegistrar(t)

--- a/framework/kernel/registry/registrar_test.go
+++ b/framework/kernel/registry/registrar_test.go
@@ -18,6 +18,10 @@ import (
 
 var testEpoch = time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC)
 
+// advanceClockStep is the clock advance between transitions in timestamp tests
+// (TEST-TIME-LITERAL-01: site-specific test durations are package-level consts).
+const advanceClockStep = 5 * time.Minute
+
 func newRegistrar(t *testing.T) (*registry.ContractRegistrar, *clockmock.FakeClock) {
 	t.Helper()
 	clk := clockmock.New(testEpoch)
@@ -184,7 +188,7 @@ func TestAdvance_StampsUpdatedAt(t *testing.T) {
 	reg := mustSubmit(t, r, "reg-1")
 	created := reg.CreatedAt
 
-	clk.Advance(5 * time.Minute)
+	clk.Advance(advanceClockStep)
 	advanced, err := advance(r, "reg-1", registry.StateProbing(), "system", "")
 	require.NoError(t, err)
 	assert.Equal(t, created, advanced.CreatedAt, "CreatedAt must not change on advance")
@@ -293,11 +297,11 @@ func TestEvents_DeepCopy(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestGet_NotFound(t *testing.T) {
+func TestGet_Missing(t *testing.T) {
 	t.Parallel()
 	r, _ := newRegistrar(t)
 	_, ok := r.Get("missing")
-	assert.False(t, ok)
+	assert.False(t, ok, "Get returns (zero, false) for an unknown id — no error, by design")
 }
 
 func TestAllIDs_Sorted(t *testing.T) {

--- a/framework/kernel/registry/registrar_test.go
+++ b/framework/kernel/registry/registrar_test.go
@@ -3,6 +3,7 @@ package registry_test
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -30,6 +31,20 @@ func mustSubmit(t *testing.T, r *registry.ContractRegistrar, id string) registry
 	return reg
 }
 
+// advance is a test convenience over the named-field AdvanceInput API.
+func advance(r *registry.ContractRegistrar, id string, to registry.RegistrationState, actor, reason string) (
+	registry.ContractRegistration, error,
+) {
+	return r.Advance(registry.AdvanceInput{ID: id, To: to, Actor: actor, Reason: reason})
+}
+
+// happyPath is the full main-path lifecycle (excluding the initial submitted state).
+var happyPath = []registry.RegistrationState{
+	registry.StateProbing(), registry.StateConformant(),
+	registry.StatePendingApproval(), registry.StateApproved(),
+	registry.StateActive(), registry.StateRetired(),
+}
+
 func TestSubmit_CreatesAtSubmitted(t *testing.T) {
 	t.Parallel()
 	r, clk := newRegistrar(t)
@@ -47,6 +62,7 @@ func TestSubmit_CreatesAtSubmitted(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, events, 1)
 	assert.Equal(t, 1, events[0].Seq)
+	assert.Equal(t, "reg-1", events[0].RegistrationID)
 	assert.True(t, events[0].From.IsZero(), "initial event From must be the zero sentinel")
 	assert.Equal(t, registry.StateSubmitted(), events[0].To)
 	assert.Equal(t, "cell-a", events[0].Actor)
@@ -81,19 +97,14 @@ func TestAdvance_FullLifecycle(t *testing.T) {
 	t.Parallel()
 	r, _ := newRegistrar(t)
 	mustSubmit(t, r, "reg-1")
-	path := []registry.RegistrationState{
-		registry.StateProbing(), registry.StateConformant(),
-		registry.StatePendingApproval(), registry.StateApproved(),
-		registry.StateActive(), registry.StateRetired(),
-	}
-	for _, to := range path {
-		reg, err := r.Advance("reg-1", to, "admin", "ok")
+	for _, to := range happyPath {
+		reg, err := advance(r, "reg-1", to, "admin", "ok")
 		require.NoError(t, err, "advance to %q", to)
 		assert.Equal(t, to, reg.State)
 	}
 	events, ok := r.Events("reg-1")
 	require.True(t, ok)
-	assert.Len(t, events, len(path)+1) // +1 for the initial submit event
+	assert.Len(t, events, len(happyPath)+1) // +1 for the initial submit event
 }
 
 // TestAdvance_SubmittedToActivate_Rejected is acceptance scenario 1: a submitted
@@ -104,7 +115,7 @@ func TestAdvance_SubmittedToActivate_Rejected(t *testing.T) {
 	r, _ := newRegistrar(t)
 	mustSubmit(t, r, "reg-1")
 
-	_, err := r.Advance("reg-1", registry.StateActive(), "attacker", "bypass")
+	_, err := advance(r, "reg-1", registry.StateActive(), "attacker", "bypass")
 	errcodetest.AssertCode(t, err, errcode.ErrRegistrationInvalidTransition)
 
 	reg, ok := r.Get("reg-1")
@@ -119,22 +130,52 @@ func TestAdvance_SubmittedToActivate_Rejected(t *testing.T) {
 func TestAdvance_NotFound(t *testing.T) {
 	t.Parallel()
 	r, _ := newRegistrar(t)
-	_, err := r.Advance("nope", registry.StateProbing(), "admin", "")
+	_, err := advance(r, "nope", registry.StateProbing(), "admin", "")
 	errcodetest.AssertCode(t, err, errcode.ErrRegistrationNotFound)
 }
 
+// TestAdvance_EmptyFields verifies the attribution guard: an empty id or actor is
+// rejected with ErrValidationFailed (symmetric with SubmitInput requiring a
+// Submitter — an approve/retire with no actor is an audit-attribution hole).
+func TestAdvance_EmptyFields(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	mustSubmit(t, r, "reg-1")
+	_, err := advance(r, "", registry.StateProbing(), "admin", "")
+	errcodetest.AssertCode(t, err, errcode.ErrValidationFailed)
+	_, err = advance(r, "reg-1", registry.StateProbing(), "", "no actor")
+	errcodetest.AssertCode(t, err, errcode.ErrValidationFailed)
+
+	// The rejected empty-actor advance must not have mutated state or appended.
+	reg, ok := r.Get("reg-1")
+	require.True(t, ok)
+	assert.Equal(t, registry.StateSubmitted(), reg.State)
+	events, _ := r.Events("reg-1")
+	assert.Len(t, events, 1)
+}
+
+// TestAdvance_SetsApproverOnApprove verifies Approver is set ONLY on the approve
+// transition, stays empty before it, and is NOT changed by later transitions
+// (active/retired) — symmetric with TestTransition_ActiveOnlyFromApproved.
 func TestAdvance_SetsApproverOnApprove(t *testing.T) {
 	t.Parallel()
 	r, _ := newRegistrar(t)
 	mustSubmit(t, r, "reg-1")
 	for _, to := range []registry.RegistrationState{registry.StateProbing(), registry.StateConformant(), registry.StatePendingApproval()} {
-		reg, err := r.Advance("reg-1", to, "system", "")
+		reg, err := advance(r, "reg-1", to, "system", "")
 		require.NoError(t, err)
 		assert.Empty(t, reg.Approver, "Approver must not be set before approval (state %q)", to)
 	}
-	reg, err := r.Advance("reg-1", registry.StateApproved(), "admin-42", "looks good")
+	reg, err := advance(r, "reg-1", registry.StateApproved(), "admin-42", "looks good")
 	require.NoError(t, err)
 	assert.Equal(t, "admin-42", reg.Approver)
+
+	// Subsequent transitions must NOT change the recorded approver.
+	for _, to := range []registry.RegistrationState{registry.StateActive(), registry.StateRetired()} {
+		reg, err := advance(r, "reg-1", to, "ops-1", "")
+		require.NoError(t, err)
+		assert.Equal(t, "admin-42", reg.Approver, "Approver must be unchanged after approval (state %q)", to)
+	}
 }
 
 func TestAdvance_StampsUpdatedAt(t *testing.T) {
@@ -144,7 +185,7 @@ func TestAdvance_StampsUpdatedAt(t *testing.T) {
 	created := reg.CreatedAt
 
 	clk.Advance(5 * time.Minute)
-	advanced, err := r.Advance("reg-1", registry.StateProbing(), "system", "")
+	advanced, err := advance(r, "reg-1", registry.StateProbing(), "system", "")
 	require.NoError(t, err)
 	assert.Equal(t, created, advanced.CreatedAt, "CreatedAt must not change on advance")
 	assert.Equal(t, clk.Now(), advanced.UpdatedAt)
@@ -153,18 +194,19 @@ func TestAdvance_StampsUpdatedAt(t *testing.T) {
 
 // TestReplayEvents_ProjectionConsistent is acceptance scenario 3: folding the
 // append-only event stream (from the zero sentinel) reproduces the live
-// projection state — an honest cross-check that the independently-maintained
-// projection equals the fold of the log.
+// projection — an honest cross-check that the independently-maintained
+// projection equals the fold of the log. It drives the FULL happy path so the
+// Approver field (set on the approve event) is also reconstructed from the log.
 func TestReplayEvents_ProjectionConsistent(t *testing.T) {
 	t.Parallel()
 	r, _ := newRegistrar(t)
 	mustSubmit(t, r, "reg-1")
-	lifecycle := []registry.RegistrationState{
-		registry.StateProbing(), registry.StateConformant(),
-		registry.StatePendingApproval(), registry.StateRejected(),
-	}
-	for _, to := range lifecycle {
-		_, err := r.Advance("reg-1", to, "system", "")
+	for _, to := range happyPath {
+		actor := "system"
+		if to == registry.StateApproved() {
+			actor = "admin-7"
+		}
+		_, err := advance(r, "reg-1", to, actor, "")
 		require.NoError(t, err)
 	}
 
@@ -173,17 +215,25 @@ func TestReplayEvents_ProjectionConsistent(t *testing.T) {
 	require.NotEmpty(t, events)
 
 	// Fold the event stream from the zero sentinel; each event's From must chain
-	// to the prior event's To, and the final To is the derived current state.
-	var derived registry.RegistrationState
+	// to the prior event's To. State and Approver are reconstructed independently
+	// of the live projection.
+	var derivedState registry.RegistrationState
+	var derivedApprover string
 	for i, e := range events {
 		assert.Equal(t, i+1, e.Seq, "events must be 1-based and contiguous")
-		assert.Equal(t, derived, e.From, "event %d From must chain from prior To", i)
-		derived = e.To
+		assert.Equal(t, "reg-1", e.RegistrationID)
+		assert.Equal(t, derivedState, e.From, "event %d From must chain from prior To", i)
+		derivedState = e.To
+		if e.To == registry.StateApproved() {
+			derivedApprover = e.Actor
+		}
 	}
 
 	live, ok := r.Get("reg-1")
 	require.True(t, ok)
-	assert.Equal(t, live.State, derived, "replayed state must equal the live projection")
+	assert.Equal(t, live.State, derivedState, "replayed state must equal the live projection")
+	assert.Equal(t, live.Approver, derivedApprover, "replayed approver must equal the live projection")
+	assert.Equal(t, "admin-7", live.Approver)
 }
 
 func TestByState_Filters(t *testing.T) {
@@ -192,7 +242,7 @@ func TestByState_Filters(t *testing.T) {
 	mustSubmit(t, r, "a")
 	mustSubmit(t, r, "b")
 	mustSubmit(t, r, "c")
-	_, err := r.Advance("b", registry.StateProbing(), "system", "")
+	_, err := advance(r, "b", registry.StateProbing(), "system", "")
 	require.NoError(t, err)
 
 	submitted := r.ByState(registry.StateSubmitted())
@@ -201,6 +251,15 @@ func TestByState_Filters(t *testing.T) {
 	assert.Len(t, probing, 1)
 	assert.Equal(t, "b", probing[0].ID)
 	assert.Empty(t, r.ByState(registry.StateApproved()))
+}
+
+// TestByState_ZeroStateEmpty pins the fail-closed contract: querying a
+// forged/zero RegistrationState returns empty (never panics, never matches).
+func TestByState_ZeroStateEmpty(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	mustSubmit(t, r, "a")
+	assert.Empty(t, r.ByState(registry.RegistrationState{}))
 }
 
 func TestGet_NoAliasMutation(t *testing.T) {
@@ -250,9 +309,9 @@ func TestAllIDs_Sorted(t *testing.T) {
 	assert.Equal(t, []string{"a", "b", "c"}, r.AllIDs())
 }
 
-// TestConcurrent_SubmitAdvance_Race fires concurrent Submit+Advance and asserts
-// no data race (run with -race) and that each registration's event count matches
-// the transitions applied (projection consistent under the lock).
+// TestConcurrent_SubmitAdvance_Race fires concurrent Submit+Advance on DISTINCT
+// ids and asserts no data race (run with -race) and that each registration's
+// event count matches the transitions applied (projection consistent).
 func TestConcurrent_SubmitAdvance_Race(t *testing.T) {
 	t.Parallel()
 	r, _ := newRegistrar(t)
@@ -265,7 +324,7 @@ func TestConcurrent_SubmitAdvance_Race(t *testing.T) {
 			id := fmt.Sprintf("reg-%d", i)
 			_, err := r.Submit(registry.SubmitInput{ID: id, Kind: "http", Submitter: "cell"})
 			require.NoError(t, err)
-			_, err = r.Advance(id, registry.StateProbing(), "system", "")
+			_, err = advance(r, id, registry.StateProbing(), "system", "")
 			require.NoError(t, err)
 			_ = r.ByState(registry.StateProbing())
 		}(i)
@@ -282,4 +341,37 @@ func TestConcurrent_SubmitAdvance_Race(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, registry.StateProbing(), reg.State)
 	}
+}
+
+// TestConcurrent_SameID_Advance fires N concurrent Advance calls against the SAME
+// id (submitted→probing). The lock must serialize them: exactly one wins, the
+// rest see the already-advanced state and fail with ErrRegistrationInvalidTransition
+// (probing→probing is a self-loop). Run with -race to prove single-key locking.
+func TestConcurrent_SameID_Advance(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	mustSubmit(t, r, "shared")
+	const n = 16
+	var wg sync.WaitGroup
+	var success, rejected int64
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := advance(r, "shared", registry.StateProbing(), "system", "")
+			if err == nil {
+				atomic.AddInt64(&success, 1)
+			} else {
+				errcodetest.AssertCode(t, err, errcode.ErrRegistrationInvalidTransition)
+				atomic.AddInt64(&rejected, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(1), success, "exactly one concurrent advance must win")
+	assert.Equal(t, int64(n-1), rejected, "the rest must be rejected as invalid transitions")
+	events, ok := r.Events("shared")
+	require.True(t, ok)
+	assert.Len(t, events, 2, "submit + exactly one successful advance")
 }

--- a/framework/kernel/registry/registrar_test.go
+++ b/framework/kernel/registry/registrar_test.go
@@ -1,0 +1,285 @@
+package registry_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/framework/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/framework/kernel/registry"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/errcode/errcodetest"
+)
+
+var testEpoch = time.Date(2026, 6, 17, 0, 0, 0, 0, time.UTC)
+
+func newRegistrar(t *testing.T) (*registry.ContractRegistrar, *clockmock.FakeClock) {
+	t.Helper()
+	clk := clockmock.New(testEpoch)
+	return registry.NewContractRegistrar(clk), clk
+}
+
+func mustSubmit(t *testing.T, r *registry.ContractRegistrar, id string) registry.ContractRegistration {
+	t.Helper()
+	reg, err := r.Submit(registry.SubmitInput{ID: id, Kind: "http", PayloadSchema: "schema-ref", Submitter: "cell-a"})
+	require.NoError(t, err)
+	return reg
+}
+
+func TestSubmit_CreatesAtSubmitted(t *testing.T) {
+	t.Parallel()
+	r, clk := newRegistrar(t)
+	reg := mustSubmit(t, r, "reg-1")
+
+	assert.Equal(t, "reg-1", reg.ID)
+	assert.Equal(t, "http", reg.Kind)
+	assert.Equal(t, "cell-a", reg.Submitter)
+	assert.Equal(t, registry.StateSubmitted(), reg.State)
+	assert.Empty(t, reg.Approver)
+	assert.Equal(t, clk.Now(), reg.CreatedAt)
+	assert.Equal(t, clk.Now(), reg.UpdatedAt)
+
+	events, ok := r.Events("reg-1")
+	require.True(t, ok)
+	require.Len(t, events, 1)
+	assert.Equal(t, 1, events[0].Seq)
+	assert.True(t, events[0].From.IsZero(), "initial event From must be the zero sentinel")
+	assert.Equal(t, registry.StateSubmitted(), events[0].To)
+	assert.Equal(t, "cell-a", events[0].Actor)
+	assert.Equal(t, 1, r.Count())
+}
+
+func TestSubmit_DuplicateID(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	mustSubmit(t, r, "dup")
+	_, err := r.Submit(registry.SubmitInput{ID: "dup", Kind: "event", Submitter: "cell-b"})
+	errcodetest.AssertCode(t, err, errcode.ErrRegistrationDuplicate)
+	assert.Equal(t, 1, r.Count(), "duplicate submit must not create a second registration")
+}
+
+func TestSubmit_EmptyFields(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	cases := []registry.SubmitInput{
+		{ID: "", Kind: "http", Submitter: "cell-a"},
+		{ID: "x", Kind: "", Submitter: "cell-a"},
+		{ID: "x", Kind: "http", Submitter: ""},
+	}
+	for _, in := range cases {
+		_, err := r.Submit(in)
+		errcodetest.AssertCode(t, err, errcode.ErrValidationFailed)
+	}
+	assert.Equal(t, 0, r.Count())
+}
+
+func TestAdvance_FullLifecycle(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	mustSubmit(t, r, "reg-1")
+	path := []registry.RegistrationState{
+		registry.StateProbing(), registry.StateConformant(),
+		registry.StatePendingApproval(), registry.StateApproved(),
+		registry.StateActive(), registry.StateRetired(),
+	}
+	for _, to := range path {
+		reg, err := r.Advance("reg-1", to, "admin", "ok")
+		require.NoError(t, err, "advance to %q", to)
+		assert.Equal(t, to, reg.State)
+	}
+	events, ok := r.Events("reg-1")
+	require.True(t, ok)
+	assert.Len(t, events, len(path)+1) // +1 for the initial submit event
+}
+
+// TestAdvance_SubmittedToActivate_Rejected is acceptance scenario 1: a submitted
+// contract cannot be activated without approval; the call is rejected, state is
+// unchanged, and NO event is appended (fail-closed, no half-write).
+func TestAdvance_SubmittedToActivate_Rejected(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	mustSubmit(t, r, "reg-1")
+
+	_, err := r.Advance("reg-1", registry.StateActive(), "attacker", "bypass")
+	errcodetest.AssertCode(t, err, errcode.ErrRegistrationInvalidTransition)
+
+	reg, ok := r.Get("reg-1")
+	require.True(t, ok)
+	assert.Equal(t, registry.StateSubmitted(), reg.State, "state must be unchanged after rejected transition")
+
+	events, ok := r.Events("reg-1")
+	require.True(t, ok)
+	assert.Len(t, events, 1, "no event must be appended on a rejected transition (no half-write)")
+}
+
+func TestAdvance_NotFound(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	_, err := r.Advance("nope", registry.StateProbing(), "admin", "")
+	errcodetest.AssertCode(t, err, errcode.ErrRegistrationNotFound)
+}
+
+func TestAdvance_SetsApproverOnApprove(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	mustSubmit(t, r, "reg-1")
+	for _, to := range []registry.RegistrationState{registry.StateProbing(), registry.StateConformant(), registry.StatePendingApproval()} {
+		reg, err := r.Advance("reg-1", to, "system", "")
+		require.NoError(t, err)
+		assert.Empty(t, reg.Approver, "Approver must not be set before approval (state %q)", to)
+	}
+	reg, err := r.Advance("reg-1", registry.StateApproved(), "admin-42", "looks good")
+	require.NoError(t, err)
+	assert.Equal(t, "admin-42", reg.Approver)
+}
+
+func TestAdvance_StampsUpdatedAt(t *testing.T) {
+	t.Parallel()
+	r, clk := newRegistrar(t)
+	reg := mustSubmit(t, r, "reg-1")
+	created := reg.CreatedAt
+
+	clk.Advance(5 * time.Minute)
+	advanced, err := r.Advance("reg-1", registry.StateProbing(), "system", "")
+	require.NoError(t, err)
+	assert.Equal(t, created, advanced.CreatedAt, "CreatedAt must not change on advance")
+	assert.Equal(t, clk.Now(), advanced.UpdatedAt)
+	assert.True(t, advanced.UpdatedAt.After(created), "UpdatedAt must advance with the clock")
+}
+
+// TestReplayEvents_ProjectionConsistent is acceptance scenario 3: folding the
+// append-only event stream (from the zero sentinel) reproduces the live
+// projection state — an honest cross-check that the independently-maintained
+// projection equals the fold of the log.
+func TestReplayEvents_ProjectionConsistent(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	mustSubmit(t, r, "reg-1")
+	lifecycle := []registry.RegistrationState{
+		registry.StateProbing(), registry.StateConformant(),
+		registry.StatePendingApproval(), registry.StateRejected(),
+	}
+	for _, to := range lifecycle {
+		_, err := r.Advance("reg-1", to, "system", "")
+		require.NoError(t, err)
+	}
+
+	events, ok := r.Events("reg-1")
+	require.True(t, ok)
+	require.NotEmpty(t, events)
+
+	// Fold the event stream from the zero sentinel; each event's From must chain
+	// to the prior event's To, and the final To is the derived current state.
+	var derived registry.RegistrationState
+	for i, e := range events {
+		assert.Equal(t, i+1, e.Seq, "events must be 1-based and contiguous")
+		assert.Equal(t, derived, e.From, "event %d From must chain from prior To", i)
+		derived = e.To
+	}
+
+	live, ok := r.Get("reg-1")
+	require.True(t, ok)
+	assert.Equal(t, live.State, derived, "replayed state must equal the live projection")
+}
+
+func TestByState_Filters(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	mustSubmit(t, r, "a")
+	mustSubmit(t, r, "b")
+	mustSubmit(t, r, "c")
+	_, err := r.Advance("b", registry.StateProbing(), "system", "")
+	require.NoError(t, err)
+
+	submitted := r.ByState(registry.StateSubmitted())
+	probing := r.ByState(registry.StateProbing())
+	assert.Len(t, submitted, 2)
+	assert.Len(t, probing, 1)
+	assert.Equal(t, "b", probing[0].ID)
+	assert.Empty(t, r.ByState(registry.StateApproved()))
+}
+
+func TestGet_NoAliasMutation(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	mustSubmit(t, r, "reg-1")
+	got, ok := r.Get("reg-1")
+	require.True(t, ok)
+	got.Kind = "tampered"
+	got.Submitter = "tampered"
+
+	again, ok := r.Get("reg-1")
+	require.True(t, ok)
+	assert.Equal(t, "http", again.Kind, "mutating a returned copy must not affect the registrar")
+	assert.Equal(t, "cell-a", again.Submitter)
+}
+
+func TestEvents_DeepCopy(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	mustSubmit(t, r, "reg-1")
+	events, ok := r.Events("reg-1")
+	require.True(t, ok)
+	events[0].Actor = "tampered"
+
+	again, ok := r.Events("reg-1")
+	require.True(t, ok)
+	assert.Equal(t, "cell-a", again[0].Actor, "mutating returned events must not affect the registrar")
+
+	_, ok = r.Events("missing")
+	assert.False(t, ok)
+}
+
+func TestGet_NotFound(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	_, ok := r.Get("missing")
+	assert.False(t, ok)
+}
+
+func TestAllIDs_Sorted(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	for _, id := range []string{"c", "a", "b"} {
+		mustSubmit(t, r, id)
+	}
+	assert.Equal(t, []string{"a", "b", "c"}, r.AllIDs())
+}
+
+// TestConcurrent_SubmitAdvance_Race fires concurrent Submit+Advance and asserts
+// no data race (run with -race) and that each registration's event count matches
+// the transitions applied (projection consistent under the lock).
+func TestConcurrent_SubmitAdvance_Race(t *testing.T) {
+	t.Parallel()
+	r, _ := newRegistrar(t)
+	const n = 32
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			id := fmt.Sprintf("reg-%d", i)
+			_, err := r.Submit(registry.SubmitInput{ID: id, Kind: "http", Submitter: "cell"})
+			require.NoError(t, err)
+			_, err = r.Advance(id, registry.StateProbing(), "system", "")
+			require.NoError(t, err)
+			_ = r.ByState(registry.StateProbing())
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, n, r.Count())
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("reg-%d", i)
+		events, ok := r.Events(id)
+		require.True(t, ok)
+		assert.Len(t, events, 2, "submit + one advance")
+		reg, ok := r.Get(id)
+		require.True(t, ok)
+		assert.Equal(t, registry.StateProbing(), reg.State)
+	}
+}

--- a/framework/kernel/registry/registration.go
+++ b/framework/kernel/registry/registration.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
@@ -72,16 +73,28 @@ type SubmitInput struct {
 	Submitter     string
 }
 
-// validate rejects empty required fields with ErrValidationFailed. An empty ID
-// is especially hazardous (a "" map key is a silent collision), so it is barred.
+// normalized returns a copy with the required identity fields trimmed, so padded
+// values (" cell-a ") are stored canonically and a whitespace-only field is
+// caught by validate as missing. Optional free-form fields (PayloadSchema) are
+// left untouched. Submit normalizes before validating and storing.
+func (in SubmitInput) normalized() SubmitInput {
+	in.ID = strings.TrimSpace(in.ID)
+	in.Kind = strings.TrimSpace(in.Kind)
+	in.Submitter = strings.TrimSpace(in.Submitter)
+	return in
+}
+
+// validate rejects missing required fields with ErrValidationFailed, treating a
+// whitespace-only value as missing (TrimSpace) — a blank ID is a silent map-key
+// collision, and a blank Submitter is a phantom audit identity.
 func (in SubmitInput) validate() error {
 	missing := ""
 	switch {
-	case in.ID == "":
+	case strings.TrimSpace(in.ID) == "":
 		missing = "id"
-	case in.Kind == "":
+	case strings.TrimSpace(in.Kind) == "":
 		missing = "kind"
-	case in.Submitter == "":
+	case strings.TrimSpace(in.Submitter) == "":
 		missing = "submitter"
 	}
 	if missing == "" {
@@ -105,17 +118,28 @@ type AdvanceInput struct {
 	Reason string
 }
 
-// validate rejects empty required fields (ID, Actor) with ErrValidationFailed.
-// A non-empty Actor closes the audit-attribution gap: an approve / retire
-// transition must name who performed it, symmetric with SubmitInput requiring a
-// Submitter. To legality is validated by Transition (so an illegal/zero target
-// surfaces as ErrRegistrationInvalidTransition, not a missing-field error).
+// normalized returns a copy with the required identity fields (ID, Actor)
+// trimmed so a padded actor is stored canonically and a whitespace-only one is
+// caught by validate. The optional free-form Reason is left untouched. Advance
+// normalizes before validating and storing.
+func (in AdvanceInput) normalized() AdvanceInput {
+	in.ID = strings.TrimSpace(in.ID)
+	in.Actor = strings.TrimSpace(in.Actor)
+	return in
+}
+
+// validate rejects missing required fields (ID, Actor) with ErrValidationFailed,
+// treating a whitespace-only value as missing (TrimSpace). A non-blank Actor
+// closes the audit-attribution gap: an approve / retire transition must name who
+// performed it, symmetric with SubmitInput requiring a Submitter. To legality is
+// validated by Transition (an illegal/zero target surfaces as
+// ErrRegistrationInvalidTransition, not a missing-field error).
 func (in AdvanceInput) validate() error {
 	missing := ""
 	switch {
-	case in.ID == "":
+	case strings.TrimSpace(in.ID) == "":
 		missing = "id"
-	case in.Actor == "":
+	case strings.TrimSpace(in.Actor) == "":
 		missing = "actor"
 	}
 	if missing == "" {

--- a/framework/kernel/registry/registration.go
+++ b/framework/kernel/registry/registration.go
@@ -44,12 +44,15 @@ type ContractRegistration struct {
 // stream from the zero state reproduces the current State (the From of the first
 // event is the zero sentinel; each subsequent From chains from the prior To).
 type RegistrationEvent struct {
-	// RegistrationID is the owning registration's ID.
+	// RegistrationID is the owning registration's ID. It is injected by the
+	// registrar in appendLocked; callers reading via Events() always receive a
+	// non-empty value matching the queried id (no need to set it by hand).
 	RegistrationID string
 	// Seq is the 1-based, contiguous position within this registration's stream.
 	Seq int
-	// From is the prior state (the zero sentinel for the initial submit event);
-	// To is the resulting state.
+	// From is the prior state; To is the resulting state. On the initial submit
+	// event From is the zero sentinel (From.IsZero() == true), so folding the
+	// stream from a zero RegistrationState reproduces the lifecycle.
 	From RegistrationState
 	To   RegistrationState
 	// Actor is the identity driving the transition (submitter / admin / system);
@@ -86,5 +89,39 @@ func (in SubmitInput) validate() error {
 	}
 	return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 		"registry: submit input missing required field",
+		errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("field=%s", missing))))
+}
+
+// AdvanceInput is the data required to advance a registration to a new state.
+// It mirrors SubmitInput (a named-field struct, not positional args) so that the
+// two same-typed strings Actor and Reason cannot be silently swapped at a call
+// site. Actor is required (attribution: who drove the transition — submitter /
+// admin / system); Reason is optional free-form (e.g. a rejection reason). To's
+// legality is enforced by Transition against legalTransitions, not here.
+type AdvanceInput struct {
+	ID     string
+	To     RegistrationState
+	Actor  string
+	Reason string
+}
+
+// validate rejects empty required fields (ID, Actor) with ErrValidationFailed.
+// A non-empty Actor closes the audit-attribution gap: an approve / retire
+// transition must name who performed it, symmetric with SubmitInput requiring a
+// Submitter. To legality is validated by Transition (so an illegal/zero target
+// surfaces as ErrRegistrationInvalidTransition, not a missing-field error).
+func (in AdvanceInput) validate() error {
+	missing := ""
+	switch {
+	case in.ID == "":
+		missing = "id"
+	case in.Actor == "":
+		missing = "actor"
+	}
+	if missing == "" {
+		return nil
+	}
+	return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+		"registry: advance input missing required field",
 		errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("field=%s", missing))))
 }

--- a/framework/kernel/registry/registration.go
+++ b/framework/kernel/registry/registration.go
@@ -1,0 +1,90 @@
+package registry
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+)
+
+// ContractRegistration is the projected current state of a runtime-submitted
+// contract registration (303-US2, #2233), rebuilt from / kept consistent with
+// its append-only RegistrationEvent stream. It carries the registration's
+// identity (set at Submit, immutable) plus the mutable projection fields
+// (State / Approver / UpdatedAt) advanced by transitions.
+//
+// All fields are value types (string / sealed RegistrationState / time.Time), so
+// a struct copy is a full deep copy — read methods on ContractRegistrar return
+// copies, never pointers into the projection (unlike the read-only
+// ContractRegistry which hands out pointers to immutable, bootstrap-built data).
+type ContractRegistration struct {
+	// ID is the registration identifier (Submit dedup key).
+	ID string
+	// Kind is the contract kind (http / event / command / …), opaque here.
+	Kind string
+	// PayloadSchema is an opaque schema reference/hash recorded at Submit; the
+	// kernel state machine does not interpret it (US5 persists it).
+	PayloadSchema string
+	// Submitter is the identity that submitted the registration (set at Submit).
+	Submitter string
+	// Approver is the admin identity that approved the registration, set when the
+	// pending-approval → approved transition occurs; empty otherwise.
+	Approver string
+	// State is the current sealed lifecycle state.
+	State RegistrationState
+	// CreatedAt is the submit timestamp; UpdatedAt is the last-transition
+	// timestamp. Both are clock-stamped inside the registrar lock.
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// RegistrationEvent is one append-only entry in a registration's migration
+// history. The stream is the source of truth for history; the ContractRegistration
+// projection is kept consistent with it under the registrar lock. Folding the
+// stream from the zero state reproduces the current State (the From of the first
+// event is the zero sentinel; each subsequent From chains from the prior To).
+type RegistrationEvent struct {
+	// RegistrationID is the owning registration's ID.
+	RegistrationID string
+	// Seq is the 1-based, contiguous position within this registration's stream.
+	Seq int
+	// From is the prior state (the zero sentinel for the initial submit event);
+	// To is the resulting state.
+	From RegistrationState
+	To   RegistrationState
+	// Actor is the identity driving the transition (submitter / admin / system);
+	// Reason is an optional free-form note (e.g. a rejection reason).
+	Actor  string
+	Reason string
+	// OccurredAt is the clock-stamped transition time.
+	OccurredAt time.Time
+}
+
+// SubmitInput is the data required to create a new registration. PayloadSchema
+// is optional; ID, Kind, and Submitter are required.
+type SubmitInput struct {
+	ID            string
+	Kind          string
+	PayloadSchema string
+	Submitter     string
+}
+
+// validate rejects empty required fields with ErrValidationFailed. An empty ID
+// is especially hazardous (a "" map key is a silent collision), so it is barred.
+func (in SubmitInput) validate() error {
+	missing := ""
+	switch {
+	case in.ID == "":
+		missing = "id"
+	case in.Kind == "":
+		missing = "kind"
+	case in.Submitter == "":
+		missing = "submitter"
+	}
+	if missing == "" {
+		return nil
+	}
+	return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+		"registry: submit input missing required field",
+		errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("field=%s", missing))))
+}

--- a/framework/kernel/registry/state.go
+++ b/framework/kernel/registry/state.go
@@ -22,6 +22,8 @@ type RegistrationState struct {
 
 // RegistrationStateUnknown is the fail-closed render of a zero-value (forged)
 // RegistrationState. It is NOT a producible state (not in allRegistrationStates).
+// It is a plain string (the String() output), not a RegistrationState value — to
+// test for a forged/uninitialised state use IsZero(), not a string comparison.
 const RegistrationStateUnknown = "unknown"
 
 // String returns the wire/label value. The zero value renders as

--- a/framework/kernel/registry/state.go
+++ b/framework/kernel/registry/state.go
@@ -1,0 +1,107 @@
+package registry
+
+// RegistrationState is the sealed lifecycle state of a runtime-submitted
+// contract registration (303-US2, #2233). A non-zero RegistrationState cannot
+// be constructed outside this package — the single field is unexported and the
+// only values are the package-private singletons exposed via the accessor
+// functions below (reassigning a function is a compile error). This makes
+// "an external package cannot forge a state or jump the state machine"
+// expressible at compile time (AI-robust Hard), mirroring
+// runtime/transport.TransportMode, kernel/metadata.ContractOwner, and
+// pkg/authz.Permission.
+//
+// The zero value is invalid: String() renders it as [RegistrationStateUnknown]
+// (fail-closed), never the empty string, and it is not a member of
+// allRegistrationStates, so the transition table never accepts it as a source
+// or target.
+type RegistrationState struct {
+	// v is the wire/label value ("submitted" | "probing" | …). Unexported: a
+	// non-zero RegistrationState cannot be constructed outside this package.
+	v string
+}
+
+// RegistrationStateUnknown is the fail-closed render of a zero-value (forged)
+// RegistrationState. It is NOT a producible state (not in allRegistrationStates).
+const RegistrationStateUnknown = "unknown"
+
+// String returns the wire/label value. The zero value renders as
+// [RegistrationStateUnknown] (fail-closed), never the empty string.
+func (s RegistrationState) String() string {
+	if s.v == "" {
+		return RegistrationStateUnknown
+	}
+	return s.v
+}
+
+// IsZero reports whether s is the zero (forged/uninitialised) value.
+func (s RegistrationState) IsZero() bool { return s.v == "" }
+
+// Package-private singletons — the sole RegistrationState values. Exposed via
+// accessor functions (not exported vars) so the registered values are
+// immutable: reassigning a function is a compile error.
+var (
+	stateSubmitted       = RegistrationState{v: "submitted"}
+	stateProbing         = RegistrationState{v: "probing"}
+	stateConformant      = RegistrationState{v: "conformant"}
+	statePendingApproval = RegistrationState{v: "pending-approval"}
+	stateApproved        = RegistrationState{v: "approved"}
+	stateRejected        = RegistrationState{v: "rejected"}
+	stateActive          = RegistrationState{v: "active"}
+	stateRetired         = RegistrationState{v: "retired"}
+)
+
+// StateSubmitted: a contract registration was accepted by the gate and recorded.
+func StateSubmitted() RegistrationState { return stateSubmitted }
+
+// StateProbing: automated conformance probing is in progress.
+func StateProbing() RegistrationState { return stateProbing }
+
+// StateConformant: conformance probing passed; awaiting admin review.
+func StateConformant() RegistrationState { return stateConformant }
+
+// StatePendingApproval: queued for an admin approve/reject decision.
+func StatePendingApproval() RegistrationState { return statePendingApproval }
+
+// StateApproved: an admin approved the registration; it may be activated.
+func StateApproved() RegistrationState { return stateApproved }
+
+// StateRejected: conformance failed or an admin rejected it (terminal — never
+// activatable).
+func StateRejected() RegistrationState { return stateRejected }
+
+// StateActive: the contract is live on the data plane (reachable only from
+// approved).
+func StateActive() RegistrationState { return stateActive }
+
+// StateRetired: an admin retired a previously active contract (terminal).
+func StateRetired() RegistrationState { return stateRetired }
+
+// allRegistrationStates is the closed registry of every RegistrationState value.
+// It backs the anti-vacuity freeze (TestRegistrationState_FrozenRegistry): a new
+// state added without registering it here — or a renamed wire value — is caught.
+var allRegistrationStates = []RegistrationState{
+	stateSubmitted, stateProbing, stateConformant, statePendingApproval,
+	stateApproved, stateRejected, stateActive, stateRetired,
+}
+
+// isRegistered reports whether s is one of the producible states. A zero value
+// (forged) is NOT registered, so the transition table fail-closes on it.
+func (s RegistrationState) isRegistered() bool {
+	for _, x := range allRegistrationStates {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+// IsTerminal reports whether s is a terminal (final) state with no outgoing
+// transitions: rejected (conformance failed / admin rejected) or retired.
+func (s RegistrationState) IsTerminal() bool {
+	switch s {
+	case stateRejected, stateRetired:
+		return true
+	default:
+		return false
+	}
+}

--- a/framework/kernel/registry/state_test.go
+++ b/framework/kernel/registry/state_test.go
@@ -1,0 +1,101 @@
+package registry
+
+import "testing"
+
+// TestRegistrationState_FrozenRegistry pins the closed RegistrationState value
+// set to exactly the 8 documented states and proves the registry is non-vacuous
+// (anti-vacuity for the sealed-type value closure). Adding a new state without
+// registering it in allRegistrationStates — or renaming a wire value — trips
+// this test. Mirrors transport.TestTransportMode_FrozenRegistry.
+func TestRegistrationState_FrozenRegistry(t *testing.T) {
+	t.Parallel()
+
+	got := make(map[string]int, len(allRegistrationStates))
+	for _, s := range allRegistrationStates {
+		got[s.String()]++
+	}
+
+	want := map[string]int{
+		"submitted":        1,
+		"probing":          1,
+		"conformant":       1,
+		"pending-approval": 1,
+		"approved":         1,
+		"rejected":         1,
+		"active":           1,
+		"retired":          1,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("registration state value set = %v, want %v", got, want)
+	}
+	for v, n := range want {
+		if got[v] != n {
+			t.Errorf("registration state %q count = %d, want %d (registry: %v)", v, got[v], n, got)
+		}
+	}
+}
+
+// TestRegistrationState_Accessors verifies each package-private singleton renders
+// the expected wire string via its exported accessor (the sole way an external
+// package can name a state — reassigning a func is a compile error).
+func TestRegistrationState_Accessors(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		got  RegistrationState
+		want string
+	}{
+		{StateSubmitted(), "submitted"},
+		{StateProbing(), "probing"},
+		{StateConformant(), "conformant"},
+		{StatePendingApproval(), "pending-approval"},
+		{StateApproved(), "approved"},
+		{StateRejected(), "rejected"},
+		{StateActive(), "active"},
+		{StateRetired(), "retired"},
+	}
+	for _, tc := range cases {
+		if got := tc.got.String(); got != tc.want {
+			t.Errorf("String() = %q, want %q", got, tc.want)
+		}
+		if tc.got.IsZero() {
+			t.Errorf("%q reported IsZero", tc.want)
+		}
+		if !tc.got.isRegistered() {
+			t.Errorf("%q not registered", tc.want)
+		}
+	}
+}
+
+// TestRegistrationState_ZeroValueFailClosed verifies a forged zero value renders
+// fail-closed ("unknown"), reports IsZero, and is NOT registered.
+func TestRegistrationState_ZeroValueFailClosed(t *testing.T) {
+	t.Parallel()
+	var zero RegistrationState
+	if got := zero.String(); got != RegistrationStateUnknown {
+		t.Errorf("zero String() = %q, want %q", got, RegistrationStateUnknown)
+	}
+	if !zero.IsZero() {
+		t.Error("zero value should report IsZero")
+	}
+	if zero.isRegistered() {
+		t.Error("zero value must not be registered")
+	}
+	if zero.IsTerminal() {
+		t.Error("zero value must not be terminal")
+	}
+}
+
+// TestRegistrationState_IsTerminal verifies only rejected and retired are
+// terminal (no outgoing transitions).
+func TestRegistrationState_IsTerminal(t *testing.T) {
+	t.Parallel()
+	terminal := map[RegistrationState]bool{
+		StateRejected(): true,
+		StateRetired():  true,
+	}
+	for _, s := range allRegistrationStates {
+		if got, want := s.IsTerminal(), terminal[s]; got != want {
+			t.Errorf("%q IsTerminal() = %v, want %v", s, got, want)
+		}
+	}
+}

--- a/framework/kernel/registry/transition.go
+++ b/framework/kernel/registry/transition.go
@@ -1,0 +1,60 @@
+package registry
+
+import (
+	"fmt"
+
+	"github.com/ghbvf/gocell/framework/kernel/fsm"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+)
+
+// legalTransitions is the single source of truth for RegistrationState
+// legality. It maps each non-terminal state to its valid target states; the
+// frozen edge set encodes the state-machine invariants.
+//
+// Main path: submitted → probing → conformant → pending-approval → approved →
+// active → retired.
+//
+// Design notes (invariants):
+//   - probing → {conformant, rejected}: automated conformance either passes
+//     (conformant) or fails into the terminal rejected branch.
+//   - pending-approval → {approved, rejected}: an admin either approves or
+//     rejects; rejection is terminal.
+//   - approved → active: this is the ONLY edge into active. "Only approved can
+//     activate" is the approval-bypass invariant (FR-003 / SC-002): a submitted /
+//     probing / conformant / pending-approval contract cannot be activated.
+//   - active → retired: an admin retires a live contract (terminal).
+//   - rejected / retired are terminal: absent from the table (lookup miss → no
+//     outgoing edge), mirroring kernel/saga statusTransitions. There is no
+//     rejected → active edge — a rejected contract is never activatable.
+//   - No self-loops: a state cannot transition to itself (idempotent re-advance
+//     is rejected, consistent with saga).
+var legalTransitions = map[RegistrationState][]RegistrationState{
+	stateSubmitted:       {stateProbing},
+	stateProbing:         {stateConformant, stateRejected},
+	stateConformant:      {statePendingApproval},
+	statePendingApproval: {stateApproved, stateRejected},
+	stateApproved:        {stateActive},
+	stateActive:          {stateRetired},
+	// stateRejected / stateRetired: terminal, no outgoing transitions.
+}
+
+// CanTransition reports whether a transition from → to is permitted by the
+// frozen legalTransitions table. A forged zero state (source or target) is never
+// a registered key/target, so it is denied.
+func CanTransition(from, to RegistrationState) bool {
+	return fsm.CanTransition(legalTransitions, from, to)
+}
+
+// Transition validates a state transition from → to. It is a pure validation
+// function (no mutation) and returns ErrRegistrationInvalidTransition when the
+// transition is not permitted by legalTransitions — including any transition out
+// of a terminal state, any self-loop, and any source/target that is the forged
+// zero value.
+func Transition(from, to RegistrationState) error {
+	if CanTransition(from, to) {
+		return nil
+	}
+	return errcode.New(errcode.KindInvalid, errcode.ErrRegistrationInvalidTransition,
+		"registry: invalid registration state transition",
+		errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("from=%s to=%s", from, to))))
+}

--- a/framework/kernel/registry/transition_test.go
+++ b/framework/kernel/registry/transition_test.go
@@ -1,0 +1,125 @@
+package registry
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/errcode/errcodetest"
+)
+
+// TestLegalTransitions_Frozen pins the full edge set as a golden literal. A
+// silently added / removed / re-targeted edge fails this test (anti-vacuity for
+// the transition-table single source of truth). rejected/retired are terminal
+// (absent from the table), mirroring saga statusTransitions.
+func TestLegalTransitions_Frozen(t *testing.T) {
+	t.Parallel()
+	want := map[RegistrationState][]RegistrationState{
+		StateSubmitted():       {StateProbing()},
+		StateProbing():         {StateConformant(), StateRejected()},
+		StateConformant():      {StatePendingApproval()},
+		StatePendingApproval(): {StateApproved(), StateRejected()},
+		StateApproved():        {StateActive()},
+		StateActive():          {StateRetired()},
+		// StateRejected / StateRetired: terminal, no outgoing edges (absent).
+	}
+	if !reflect.DeepEqual(legalTransitions, want) {
+		t.Fatalf("legalTransitions = %v, want %v", legalTransitions, want)
+	}
+	// Anti-vacuity: every key + target must be a registered (non-zero) state.
+	for from, targets := range legalTransitions {
+		if !from.isRegistered() {
+			t.Errorf("transition key %q is not a registered state", from)
+		}
+		for _, to := range targets {
+			if !to.isRegistered() {
+				t.Errorf("transition %q→%q targets an unregistered state", from, to)
+			}
+		}
+	}
+}
+
+// TestTransition_HappyPath verifies the full main path is legal end to end.
+func TestTransition_HappyPath(t *testing.T) {
+	t.Parallel()
+	path := []RegistrationState{
+		StateSubmitted(), StateProbing(), StateConformant(),
+		StatePendingApproval(), StateApproved(), StateActive(), StateRetired(),
+	}
+	for i := 0; i+1 < len(path); i++ {
+		if err := Transition(path[i], path[i+1]); err != nil {
+			t.Errorf("main-path %q→%q rejected: %v", path[i], path[i+1], err)
+		}
+		if !CanTransition(path[i], path[i+1]) {
+			t.Errorf("CanTransition(%q,%q) = false, want true", path[i], path[i+1])
+		}
+	}
+}
+
+// TestTransition_TerminalBranches verifies the two →rejected branches are legal.
+func TestTransition_TerminalBranches(t *testing.T) {
+	t.Parallel()
+	for _, from := range []RegistrationState{StateProbing(), StatePendingApproval()} {
+		if err := Transition(from, StateRejected()); err != nil {
+			t.Errorf("terminal branch %q→rejected rejected: %v", from, err)
+		}
+	}
+}
+
+// TestTransition_ActiveOnlyFromApproved is the headline approval-bypass
+// invariant: active is reachable ONLY from approved. Every other source →active
+// must be rejected with ErrRegistrationInvalidTransition.
+func TestTransition_ActiveOnlyFromApproved(t *testing.T) {
+	t.Parallel()
+	for _, from := range allRegistrationStates {
+		err := Transition(from, StateActive())
+		if from == StateApproved() {
+			if err != nil {
+				t.Errorf("approved→active must be legal, got %v", err)
+			}
+			continue
+		}
+		if err == nil {
+			t.Errorf("%q→active must be rejected (approval-bypass invariant)", from)
+			continue
+		}
+		errcodetest.AssertCode(t, err, errcode.ErrRegistrationInvalidTransition)
+	}
+}
+
+// TestTransition_TerminalsHaveNoOutgoing verifies rejected/retired permit no
+// transition to any state.
+func TestTransition_TerminalsHaveNoOutgoing(t *testing.T) {
+	t.Parallel()
+	for _, from := range []RegistrationState{StateRejected(), StateRetired()} {
+		for _, to := range allRegistrationStates {
+			if err := Transition(from, to); err == nil {
+				t.Errorf("terminal %q→%q must be rejected", from, to)
+			}
+		}
+	}
+}
+
+// TestTransition_NoSelfLoops verifies no state may transition to itself
+// (idempotent re-advance is rejected — intentional, mirrors saga).
+func TestTransition_NoSelfLoops(t *testing.T) {
+	t.Parallel()
+	for _, s := range allRegistrationStates {
+		if err := Transition(s, s); err == nil {
+			t.Errorf("self-loop %q→%q must be rejected", s, s)
+		}
+	}
+}
+
+// TestTransition_ZeroTargetRejected verifies a forged zero target/source is
+// rejected (zero is never a registered state, so the table lookup misses).
+func TestTransition_ZeroTargetRejected(t *testing.T) {
+	t.Parallel()
+	var zero RegistrationState
+	if err := Transition(StateSubmitted(), zero); err == nil {
+		t.Error("transition to zero target must be rejected")
+	}
+	if err := Transition(zero, StateSubmitted()); err == nil {
+		t.Error("transition from zero source must be rejected")
+	}
+}

--- a/framework/pkg/errcode/errcode.go
+++ b/framework/pkg/errcode/errcode.go
@@ -965,6 +965,31 @@ const (
 	// Constructed with KindConflict → HTTP 409 (control-plane signal; normally
 	// never surfaces at an HTTP boundary).
 	ErrReconcileLeaseHeld Code = "ERR_RECONCILE_LEASE_HELD"
+
+	// Runtime contract-registration state-machine codes (303-US2, #2233).
+	// kernel/registry.ContractRegistrar drives runtime-submitted contracts
+	// through a sealed RegistrationState machine; these dedicated codes let
+	// operator dashboards / downstream handlers (US6/US7/US13) route registration
+	// failure modes without string-matching messages — mirroring the saga journal
+	// sentinels which moved off generic ErrValidationFailed/ErrConflict for the
+	// same reason (#959).
+	//
+	// ErrRegistrationInvalidTransition signals an attempted state transition that
+	// the legalTransitions table forbids (e.g. activating a contract that was
+	// never approved — the approval-bypass invariant). Constructed with
+	// KindInvalid → HTTP 400 (mirrors saga.Transition).
+	ErrRegistrationInvalidTransition Code = "ERR_REGISTRATION_INVALID_TRANSITION"
+	// ErrRegistrationNotFound signals that the addressed registration id is not
+	// known to the registrar (Advance/Events on an unknown id). Distinct from
+	// ErrContractNotFound, which the read-only ContractRegistry uses for parsed
+	// compile-time contract metadata; conflating them would mis-route operator
+	// dashboards. Constructed with KindNotFound → HTTP 404.
+	ErrRegistrationNotFound Code = "ERR_REGISTRATION_NOT_FOUND"
+	// ErrRegistrationDuplicate signals that Submit was called for a registration
+	// id that already exists. Constructed with KindConflict → HTTP 409 (mirrors
+	// ErrSagaDuplicateInstance). The (kind,domain,version,owner) uniqueness
+	// quadruple is a separate concern owned by US15/FR-009.
+	ErrRegistrationDuplicate Code = "ERR_REGISTRATION_DUPLICATE"
 )
 
 // PublicError is the structured projection shared by HTTP responses, CLI text

--- a/framework/pkg/errcode/prefix_registry.go
+++ b/framework/pkg/errcode/prefix_registry.go
@@ -252,6 +252,7 @@ var gocellPlatformPrefixes = []string{
 	"ERR_READYZ_",
 	"ERR_RECONCILE_",
 	"ERR_REFRESH_",
+	"ERR_REGISTRATION_",
 	"ERR_SESSION_",
 	"ERR_VALIDATION_",
 

--- a/framework/pkg/errcode/registration_codes_test.go
+++ b/framework/pkg/errcode/registration_codes_test.go
@@ -1,0 +1,47 @@
+package errcode_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+)
+
+// TestRegistrationSentinels asserts the three dedicated runtime
+// contract-registration sentinels (303-US2, #2233) exist, carry the expected
+// wire codes, and map to the documented Kind/HTTP status. Mirrors
+// TestSagaSentinels: dedicated codes let operator routing distinguish
+// registration failure modes from generic validation/conflict signals.
+func TestRegistrationSentinels(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		code       errcode.Code
+		wantString string
+		wantKind   errcode.Kind
+		wantStatus int
+	}{
+		{errcode.ErrRegistrationInvalidTransition, "ERR_REGISTRATION_INVALID_TRANSITION", errcode.KindInvalid, http.StatusBadRequest},
+		{errcode.ErrRegistrationNotFound, "ERR_REGISTRATION_NOT_FOUND", errcode.KindNotFound, http.StatusNotFound},
+		{errcode.ErrRegistrationDuplicate, "ERR_REGISTRATION_DUPLICATE", errcode.KindConflict, http.StatusConflict},
+	}
+	for _, tc := range cases {
+		if got := string(tc.code); got != tc.wantString {
+			t.Errorf("code %v: got string %q, want %q", tc.code, got, tc.wantString)
+		}
+		err := errcode.New(tc.wantKind, tc.code, "registry: probe message")
+		var ec *errcode.Error
+		if !errors.As(err, &ec) {
+			t.Fatalf("code %v: errors.As(*errcode.Error) failed", tc.code)
+		}
+		if ec.Kind != tc.wantKind {
+			t.Errorf("code %v: Kind=%v, want %v", tc.code, ec.Kind, tc.wantKind)
+		}
+		if ec.Code != tc.code {
+			t.Errorf("code %v: ec.Code=%v, want %v", tc.code, ec.Code, tc.code)
+		}
+		if got := ec.Status(); got != tc.wantStatus {
+			t.Errorf("code %v: Status()=%d, want %d", tc.code, got, tc.wantStatus)
+		}
+	}
+}

--- a/framework/pkg/errcode/testdata/prefix_set.golden
+++ b/framework/pkg/errcode/testdata/prefix_set.golden
@@ -47,6 +47,7 @@ ERR_READYZ_	github.com/ghbvf/gocell
 ERR_RECONCILE_	github.com/ghbvf/gocell
 ERR_REFERENCE_BROKEN	github.com/ghbvf/gocell
 ERR_REFRESH_	github.com/ghbvf/gocell
+ERR_REGISTRATION_	github.com/ghbvf/gocell
 ERR_RELAY_	github.com/ghbvf/gocell
 ERR_SAGA_	github.com/ghbvf/gocell
 ERR_SCAFFOLD_	github.com/ghbvf/gocell

--- a/tools/archtest/kernel_internal_dag_test.go
+++ b/tools/archtest/kernel_internal_dag_test.go
@@ -121,7 +121,7 @@ var allowedKernelEdges = map[string][]string{
 	"persistence":    nil,
 	"projection":     {"cell", "cellvocab", "clock", "contractspec", "healthz", "observability", "outbox", "persistence", "wrapper"},
 	"reconcile":      {"clock", "observability"},
-	"registry":       {"metadata"},
+	"registry":       {"clock", "fsm", "metadata"},
 	"saga":           {"cellvocab", "clock", "fsm", "healthz", "outbox", "projection"},
 	"verify":         {"metadata"},
 	"webhook":        {"circuitbreaker", "clock", "crypto", "observability", "outbox"},


### PR DESCRIPTION
## Summary

把 `framework/kernel/registry` 从只读升级：新增 sibling `ContractRegistrar` 运行时契约注册状态机——sealed `RegistrationState` + 迁移表不变式 + append-only 迁移事件底模 + 投影 in-mem 索引；现有只读 `ContractRegistry` 零改动（零回归）。[303-US2]

## Why / 背景

Epic #303（运行时契约注册中心）的 US2 内核地基：外部 cell 经 API 提交契约 → admin 审批 → 上线，需要一个 sealed 状态机作为内核真源。状态迁移不变式「只有 approved 才能 active」是审批旁路防护的根（FR-003 / SC-002）。当前 `ContractRegistry` 完全只读（一次性 map + deepCopy，无 mutation API），无法承载这条生命周期。

**范围严格限定 US2**：纯 kernel 机制（状态值类型 + 迁移表 + 事件模型 + 投影）。不含 US3 governance gate / US5 PG store / US6 handlers / US7 admin 审批端点 / US8 审计事件 / US15 命名空间唯一性（均为 blocked-by 下游 story）。`actor`/`reason` 字段是 US7 forward-compat seam，本 PR 不接线 US7 行为。

设计要点：
- `RegistrationState struct{ v string }`（unexported field + accessor 函数）→ 包外不可构造/伪造状态、不可跳变（**编译期不可表达，AI-robust Hard**），对标 `transport.TransportMode`/`metadata.ContractOwner`。
- `legalTransitions` 迁移表 = 唯一合法性真源，delegate `kernel/fsm` 泛型；不变式由表强制（`active` 仅可由 `approved` 到达；`rejected`/`retired` 终态无出边）。纯校验器 `Transition` 与有状态 funnel `Advance` 分离（对标 saga `status.go`/`advance.go`）。
- append-only 事件 + 投影索引同一 `sync.Mutex` 下原子更新，**validate 先于 append**（非法迁移 fail-closed，无半写），对标 `saga/journal.MemJournal` 两真源模型。append-only 由封装保证（events map unexported，无导出 delete）= Hard。

## Refs

Closes #2233 · Epic #303 · `specs/070-runtime-contract-registry/{spec,tasks}.md` US2 · ADR `docs/architecture/202606162119-303-adr-runtime-contract-registry.md`

```
ref: kubernetes/apiextensions-apiserver CRD NamesAccepted→Established condition state machine
ref: confluentinc/schema-registry append-only verification record
precedent: framework/kernel/saga/{status.go,journal/memjournal.go} + framework/kernel/fsm
```

## Risk / 兼容性

低。**纯新增**：新 sibling 类型与新 errcode 码，无签名变更、无删字段、无 shim/双路径。现有只读 `ContractRegistry`（Get/ByKind/ByOwner/Provider/Consumers）byte-identical 不动 → 零回归（既有 `registry_test.go` 不改、全绿）。

唯一跨包改动：铸造 `ERR_REGISTRATION_INVALID_TRANSITION`(400) / `_NOT_FOUND`(404) / `_DUPLICATE`(409) + 注册 `ERR_REGISTRATION_` namespace 前缀所有权 + 重生成 `prefix_set.golden`（`ERRCODE-PREFIX-OWNERSHIP-01` 绿）。无 wire/migration 影响（无持久化、无 HTTP，均下游 story）。

## Test plan

- [x] `go build ./framework/...` 本地通过（含 `-tags=integration`）
- [x] `go test -race -cover ./framework/kernel/registry/...` 本地通过，**coverage 98.3%**（kernel 门 90%）
- [x] `go test ./framework/pkg/errcode/...` 本地通过（含 golden + sentinel test）
- [x] `golangci-lint run`（v2.11.4，pinned）changed packages **0 issues**
- [x] TDD 红→绿：先写测试（freeze + 负矩阵 + replay 一致性 + race），确认 FAIL，再实现转 PASS
