### PR TITLE
refactor(auditcore): 抽重复字面量为常量（#2288 SonarCloud smell follow-up）

### DIFF
--- a/adapters/postgres/audit_ledger_store.go
+++ b/adapters/postgres/audit_ledger_store.go
@@ -456,7 +456,7 @@ func (s *LedgerStore) GetBySeq(ctx context.Context, vis tenant.RowVisibility, se
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, errcode.New(
 			errcode.KindNotFound, errcode.ErrAuditLedgerNotFound,
-			"audit ledger: entry not found",
+			msgAuditEntryNotFound,
 			errcode.WithDetails(errcode.PublicInt("seqNo", seq)),
 		)
 	}
@@ -469,12 +469,17 @@ func (s *LedgerStore) GetBySeq(ctx context.Context, vis tenant.RowVisibility, se
 	if !vis.Allows(e.ActorID) {
 		return nil, errcode.New(
 			errcode.KindNotFound, errcode.ErrAuditLedgerNotFound,
-			"audit ledger: entry not found",
+			msgAuditEntryNotFound,
 			errcode.WithDetails(errcode.PublicInt("seqNo", seq)),
 		)
 	}
 	return &e, nil
 }
+
+// msgAuditEntryNotFound is the const-literal not-found message
+// (MESSAGE-CONST-LITERAL-01) shared by every LedgerStore not-found path (GetBySeq +
+// the id-keyed auditEntryNotFoundByID).
+const msgAuditEntryNotFound = "audit ledger: entry not found"
 
 // auditEntryNotFoundByID is the IDOR-safe not-found sentinel for the id-keyed
 // single-entry reads (GetByID / GetByIDCrossTenant). It carries NO public detail:
@@ -484,7 +489,7 @@ func (s *LedgerStore) GetBySeq(ctx context.Context, vis tenant.RowVisibility, se
 // and "outside owner scope".
 func auditEntryNotFoundByID() error {
 	return errcode.New(errcode.KindNotFound, errcode.ErrAuditLedgerNotFound,
-		"audit ledger: entry not found")
+		msgAuditEntryNotFound)
 }
 
 // GetByID fetches a single entry by its opaque uuid id within tenant t for

--- a/corecells/auditcore/slices/auditquery/handler.go
+++ b/corecells/auditcore/slices/auditquery/handler.go
@@ -22,6 +22,11 @@ import (
 	auditlist "github.com/ghbvf/gocell/generated/contracts/http/audit/list/v1"
 )
 
+// msgAuthRequired is the const-literal message (MESSAGE-CONST-LITERAL-01) the audit
+// read paths return when the request carries no authenticated principal — shared by
+// the list route policy, the ListAdapter, and the GetAdapter.
+const msgAuthRequired = "authentication required"
+
 // auditQueryPolicy permits the request when:
 //   - actorId query param EQUALS the authenticated subject (explicit self-read).
 //     This is a request-shape check: it answers "is the caller asking only for its
@@ -62,7 +67,7 @@ func auditQueryPolicy(r *http.Request) error {
 	ctx := r.Context()
 	p, ok := auth.FromContext(ctx)
 	if !ok || p.Subject == "" {
-		return errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "authentication required")
+		return errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, msgAuthRequired)
 	}
 	// Only an explicit self-read (actorId names the caller) is exempt. Empty
 	// actorId is a permissioned ledger read, not an implicit self-read (F1).
@@ -160,7 +165,7 @@ type ListAdapter struct {
 func (a ListAdapter) List(ctx context.Context, req *auditlist.Request) (auditlist.ListResponseObject, error) {
 	p, ok := auth.FromContext(ctx)
 	if !ok || p.Subject == "" {
-		return nil, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "authentication required")
+		return nil, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, msgAuthRequired)
 	}
 	// Tenant isolation fail-closed (epic #1337 PR-2a, F1): a tenant-scoped audit
 	// read REQUIRES a concrete tenant. An authenticated principal with an empty
@@ -581,7 +586,7 @@ func mapGetError(err error) auditget.GetResponseObject {
 func (a GetAdapter) get(ctx context.Context, req *auditget.Request) (auditget.GetResponseObject, error) {
 	p, ok := auth.FromContext(ctx)
 	if !ok || p.Subject == "" {
-		return nil, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, "authentication required")
+		return nil, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, msgAuthRequired)
 	}
 	// Tenant isolation fail-closed (epic #1337 PR-2a, F1), mirrors ListAdapter: a
 	// tenant-scoped audit read REQUIRES a concrete tenant.

--- a/corecells/auditcore/slices/auditquery/handler_test.go
+++ b/corecells/auditcore/slices/auditquery/handler_test.go
@@ -19,12 +19,14 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/outbox"
 	"github.com/ghbvf/gocell/framework/pkg/authz"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/errcode/errcodetest"
 	"github.com/ghbvf/gocell/framework/pkg/query"
 	"github.com/ghbvf/gocell/framework/pkg/tenant"
 	"github.com/ghbvf/gocell/framework/pkg/testutil/slogcapture"
 	"github.com/ghbvf/gocell/framework/runtime/audit/ledger"
 	"github.com/ghbvf/gocell/framework/runtime/auth"
 	auditget "github.com/ghbvf/gocell/generated/contracts/http/audit/get/v1"
+	auditlist "github.com/ghbvf/gocell/generated/contracts/http/audit/list/v1"
 )
 
 const bootstrapAuditEntryOffset = 2 * time.Hour
@@ -2463,4 +2465,14 @@ func TestGetAdapter_Get_Unauthenticated_Typed401(t *testing.T) {
 	require.NoError(t, err, "declared 401 must be a typed response, not a Go error")
 	_, ok := resp.(auditget.Get401ErrorResponse)
 	assert.True(t, ok, "unauthenticated GET must map to Get401ErrorResponse, got %T", resp)
+}
+
+func TestListAdapter_List_Unauthenticated_ReturnsErrcode(t *testing.T) {
+	svc, _ := newTestService()
+	a := ListAdapter{S: svc}
+
+	resp, err := a.List(context.Background(), &auditlist.Request{})
+
+	require.Nil(t, resp)
+	errcodetest.AssertCode(t, err, errcode.ErrAuthUnauthorized)
 }

--- a/framework/runtime/audit/ledger/mem_store.go
+++ b/framework/runtime/audit/ledger/mem_store.go
@@ -230,7 +230,7 @@ func (m *MemStore) GetBySeq(ctx context.Context, vis tenant.RowVisibility, seq i
 	if chain == nil || seq < 1 || int(seq) > len(chain.entries) {
 		return nil, errcode.New(
 			errcode.KindNotFound, errcode.ErrAuditLedgerNotFound,
-			"audit ledger: entry not found",
+			msgAuditEntryNotFound,
 			errcode.WithDetails(errcode.PublicInt("seqNo", seq)),
 		)
 	}
@@ -239,12 +239,17 @@ func (m *MemStore) GetBySeq(ctx context.Context, vis tenant.RowVisibility, seq i
 		// IDOR-safe collapse: do not reveal that the entry exists.
 		return nil, errcode.New(
 			errcode.KindNotFound, errcode.ErrAuditLedgerNotFound,
-			"audit ledger: entry not found",
+			msgAuditEntryNotFound,
 			errcode.WithDetails(errcode.PublicInt("seqNo", seq)),
 		)
 	}
 	return copyEntry(e), nil
 }
+
+// msgAuditEntryNotFound is the const-literal not-found message
+// (MESSAGE-CONST-LITERAL-01) shared by every MemStore not-found path (GetBySeq +
+// the id-keyed auditEntryNotFoundByID).
+const msgAuditEntryNotFound = "audit ledger: entry not found"
 
 // auditEntryNotFoundByID is the IDOR-safe not-found sentinel for the single-entry
 // reads that key on an opaque id (MemStore.GetByID / MemCrossTenantStore.
@@ -254,7 +259,7 @@ func (m *MemStore) GetBySeq(ctx context.Context, vis tenant.RowVisibility, seq i
 // is returned for "absent", "another tenant's row", and "outside owner scope".
 func auditEntryNotFoundByID() error {
 	return errcode.New(errcode.KindNotFound, errcode.ErrAuditLedgerNotFound,
-		"audit ledger: entry not found")
+		msgAuditEntryNotFound)
 }
 
 // GetByID returns a defensive copy of the entry with the given opaque id within

--- a/framework/runtime/audit/ledger/mem_store_test.go
+++ b/framework/runtime/audit/ledger/mem_store_test.go
@@ -322,6 +322,36 @@ func TestMemStore_GetBySeq_NotFound(t *testing.T) {
 	errcodetest.AssertCode(t, err, errcode.ErrAuditLedgerNotFound)
 }
 
+func TestMemStore_GetBySeq_VisibilityDeniedCollapsesToNotFound(t *testing.T) {
+	t.Parallel()
+	fc := clockmock.New(time.Now())
+	p := newTestProtocol(t)
+	store, err := ledger.NewMemStore(p, fc)
+	if err != nil {
+		t.Fatalf("NewMemStore: %v", err)
+	}
+	if err := store.Append(context.Background(), &ledger.Entry{
+		EventID:   "seq-visibility-denied",
+		EventType: "audit.visibility.test",
+		ActorID:   "alice",
+		Timestamp: fc.Now(),
+		Payload:   []byte(`{}`),
+	}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	vis, err := tenant.NewRowVisibility(tenant.RowScopeSelf, "bob")
+	if err != nil {
+		t.Fatalf("NewRowVisibility: %v", err)
+	}
+
+	got, err := store.GetBySeq(context.Background(), vis, 1)
+
+	if got != nil {
+		t.Fatalf("GetBySeq visibility denied returned entry: %+v", got)
+	}
+	errcodetest.AssertCode(t, err, errcode.ErrAuditLedgerNotFound)
+}
+
 // TestMemStore_Idempotency_DuplicateContent: appending the same payload twice
 // returns ErrAlreadyExists on the second call (content fingerprint check).
 func TestMemStore_Idempotency_DuplicateContent(t *testing.T) {

--- a/framework/runtime/audit/ledger/storetest/suite.go
+++ b/framework/runtime/audit/ledger/storetest/suite.go
@@ -1669,7 +1669,7 @@ func runQueryVisibilityObligations(t *testing.T, factory Factory) {
 		// #1618 FORCE RLS; no silent degrade to tenant scope) — see
 		// RowScopeAllUnsupportedError. Code = ErrInternal (5xx wire-collapse);
 		// Kind = KindNotImplemented → HTTP 501 at the handler (review F5).
-		{"all-fail-closed", tenant.RowScopeAll, "", 0, "", errcode.ErrInternal},
+		{caseAllFailClosed, tenant.RowScopeAll, "", 0, "", errcode.ErrInternal},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) { tc.run(t, store, filters, params) })
@@ -1709,12 +1709,16 @@ func runGetBySeqVisibilityObligations(t *testing.T, factory Factory) {
 		// RowScopeAll is fail-closed on every backend (deferred to backlog under
 		// #1618 FORCE RLS; distinct from the IDOR-collapse NotFound: it is a
 		// deferred CAPABILITY, KindNotImplemented → HTTP 501, Code ErrInternal).
-		{"all-fail-closed", tenant.RowScopeAll, "", false, errcode.ErrInternal},
+		{caseAllFailClosed, tenant.RowScopeAll, "", false, errcode.ErrInternal},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) { tc.run(t, store) })
 	}
 }
+
+// caseAllFailClosed is the shared subtest name for the RowScopeAll fail-close case
+// across the Query / GetBySeq / GetByID visibility-obligation tables.
+const caseAllFailClosed = "all-fail-closed"
 
 // getByIDMissingID is a syntactically valid UUID the conformance never seeds, so
 // every backend's GetByID / GetByIDCrossTenant returns ErrAuditLedgerNotFound for
@@ -1798,7 +1802,7 @@ func runGetByIDVisibilityObligations(t *testing.T, factory Factory) {
 		{"tenant-wide-found", tenant.RowScopeTenant, "", true, ""},
 		// RowScopeAll is fail-closed on every serving backend (Code ErrInternal,
 		// Kind KindNotImplemented → HTTP 501); distinct from the IDOR-collapse 404.
-		{"all-fail-closed", tenant.RowScopeAll, "", false, errcode.ErrInternal},
+		{caseAllFailClosed, tenant.RowScopeAll, "", false, errcode.ErrInternal},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) { tc.run(t, store, id) })


### PR DESCRIPTION
## Summary

抽 4 处重复字面量为常量，消除 SonarCloud 在 PR #2288 标出的 4 个 CRITICAL code smell（「重复字面量 ≥3 次抽常量」）。

## Why / 背景

#2288（`http.audit.get.v1` 审计详情端点）合并时，SonarCloud quality gate 已 pass（新代码覆盖率 89.5%），但标了 4 个 CRITICAL code smell——均为 #2288 新代码把各处同义字符串推到第 3 次出现触发。这些 advisory smell 未阻塞合并，故 #2288 已合入 develop 但 smell 残留。本 PR 是 #2288 的直接 follow-up，按 `.claude/rules/gocell/go-standards.md`「同义字符串重复三次及以上抽常量」清理。

## Refs

Refs #2288（follow-up；smell 来源端点 PR）

## Risk / 兼容性

无。纯重构——抽常量，行为/wire 不变。常量引用满足 `MESSAGE-CONST-LITERAL-01`（const literal 仍是合法 errcode 消息）。

## 改动

| 文件 | 字面量（×3）| 常量 |
|------|----------|------|
| `handler.go` | `"authentication required"`（auditQueryPolicy/ListAdapter/GetAdapter）| `msgAuthRequired` |
| `mem_store.go` | `"audit ledger: entry not found"`（GetBySeq×2 + auditEntryNotFoundByID）| `msgAuditEntryNotFound` |
| `audit_ledger_store.go`(PG) | 同上 | `msgAuditEntryNotFound` |
| `storetest/suite.go` | `"all-fail-closed"`（visQueryCase/visGetCase/visGetByIDCase）| `caseAllFailClosed` |

## Test plan

- [x] `go build ./...` 通过（framework/adapters/corecells）
- [x] `go test ./...` 通过（framework ledger + storetest + corecells auditquery）
- [x] `golangci-lint run` 0 issues（所有改动包）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
