### PR TITLE
feat(governance): #2234 注册时 governance gate — 复用 Validator + :check/submit 双入口 fail-closed [303-US3]

### DIFF
--- a/framework/kernel/governance/gate.go
+++ b/framework/kernel/governance/gate.go
@@ -1,9 +1,13 @@
+// gate.go implements RegistrationGate — the runtime governance gate for contract
+// registration (303-US3, #2234). The AdmissionResponse-style result types
+// (GovernanceGateResult + the sealed GateReason) live in gate_result.go.
 package governance
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/ghbvf/gocell/framework/kernel/clock"
@@ -116,6 +120,13 @@ func (g *RegistrationGate) Submit(
 	if !res.Allowed {
 		return registry.ContractRegistration{}, res, nil
 	}
+	if strings.TrimSpace(submitter) == "" {
+		// submitter is the required audit identity. Reject it at the gate rather
+		// than relying on the store's validate() side-effect, so the deny reason is
+		// the gate's own invalid-input — not an opaque store error a caller would
+		// have to introspect.
+		return registry.ContractRegistration{}, GovernanceGateResult{Allowed: false, Reason: reasonInvalidInput}, nil
+	}
 	reg, err := g.store.Submit(registry.SubmitInput{
 		ID:        candidate.ID,
 		Kind:      candidate.Kind,
@@ -137,7 +148,10 @@ func (g *RegistrationGate) evaluate(ctx context.Context, tnt tenant.TenantID, ca
 		return GovernanceGateResult{Allowed: false, Reason: reasonTenantInvalid}
 	}
 	if candidate == nil {
-		return GovernanceGateResult{Allowed: false, Reason: reasonValidationFailed}
+		// A nil candidate is a caller precondition violation — no rule can run on
+		// it — so it is invalid-input, NOT validation-failed (which means rules ran
+		// and a contract violated one). Keeps the two distinguishable for callers.
+		return GovernanceGateResult{Allowed: false, Reason: reasonInvalidInput}
 	}
 	findings, err := g.runRules(ctx, candidate)
 	if err != nil {
@@ -159,10 +173,19 @@ func (g *RegistrationGate) evaluate(ctx context.Context, tnt tenant.TenantID, ca
 func (g *RegistrationGate) runRules(ctx context.Context, candidate *metadata.ContractMeta) (findings []ValidationResult, err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			// A governance rule panicking is a defect, but the gate must stay
+			// fail-closed (deny, never crash/fail-open). Log it (server-side, the
+			// primary diagnostic channel — mirrors CH-04's slog usage in this
+			// package) so ReasonValidatorUnavailable is diagnosable, then deny.
+			slog.Error("governance: registration gate rule panicked; failing closed",
+				slog.Any("panic", r), slog.String("contract", candidate.ID))
 			findings = nil
 			err = errcode.Assertion("governance: registration gate validation panicked")
 		}
 	}()
+	// NewValidator is pure in-memory construction (no I/O, non-blocking), so the
+	// ctx.Err() check before the first rule fires is sufficient to honor a
+	// pre-canceled context.
 	v := NewValidator(singleContractProject(candidate), "", g.clk)
 	rules := []func() []ValidationResult{
 		v.checkCH01, v.checkCH02, v.checkCH03,
@@ -192,10 +215,15 @@ func singleContractProject(c *metadata.ContractMeta) *metadata.ProjectMeta {
 
 // denyForStoreError maps a registrar Submit error to a fail-closed verdict,
 // preserving the (passing) validation findings for context. A duplicate id is a
-// conflict (the contract was valid, just already registered); any other store
-// error is treated as a validation failure.
+// conflict (the contract was valid, just already registered → ReasonDuplicate).
+// Any OTHER store error reaches here only after the candidate already passed
+// validation and identity/submitter pre-checks, so it is an infrastructure
+// failure ("could not persist"), mapped to ReasonValidatorUnavailable (a
+// 503-class condition) rather than ReasonValidationFailed — a store-down deny
+// must not read as a rule violation. The live PG-backed store's unavailable path
+// lands in US5; the in-mem store reaches this only via the duplicate branch.
 func denyForStoreError(prior GovernanceGateResult, err error) GovernanceGateResult {
-	reason := reasonValidationFailed
+	reason := reasonValidatorUnavailable
 	var ec *errcode.Error
 	if errors.As(err, &ec) && ec.Code == errcode.ErrRegistrationDuplicate {
 		reason = reasonDuplicate
@@ -241,10 +269,15 @@ func (v *Validator) fanoutFindingsFor(c *metadata.ContractMeta) []ValidationResu
 			"set the contract kind (http/event/command/projection/webhook/grpc/saga)"))
 		return out // kind unknown → provider/consumer dispatch is undefined
 	}
-	if provider, err := v.contracts.Provider(c.ID); err != nil || strings.TrimSpace(provider) == "" {
-		out = append(out, v.newError(codeREG01, IssueRequired, c.File, fanoutProviderField(c.Kind),
-			fmt.Sprintf("runtime contract %q (kind %q) is missing its provider endpoint — fanout incomplete", c.ID, c.Kind),
-			"declare the provider endpoint so the registered contract has a producer"))
+	// Provider completeness. Webhook is exempt here: its "provider" IS ownerCell
+	// (ContractRegistry.Provider returns OwnerCell for webhook), already covered by
+	// CH-01 — re-checking would emit a redundant second finding for the same field.
+	if c.Kind != "webhook" {
+		if provider, err := v.contracts.Provider(c.ID); err != nil || strings.TrimSpace(provider) == "" {
+			out = append(out, v.newError(codeREG01, IssueRequired, c.File, fanoutProviderField(c.Kind),
+				fmt.Sprintf("runtime contract %q (kind %q) is missing its provider endpoint — fanout incomplete", c.ID, c.Kind),
+				"declare the provider endpoint so the registered contract has a producer"))
+		}
 	}
 	if fanoutRequiresConsumer(c.Kind) {
 		if consumers, err := v.contracts.Consumers(c.ID); err != nil || len(consumers) == 0 {
@@ -267,7 +300,7 @@ func (v *Validator) runtimeRegistrationAdvisories() []ValidationResult {
 	var out []ValidationResult
 	for _, c := range v.sortedContracts() {
 		if c.Lifecycle == "deprecated" {
-			out = append(out, v.newWarning(codeREG02, IssueForbidden, c.File, "lifecycle",
+			out = append(out, v.newWarning(codeREG02, IssueInvalid, c.File, "lifecycle",
 				fmt.Sprintf("runtime contract %q is being registered with lifecycle %q", c.ID, c.Lifecycle),
 				"register an active (non-deprecated) version of this contract, or confirm the deprecated registration is intentional"))
 		}
@@ -276,7 +309,11 @@ func (v *Validator) runtimeRegistrationAdvisories() []ValidationResult {
 }
 
 // fanoutProviderField names the YAML field carrying the provider for a kind, for
-// the REG-01 finding's Field anchor (mirrors ContractMeta.ProviderEndpoint).
+// the REG-01 finding's Field anchor. It mirrors the per-kind provider dispatch in
+// metadata.ContractMeta.ProviderEndpoint and tools/archtest
+// reverse_coverage_invariants.contractProviderFieldLabel — a new contract kind
+// must update all three in sync (the value-set is small and kind-stable; no shared
+// table is warranted).
 func fanoutProviderField(kind string) string {
 	switch kind {
 	case "event":

--- a/framework/kernel/governance/gate.go
+++ b/framework/kernel/governance/gate.go
@@ -1,0 +1,323 @@
+package governance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/metadata"
+	"github.com/ghbvf/gocell/framework/kernel/registry"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/panicregister"
+	"github.com/ghbvf/gocell/framework/pkg/tenant"
+)
+
+// RegistrationGate is the runtime governance gate for the contract registry
+// (303-US3, #2234). It wraps the existing kernel/governance Validator — today
+// only reachable via the `gocell validate` CLI — as a K8s AdmissionResponse-style
+// {allowed, result, warnings} decision, exposing two entry points that share one
+// validation path (mirroring Confluent Schema Registry's /compatibility (dry-run)
+// vs /versions (write) split):
+//
+//   - Check  : dry-run. Validates a candidate contract and returns the verdict
+//     WITHOUT persisting. Side-effect free (K8s SideEffects: NoneOnDryRun).
+//   - Submit : validate-before-persist. Runs the SAME validation; only when
+//     Allowed does it record the registration via the registrar's Submit entry.
+//     A contract that fails the gate never reaches the `submitted` state — there
+//     is no "submitted but invalid" intermediate state.
+//
+// # FailurePolicy=Fail (fail-closed)
+//
+// The gate never fails open. It denies (Allowed=false) when it cannot fully and
+// safely evaluate a request: an invalid tenant (FR-002 "缺租户 → deny"), a
+// validation run that is interrupted (ctx canceled) or panics
+// (ReasonValidatorUnavailable), or any governance error in the candidate
+// (ReasonValidationFailed). The store (registrar) is a required construction
+// dependency (nil → fail-fast in NewRegistrationGate); a live-backend
+// "unavailable" deny path lands with the PG-backed store in US5. Mirrors K8s
+// ValidatingWebhook FailurePolicy=Fail.
+//
+// # Validation scope — single candidate contract
+//
+// The gate validates ONE submitted contract in isolation: it builds a
+// single-contract ProjectMeta and runs the CURATED subset of governance rules
+// that validate a contract's DECLARATION (CH-01 ownerCell, CH-02 lifecycle,
+// CH-03 HTTP schemaRefs, REG-01 runtime fanout completeness). It deliberately
+// does NOT run the rules that validate in-tree IMPLEMENTATION artifacts — REF/
+// TOPO cross-references (a runtime contract has no sibling cells/slices in the
+// gate's project), CH-04/CH-05 handler-file scans (the handler is out-of-process),
+// CH-06/CH-07 codegen, VERIFY test-file closure. Those are structurally
+// inapplicable to an out-of-process runtime contract: that inapplicability is the
+// very "扇出 archtest vacuous for runtime contracts" the epic-303 ADR documents,
+// and REG-01 (runtimeFanoutCompleteness) is its equivalent runtime compensation.
+//
+// # AI-robust grading (FR-013 — honest, NOT disguised as Hard)
+//
+// The gate VERDICT ("does this runtime contract satisfy governance?") is a
+// runtime guard = MEDIUM. A runtime-submitted contract does not exist at compile
+// time, so its validity cannot be a compile fact — this is the dual-track ceiling
+// the epic-303 ADR mandates be graded Medium, not faked as Hard (threat T10).
+// GateReason / GovernanceGateResult value sets ARE Hard (sealed unexported field +
+// accessor funcs + frozen-registry test). The structural invariant "submitted is
+// only reachable through this gate" is locked at MEDIUM by the caller-funnel
+// archtest REGISTRAR-SUBMIT-CALLER-01 (only this package may call
+// registry.ContractRegistrar.Submit in production). A genuinely-Hard
+// sealed-construction token funnel is blocked by kernel layering — a token sealed
+// in registry cannot be minted by governance, and registry cannot import
+// governance (cycle) — so the caller-funnel is the documented Go ceiling, same
+// family as COMMAND-ASYNC-EMIT-CALLER-01.
+//
+// RegistrationGate is safe for concurrent Check/Submit: it builds a fresh
+// Validator per request (the Validator itself is not concurrency-safe) and the
+// registrar is internally locked.
+type RegistrationGate struct {
+	store *registry.ContractRegistrar
+	clk   clock.Clock
+}
+
+// NewRegistrationGate builds a gate over the given registrar. store and clk are
+// required strong dependencies and fail-fast when nil (a gate without a store
+// cannot persist, and the clock stamps validation; a nil dep is a wiring bug,
+// not a degraded mode). clk is a positional dependency per the clock.Clock
+// convention.
+func NewRegistrationGate(store *registry.ContractRegistrar, clk clock.Clock) *RegistrationGate {
+	clock.MustHaveClock(clk, "governance.NewRegistrationGate")
+	if store == nil {
+		panic(panicregister.Approved("registration-gate-nil-store",
+			errcode.Assertion("governance.NewRegistrationGate: store (*registry.ContractRegistrar) is required (nil rejected); "+
+				"pass a constructed registrar at the composition root")))
+	}
+	return &RegistrationGate{store: store, clk: clk}
+}
+
+// Check is the dry-run entry point (no persistence). It returns the gate verdict
+// for candidate under tenant tnt, leaving the registry untouched. A wire-compliant
+// contract with non-blocking advisories returns {Allowed:true, Warnings:[…]}.
+func (g *RegistrationGate) Check(ctx context.Context, tnt tenant.TenantID, candidate *metadata.ContractMeta) GovernanceGateResult {
+	return g.evaluate(ctx, tnt, candidate)
+}
+
+// Submit is the validate-before-persist entry point. It runs the SAME validation
+// as Check; only when the verdict is Allowed does it record the registration via
+// the registrar (entering the sealed state machine at `submitted`). A denied
+// candidate is never persisted (no "submitted but invalid" intermediate state),
+// and the returned result carries the machine-readable Reason.
+//
+// On a store-side error the gate stays fail-closed: a duplicate id maps to
+// ReasonDuplicate, any other store error to ReasonValidationFailed; the store
+// error is also returned so callers can inspect it. submitter is the audit
+// identity recorded against the registration.
+func (g *RegistrationGate) Submit(
+	ctx context.Context, tnt tenant.TenantID, candidate *metadata.ContractMeta, submitter string,
+) (registry.ContractRegistration, GovernanceGateResult, error) {
+	res := g.evaluate(ctx, tnt, candidate)
+	if !res.Allowed {
+		return registry.ContractRegistration{}, res, nil
+	}
+	reg, err := g.store.Submit(registry.SubmitInput{
+		ID:        candidate.ID,
+		Kind:      candidate.Kind,
+		Submitter: submitter,
+		// PayloadSchema is opaque to the state machine and optional at US3; the
+		// concrete schema artifact/hash is wired with the persisting store (US5).
+	})
+	if err != nil {
+		return registry.ContractRegistration{}, denyForStoreError(res, err), err
+	}
+	return reg, res, nil
+}
+
+// evaluate is the single validation path shared by Check and Submit. It is total
+// (never panics out) and fail-closed: any condition under which the gate cannot
+// safely conclude "allowed" yields Allowed=false with a machine-readable Reason.
+func (g *RegistrationGate) evaluate(ctx context.Context, tnt tenant.TenantID, candidate *metadata.ContractMeta) GovernanceGateResult {
+	if err := tnt.Validate(); err != nil {
+		return GovernanceGateResult{Allowed: false, Reason: reasonTenantInvalid}
+	}
+	if candidate == nil {
+		return GovernanceGateResult{Allowed: false, Reason: reasonValidationFailed}
+	}
+	findings, err := g.runRules(ctx, candidate)
+	if err != nil {
+		return GovernanceGateResult{Allowed: false, Reason: reasonValidatorUnavailable}
+	}
+	errs := FilterErrors(findings)
+	warns := FilterWarnings(findings)
+	if len(errs) > 0 {
+		return GovernanceGateResult{Allowed: false, Result: errs, Warnings: warns, Reason: reasonValidationFailed}
+	}
+	return GovernanceGateResult{Allowed: true, Warnings: warns, Reason: reasonAllowed}
+}
+
+// runRules builds a single-contract Validator and runs the curated intrinsic
+// declaration rule set (see RegistrationGate godoc §"Validation scope"). It
+// honors ctx cancellation between rules (→ validator-unavailable fail-closed) and
+// recovers any rule panic into a non-nil error so the gate denies rather than
+// crashes (FailurePolicy=Fail).
+func (g *RegistrationGate) runRules(ctx context.Context, candidate *metadata.ContractMeta) (findings []ValidationResult, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			findings = nil
+			err = errcode.Assertion("governance: registration gate validation panicked")
+		}
+	}()
+	v := NewValidator(singleContractProject(candidate), "", g.clk)
+	rules := []func() []ValidationResult{
+		v.checkCH01, v.checkCH02, v.checkCH03,
+		v.runtimeFanoutCompleteness, v.runtimeRegistrationAdvisories,
+	}
+	for _, run := range rules {
+		if cerr := ctx.Err(); cerr != nil {
+			return nil, cerr
+		}
+		findings = append(findings, run()...)
+	}
+	return findings, nil
+}
+
+// singleContractProject wraps one candidate contract in an otherwise-empty
+// ProjectMeta. Empty sibling maps make every cross-reference rule (REF/TOPO/
+// VERIFY/DEP) naturally vacuous, so only the contract's intrinsic rules fire.
+func singleContractProject(c *metadata.ContractMeta) *metadata.ProjectMeta {
+	return &metadata.ProjectMeta{
+		Cells:      map[string]*metadata.CellMeta{},
+		Slices:     map[string]*metadata.SliceMeta{},
+		Contracts:  map[string]*metadata.ContractMeta{c.ID: c},
+		Journeys:   map[string]*metadata.JourneyMeta{},
+		Assemblies: map[string]*metadata.AssemblyMeta{},
+	}
+}
+
+// denyForStoreError maps a registrar Submit error to a fail-closed verdict,
+// preserving the (passing) validation findings for context. A duplicate id is a
+// conflict (the contract was valid, just already registered); any other store
+// error is treated as a validation failure.
+func denyForStoreError(prior GovernanceGateResult, err error) GovernanceGateResult {
+	reason := reasonValidationFailed
+	var ec *errcode.Error
+	if errors.As(err, &ec) && ec.Code == errcode.ErrRegistrationDuplicate {
+		reason = reasonDuplicate
+	}
+	return GovernanceGateResult{Allowed: false, Result: prior.Result, Warnings: prior.Warnings, Reason: reason}
+}
+
+// runtimeFanoutCompleteness is the REG-01 runtime fanout-completeness rule — the
+// register-time compensation for the in-tree reverse-coverage archtests
+// (DEAD-CONTRACT-01 / IMPL-DECL-COVER-01 / EMIT-DECL-COVER-01 / DEAD-CODE-01)
+// being vacuous over runtime-registered contracts (epic-303 ADR §"与扇出 archtest
+// 的关系"). For the candidate it asserts the contract carries an identity
+// (id/kind), a provider endpoint (publisher/server/handler/provider per kind), and
+// — for kinds with an in-repo consumer set (event/command/projection/webhook) — at
+// least one consumer, mirroring kernel/registry ContractRegistry.Provider /
+// Consumers kind dispatch.
+//
+// It is deliberately NOT named validate*/checkDEP*/checkCH* so the
+// GOVERNANCE-RULES-REGISTRATION-GUARD-01 orphan check does not require it in
+// allRules: REG-01 is a gate-only rule, never run by `gocell validate` /
+// `gocell check`, so it cannot regress in-tree static governance (FR-004). It
+// still emits through the locator constructor funnel with a rulecodes.go const
+// (GOVERNANCE-RULE-CODE-CONST-SINGLE-SOURCE-01 / -ERROR-FIX-FIELD-01).
+func (v *Validator) runtimeFanoutCompleteness() []ValidationResult {
+	var out []ValidationResult
+	for _, c := range v.sortedContracts() {
+		out = append(out, v.fanoutFindingsFor(c)...)
+	}
+	return out
+}
+
+// fanoutFindingsFor returns the REG-01 findings for a single contract.
+func (v *Validator) fanoutFindingsFor(c *metadata.ContractMeta) []ValidationResult {
+	var out []ValidationResult
+	if strings.TrimSpace(c.ID) == "" {
+		out = append(out, v.newError(codeREG01, IssueRequired, c.File, "id",
+			"runtime contract is missing an id",
+			"set the contract id before submitting it for registration"))
+	}
+	if strings.TrimSpace(c.Kind) == "" {
+		out = append(out, v.newError(codeREG01, IssueRequired, c.File, "kind",
+			"runtime contract is missing a kind",
+			"set the contract kind (http/event/command/projection/webhook/grpc/saga)"))
+		return out // kind unknown → provider/consumer dispatch is undefined
+	}
+	if provider, err := v.contracts.Provider(c.ID); err != nil || strings.TrimSpace(provider) == "" {
+		out = append(out, v.newError(codeREG01, IssueRequired, c.File, fanoutProviderField(c.Kind),
+			fmt.Sprintf("runtime contract %q (kind %q) is missing its provider endpoint — fanout incomplete", c.ID, c.Kind),
+			"declare the provider endpoint so the registered contract has a producer"))
+	}
+	if fanoutRequiresConsumer(c.Kind) {
+		if consumers, err := v.contracts.Consumers(c.ID); err != nil || len(consumers) == 0 {
+			out = append(out, v.newError(codeREG01, IssueRequired, c.File, fanoutConsumerField(c.Kind),
+				fmt.Sprintf("runtime contract %q (kind %q) has no consumer — dead contract, fanout incomplete", c.ID, c.Kind),
+				"declare at least one consumer (subscriber/invoker/reader/receiver) or retire the contract"))
+		}
+	}
+	return out
+}
+
+// runtimeRegistrationAdvisories emits the gate's non-blocking registration
+// warnings (REG-02). Today it surfaces one advisory: submitting a contract whose
+// lifecycle is already "deprecated" is allowed, but warned — mirroring the
+// canonical K8s AdmissionResponse warning for a deprecated API version
+// (research.md §2.2). Like runtimeFanoutCompleteness it is gate-only (not a
+// validate*/checkDEP*/checkCH* method, not in allRules) so it never runs in
+// `gocell validate` / `gocell check` (FR-004).
+func (v *Validator) runtimeRegistrationAdvisories() []ValidationResult {
+	var out []ValidationResult
+	for _, c := range v.sortedContracts() {
+		if c.Lifecycle == "deprecated" {
+			out = append(out, v.newWarning(codeREG02, IssueForbidden, c.File, "lifecycle",
+				fmt.Sprintf("runtime contract %q is being registered with lifecycle %q", c.ID, c.Lifecycle),
+				"register an active (non-deprecated) version of this contract, or confirm the deprecated registration is intentional"))
+		}
+	}
+	return out
+}
+
+// fanoutProviderField names the YAML field carrying the provider for a kind, for
+// the REG-01 finding's Field anchor (mirrors ContractMeta.ProviderEndpoint).
+func fanoutProviderField(kind string) string {
+	switch kind {
+	case "event":
+		return "endpoints.publisher"
+	case "command":
+		return "endpoints.handler"
+	case "projection":
+		return "endpoints.provider"
+	case "webhook":
+		return "ownerCell"
+	default: // http, grpc, saga
+		return "endpoints.server"
+	}
+}
+
+// fanoutRequiresConsumer reports whether a kind has an in-repo consumer set whose
+// emptiness means a dead contract. http/grpc consumers (clients) may legitimately
+// be external/out-of-process and saga has no consumer endpoints, so those kinds
+// are exempt from the consumer-completeness arm.
+func fanoutRequiresConsumer(kind string) bool {
+	switch kind {
+	case "event", "command", "projection", "webhook":
+		return true
+	default:
+		return false
+	}
+}
+
+// fanoutConsumerField names the YAML field carrying the consumer set for a kind,
+// for the REG-01 finding's Field anchor.
+func fanoutConsumerField(kind string) string {
+	switch kind {
+	case "event":
+		return "endpoints.subscribers"
+	case "command":
+		return "endpoints.invokers"
+	case "projection":
+		return "endpoints.readers"
+	case "webhook":
+		return "endpoints.receivers"
+	default:
+		return "endpoints"
+	}
+}

--- a/framework/kernel/governance/gate.go
+++ b/framework/kernel/governance/gate.go
@@ -107,12 +107,21 @@ func (g *RegistrationGate) Check(ctx context.Context, tnt tenant.TenantID, candi
 // as Check; only when the verdict is Allowed does it record the registration via
 // the registrar (entering the sealed state machine at `submitted`). A denied
 // candidate is never persisted (no "submitted but invalid" intermediate state),
-// and the returned result carries the machine-readable Reason.
+// and the returned result carries the machine-readable Reason. An empty submitter
+// (the required audit identity) is rejected as ReasonInvalidInput before any store
+// call.
 //
 // On a store-side error the gate stays fail-closed: a duplicate id maps to
-// ReasonDuplicate, any other store error to ReasonValidationFailed; the store
-// error is also returned so callers can inspect it. submitter is the audit
-// identity recorded against the registration.
+// ReasonDuplicate, any other (infrastructure) store error to
+// ReasonValidatorUnavailable; the store error is also returned so callers can
+// inspect it.
+//
+// Idempotency boundary: US3 dedups by registration id and treats a duplicate as a
+// conflict (ReasonDuplicate). The spec's idempotent "re-submit returns the EXISTING
+// registration" semantic dedups by the (kind,domain,version,owner) quadruple plus a
+// content fingerprint — that is FR-009 / US15 (#2245). Returning the existing
+// registration here without a fingerprint would silently mask a same-id /
+// different-content conflict, so US3 keeps the conflict verdict pending US15.
 func (g *RegistrationGate) Submit(
 	ctx context.Context, tnt tenant.TenantID, candidate *metadata.ContractMeta, submitter string,
 ) (registry.ContractRegistration, GovernanceGateResult, error) {
@@ -183,21 +192,55 @@ func (g *RegistrationGate) runRules(ctx context.Context, candidate *metadata.Con
 			err = errcode.Assertion("governance: registration gate validation panicked")
 		}
 	}()
-	// NewValidator is pure in-memory construction (no I/O, non-blocking), so the
-	// ctx.Err() check before the first rule fires is sufficient to honor a
-	// pre-canceled context.
-	v := NewValidator(singleContractProject(candidate), "", g.clk)
-	rules := []func() []ValidationResult{
-		v.checkCH01, v.checkCH02, v.checkCH03,
-		v.runtimeFanoutCompleteness, v.runtimeRegistrationAdvisories,
-	}
-	for _, run := range rules {
+	// Canonicalize a COPY of the candidate (Check is side-effect-free, so the
+	// caller's contract must not be mutated) to the parser-equivalent field state
+	// the declaration rules expect, then validate. NewValidator is pure in-memory
+	// construction (no I/O), so the ctx.Err() check before the first rule fires is
+	// sufficient to honor a pre-canceled context.
+	normalized := *candidate
+	metadata.NormalizeRuntimeContract(&normalized)
+	v := NewValidator(singleContractProject(&normalized), "", g.clk)
+	for _, run := range v.runtimeDeclarationRules() {
 		if cerr := ctx.Err(); cerr != nil {
 			return nil, cerr
 		}
 		findings = append(findings, run()...)
 	}
 	return findings, nil
+}
+
+// runtimeDeclarationRules is the SINGLE SOURCE for the rule set the runtime
+// registration gate runs over a (NormalizeRuntimeContract-canonicalized)
+// single-contract candidate — the runtime "form" of `gocell validate`'s
+// per-contract declaration checks (Check and Submit share it).
+//
+// Inclusion criteria — a rule belongs here iff it is: (1) per-contract (iterates
+// v.project.Contracts; no REF/TOPO/DEP cross-reference to sibling cells/slices a
+// standalone candidate lacks — that is the very "vacuous for runtime contracts"
+// set the epic-303 ADR documents); (2) free of filesystem dependency (no
+// handler-file scan / verify-command existence — CH-04/05, VERIFY-*); (3) not
+// codegen-coupled (CH-06/07); (4) any parser-derived field it reads is
+// canonicalized by metadata.NormalizeRuntimeContract (transports → FMT-39, event
+// subscribers → REG-01).
+//
+// The exact set is golden-locked by TestGateDeclarationRuleSet_Golden, so adding a
+// rule forces a conscious in/out classification against the criteria above instead
+// of silent drift (the hand-picked-subset risk). FMT-01/08/09/39 +
+// FRAMEWORK-OWNED close the "invalid lifecycle / wrong-prefix / unknown kind /
+// bad transport / ineligible _framework owner all pass the gate" hole.
+func (v *Validator) runtimeDeclarationRules() []func() []ValidationResult {
+	return []func() []ValidationResult{
+		v.validateFMT01,                          // lifecycle ∈ {draft,active,deprecated}
+		v.validateFMT08,                          // ID prefix matches kind
+		v.validateFMT09,                          // kind ∈ known kinds
+		v.validateFMT39,                          // transport ↔ kind compatibility
+		v.validateFRAMEWORKOWNEDCONTRACTSCOPED01, // _framework owner eligibility
+		v.checkCH01,                              // ownerCell present
+		v.checkCH02,                              // lifecycle present
+		v.checkCH03,                              // http schemaRefs complete
+		v.runtimeFanoutCompleteness,              // REG-01 publisher/subscriber completeness
+		v.runtimeRegistrationAdvisories,          // REG-02 deprecated-registration advisory
+	}
 }
 
 // singleContractProject wraps one candidate contract in an otherwise-empty

--- a/framework/kernel/governance/gate_result.go
+++ b/framework/kernel/governance/gate_result.go
@@ -53,6 +53,17 @@ func (r GateReason) String() string {
 // IsZero reports whether r is the zero (forged/uninitialised) value.
 func (r GateReason) IsZero() bool { return r.v == "" }
 
+// MarshalText implements encoding.TextMarshaler so GateReason serializes to its
+// wire value string (e.g. "validation-failed") under encoding/json — the
+// AdmissionResponse-style result is meant to be machine-readable, but a struct
+// with only an unexported field would otherwise JSON-encode to "{}" and silently
+// drop the reason. A forged zero value marshals to [GateReasonUnknown]
+// (fail-closed), never the empty string. The wire values are golden-locked by
+// TestGateReason_FrozenRegistry, so this is a stable wire contract.
+func (r GateReason) MarshalText() ([]byte, error) {
+	return []byte(r.String()), nil
+}
+
 // Package-private singletons — the sole GateReason values. Exposed via accessor
 // functions (not exported vars) so the registered values are immutable.
 var (
@@ -67,8 +78,11 @@ var (
 // ReasonAllowed: the candidate passed every applicable governance rule.
 func ReasonAllowed() GateReason { return reasonAllowed }
 
-// ReasonValidationFailed: the candidate violated a governance rule (including a
-// REG-01 fanout-completeness error), or a malformed/missing candidate.
+// ReasonValidationFailed: the declaration rules ran and the candidate violated at
+// least one — a CH/FMT/FRAMEWORK-OWNED declaration error or a REG-01
+// fanout-completeness error. A nil/malformed candidate or empty submitter is
+// ReasonInvalidInput (not this); an interrupted run is ReasonValidatorUnavailable;
+// a store-side failure is ReasonValidatorUnavailable / ReasonDuplicate.
 func ReasonValidationFailed() GateReason { return reasonValidationFailed }
 
 // ReasonValidatorUnavailable: the validation run could not complete (ctx

--- a/framework/kernel/governance/gate_result.go
+++ b/framework/kernel/governance/gate_result.go
@@ -1,0 +1,103 @@
+package governance
+
+// GovernanceGateResult is the K8s AdmissionResponse-style outcome of a
+// RegistrationGate decision (303-US3, #2234), modeled on
+// admission/v1.AdmissionResponse{Allowed, Result, Warnings}:
+//
+//   - Allowed  : the verdict. false = denied (the contract must not be persisted).
+//   - Result   : the blocking error findings explaining a denial (the deny detail,
+//     ~ AdmissionResponse.Result *Status). Empty when Allowed.
+//   - Warnings : non-blocking advisory findings. May be non-empty even when Allowed
+//     (~ AdmissionResponse.Warnings).
+//   - Reason   : the sealed, machine-readable reason for the verdict, so a caller
+//     (e.g. a registry HTTP handler) can branch without parsing English text.
+//
+// ref: kubernetes/api admission/v1/types.go — AdmissionResponse.
+type GovernanceGateResult struct {
+	Allowed  bool
+	Result   []ValidationResult
+	Warnings []ValidationResult
+	Reason   GateReason
+}
+
+// GateReason is the sealed, machine-readable reason a gate verdict took. A
+// non-zero GateReason cannot be constructed outside this package — the single
+// field is unexported and the only values are the package-private singletons
+// exposed via the accessor functions below (reassigning a function is a compile
+// error). This makes "an external package cannot forge a reason" expressible at
+// compile time (AI-robust Hard), mirroring registry.RegistrationState and
+// transport.TransportOutcome.
+//
+// The zero value is invalid: String() renders it as [GateReasonUnknown]
+// (fail-closed), never the empty string, and it is not a member of allGateReasons.
+type GateReason struct {
+	// v is the wire/label value ("allowed" | "validation-failed" | …). Unexported:
+	// a non-zero GateReason cannot be constructed outside this package.
+	v string
+}
+
+// GateReasonUnknown is the fail-closed render of a zero-value (forged) GateReason.
+// It is NOT a producible reason (not in allGateReasons). To test for a forged
+// reason use IsZero(), not a string comparison.
+const GateReasonUnknown = "unknown"
+
+// String returns the wire/label value. The zero value renders as
+// [GateReasonUnknown] (fail-closed), never the empty string.
+func (r GateReason) String() string {
+	if r.v == "" {
+		return GateReasonUnknown
+	}
+	return r.v
+}
+
+// IsZero reports whether r is the zero (forged/uninitialised) value.
+func (r GateReason) IsZero() bool { return r.v == "" }
+
+// Package-private singletons — the sole GateReason values. Exposed via accessor
+// functions (not exported vars) so the registered values are immutable.
+var (
+	reasonAllowed              = GateReason{v: "allowed"}
+	reasonValidationFailed     = GateReason{v: "validation-failed"}
+	reasonValidatorUnavailable = GateReason{v: "validator-unavailable"}
+	reasonTenantInvalid        = GateReason{v: "tenant-invalid"}
+	reasonDuplicate            = GateReason{v: "duplicate"}
+)
+
+// ReasonAllowed: the candidate passed every applicable governance rule.
+func ReasonAllowed() GateReason { return reasonAllowed }
+
+// ReasonValidationFailed: the candidate violated a governance rule (including a
+// REG-01 fanout-completeness error), or a malformed/missing candidate.
+func ReasonValidationFailed() GateReason { return reasonValidationFailed }
+
+// ReasonValidatorUnavailable: the validation run could not complete (ctx
+// canceled / interrupted, or a recovered rule panic) — fail-closed, never
+// fail-open.
+func ReasonValidatorUnavailable() GateReason { return reasonValidatorUnavailable }
+
+// ReasonTenantInvalid: the request carried an empty / non-canonical tenant
+// (FR-002 "缺租户 → deny").
+func ReasonTenantInvalid() GateReason { return reasonTenantInvalid }
+
+// ReasonDuplicate: the contract was valid but a registration with the same id
+// already exists (a conflict surfaced by the store at Submit).
+func ReasonDuplicate() GateReason { return reasonDuplicate }
+
+// allGateReasons is the closed registry of every GateReason value. It backs the
+// anti-vacuity freeze (TestGateReason_FrozenRegistry): a new reason added without
+// registering it here — or a renamed wire value — is caught.
+var allGateReasons = []GateReason{
+	reasonAllowed, reasonValidationFailed, reasonValidatorUnavailable,
+	reasonTenantInvalid, reasonDuplicate,
+}
+
+// isRegistered reports whether r is one of the producible reasons. A zero value
+// (forged) is NOT registered.
+func (r GateReason) isRegistered() bool {
+	for _, x := range allGateReasons {
+		if x == r {
+			return true
+		}
+	}
+	return false
+}

--- a/framework/kernel/governance/gate_result.go
+++ b/framework/kernel/governance/gate_result.go
@@ -61,6 +61,7 @@ var (
 	reasonValidatorUnavailable = GateReason{v: "validator-unavailable"}
 	reasonTenantInvalid        = GateReason{v: "tenant-invalid"}
 	reasonDuplicate            = GateReason{v: "duplicate"}
+	reasonInvalidInput         = GateReason{v: "invalid-input"}
 )
 
 // ReasonAllowed: the candidate passed every applicable governance rule.
@@ -83,12 +84,26 @@ func ReasonTenantInvalid() GateReason { return reasonTenantInvalid }
 // already exists (a conflict surfaced by the store at Submit).
 func ReasonDuplicate() GateReason { return reasonDuplicate }
 
+// ReasonInvalidInput: a caller precondition was violated — a nil candidate or an
+// empty submitter — rather than a governance rule failing or the validator being
+// unable to run. Distinct from ReasonValidationFailed (which means rules ran and
+// found a violation) so a caller can map malformed input to a 400-class response
+// instead of a 422-class one.
+func ReasonInvalidInput() GateReason { return reasonInvalidInput }
+
 // allGateReasons is the closed registry of every GateReason value. It backs the
 // anti-vacuity freeze (TestGateReason_FrozenRegistry): a new reason added without
 // registering it here — or a renamed wire value — is caught.
+//
+// This is a package-internal slice, not a const [N]GateReason frozen by the type
+// system — a fixed-size array would need N as a compile-time constant, and the
+// value set is hand-maintained. The drift guard is therefore Medium (value-golden
+// TestGateReason_FrozenRegistry), the documented Go ceiling for a sealed-value
+// registry, same posture as registry.allRegistrationStates /
+// transport.allTransportOutcomes.
 var allGateReasons = []GateReason{
 	reasonAllowed, reasonValidationFailed, reasonValidatorUnavailable,
-	reasonTenantInvalid, reasonDuplicate,
+	reasonTenantInvalid, reasonDuplicate, reasonInvalidInput,
 }
 
 // isRegistered reports whether r is one of the producible reasons. A zero value

--- a/framework/kernel/governance/gate_test.go
+++ b/framework/kernel/governance/gate_test.go
@@ -2,6 +2,10 @@ package governance
 
 import (
 	"context"
+	"encoding/json"
+	"reflect"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,7 +34,10 @@ func newGate(t *testing.T) (*RegistrationGate, *registry.ContractRegistrar) {
 }
 
 // validEventContract is a fully-formed event contract: owner + lifecycle +
-// provider (publisher) + a consumer (subscriber). It passes every gate rule.
+// provider (publisher) + a consumer. A runtime event declares its consumer via
+// ActorSubscribers (the user-authored field); Subscribers is parser-derived
+// (yaml:"-"), so the gate's NormalizeRuntimeContract derives it from
+// ActorSubscribers. It passes every gate rule.
 func validEventContract() *metadata.ContractMeta {
 	return &metadata.ContractMeta{
 		ID:        "event.registry.thing-happened.v1",
@@ -38,8 +45,8 @@ func validEventContract() *metadata.ContractMeta {
 		OwnerCell: "registrycore",
 		Lifecycle: "active",
 		Endpoints: metadata.EndpointsMeta{
-			Publisher:   "registrycore",
-			Subscribers: []string{"othercell"},
+			Publisher:        "registrycore",
+			ActorSubscribers: []string{"external-sink"},
 		},
 	}
 }
@@ -214,7 +221,7 @@ func TestGate_FanoutIncomplete_FailClosed(t *testing.T) {
 	}{
 		{"missing owner", func(c *metadata.ContractMeta) { c.OwnerCell = "" }, codeCH01},
 		{"missing publisher", func(c *metadata.ContractMeta) { c.Endpoints.Publisher = "" }, codeREG01},
-		{"missing subscriber", func(c *metadata.ContractMeta) { c.Endpoints.Subscribers = nil }, codeREG01},
+		{"missing subscriber", func(c *metadata.ContractMeta) { c.Endpoints.ActorSubscribers = nil }, codeREG01},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -328,6 +335,104 @@ func TestGateReason_ZeroValueFailClosed(t *testing.T) {
 	assert.Equal(t, GateReasonUnknown, zero.String())
 	assert.True(t, zero.IsZero())
 	assert.False(t, zero.isRegistered())
+}
+
+// TestGate_Check_InvalidDeclaration_FailClosed covers the C1/F1 hole: the gate
+// runs the per-contract declaration rules (FMT-01 lifecycle value, FMT-08 ID-prefix
+// ↔ kind, FMT-09 kind value), so an otherwise-complete contract with an invalid
+// declaration field is rejected — not falsely Allowed.
+func TestGate_Check_InvalidDeclaration_FailClosed(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		mutate   func(*metadata.ContractMeta)
+		wantCode RuleCode
+	}{
+		{"invalid lifecycle value", func(c *metadata.ContractMeta) { c.Lifecycle = "bogus" }, codeFMT01},
+		{"unknown kind", func(c *metadata.ContractMeta) { c.Kind = "bogus" }, codeFMT09},
+		{"id prefix mismatches kind", func(c *metadata.ContractMeta) { c.ID = "wrong.registry.thing.v1" }, codeFMT08},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gate, reg := newGate(t)
+			c := validEventContract()
+			tc.mutate(c)
+
+			res := gate.Check(context.Background(), validTenant, c)
+
+			assert.False(t, res.Allowed, "invalid declaration must fail-closed")
+			assert.Equal(t, ReasonValidationFailed(), res.Reason)
+			assert.True(t, hasCode(res.Result, tc.wantCode), "expected finding %s", tc.wantCode)
+			assert.Equal(t, 0, reg.Count())
+		})
+	}
+}
+
+// TestGate_Check_ActorSubscribersOnlyEvent_Allowed covers C1/F2: a runtime event
+// declaring its consumer ONLY via actorSubscribers (Subscribers is parser-derived)
+// is Allowed — the gate's NormalizeRuntimeContract derives Subscribers, so REG-01
+// no longer falsely rejects it as having no consumer.
+func TestGate_Check_ActorSubscribersOnlyEvent_Allowed(t *testing.T) {
+	t.Parallel()
+	gate, _ := newGate(t)
+	c := &metadata.ContractMeta{
+		ID: "event.registry.actor-only.v1", Kind: "event",
+		OwnerCell: "registrycore", Lifecycle: "active",
+		Endpoints: metadata.EndpointsMeta{
+			Publisher:        "registrycore",
+			ActorSubscribers: []string{"external-sink"},
+			// Subscribers intentionally unset (derived) — pre-fix this was falsely rejected.
+		},
+	}
+
+	res := gate.Check(context.Background(), validTenant, c)
+
+	assert.True(t, res.Allowed, "actorSubscribers-only event must be allowed after canonicalization")
+	assert.Empty(t, res.Result)
+}
+
+// TestGateReason_MarshalText covers C3/F4: GateReason serializes to its wire value
+// string (not the "{}" a struct-with-unexported-field would default to), so the
+// machine-readable result survives JSON encoding.
+func TestGateReason_MarshalText(t *testing.T) {
+	t.Parallel()
+	b, err := ReasonValidationFailed().MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, "validation-failed", string(b))
+
+	j, err := json.Marshal(GovernanceGateResult{Reason: ReasonDuplicate()})
+	require.NoError(t, err)
+	assert.Contains(t, string(j), `"duplicate"`, "reason must JSON-encode to its wire string, not {}")
+
+	var zero GateReason
+	zb, err := zero.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, GateReasonUnknown, string(zb), "forged zero marshals fail-closed")
+}
+
+// TestGateDeclarationRuleSet_Golden pins the gate's runtime declaration rule set
+// (C1: single source, no silent drift). Adding/removing a rule forces a conscious
+// classification against runtimeDeclarationRules' inclusion criteria + this golden.
+func TestGateDeclarationRuleSet_Golden(t *testing.T) {
+	t.Parallel()
+	v := NewValidator(nil, "", clockmock.New(gateTestEpoch))
+	var names []string
+	for _, fn := range v.runtimeDeclarationRules() {
+		full := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+		name := full[strings.LastIndex(full, ".")+1:]
+		names = append(names, strings.TrimSuffix(name, "-fm"))
+	}
+	want := []string{
+		"validateFMT01", "validateFMT08", "validateFMT09", "validateFMT39",
+		"validateFRAMEWORKOWNEDCONTRACTSCOPED01",
+		"checkCH01", "checkCH02", "checkCH03",
+		"runtimeFanoutCompleteness", "runtimeRegistrationAdvisories",
+	}
+	assert.Equal(t, want, names,
+		"gate declaration rule set drifted — classify the rule per runtimeDeclarationRules "+
+			"inclusion criteria (per-contract / no cross-ref / no filesystem / derived-fields canonicalized) "+
+			"and update this golden")
 }
 
 // TestRuntimeFanoutCompleteness_PerKind directly exercises the REG-01 rule across

--- a/framework/kernel/governance/gate_test.go
+++ b/framework/kernel/governance/gate_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 // gateTestEpoch is the fixed clock instant for gate tests (deterministic
-// registrar timestamps). TEST-TIME-LITERAL-01: a package-level const.
+// registrar timestamps). TEST-TIME-LITERAL-01: a package-level var (time.Time
+// cannot be a const; injected via clockmock.New for determinism).
 var gateTestEpoch = time.Date(2026, 6, 18, 0, 0, 0, 0, time.UTC)
 
 // validTenant is a canonical lowercase dashed UUID accepted by tenant.Validate.
@@ -59,6 +60,76 @@ func TestGate_NewRegistrationGate_NilStoreFailFast(t *testing.T) {
 	clk := clockmock.New(gateTestEpoch)
 	assert.Panics(t, func() { NewRegistrationGate(nil, clk) },
 		"nil store must fail-fast at construction")
+}
+
+// TestGate_NewRegistrationGate_NilClockFailFast asserts the clock strong-dep
+// guard (clock.MustHaveClock) panics at construction.
+func TestGate_NewRegistrationGate_NilClockFailFast(t *testing.T) {
+	t.Parallel()
+	reg := registry.NewContractRegistrar(clockmock.New(gateTestEpoch))
+	assert.Panics(t, func() { NewRegistrationGate(reg, nil) },
+		"nil clock must fail-fast at construction")
+}
+
+// TestGate_NilCandidate_FailClosed: a nil candidate is a caller precondition
+// violation → fail-closed with ReasonInvalidInput (distinct from a rule failure),
+// never a panic or fail-open, for both Check and Submit.
+func TestGate_NilCandidate_FailClosed(t *testing.T) {
+	t.Parallel()
+	gate, reg := newGate(t)
+
+	checkRes := gate.Check(context.Background(), validTenant, nil)
+	assert.False(t, checkRes.Allowed)
+	assert.Equal(t, ReasonInvalidInput(), checkRes.Reason)
+	assert.Empty(t, checkRes.Result)
+
+	got, submitRes, err := gate.Submit(context.Background(), validTenant, nil, "submitter-cell")
+	require.NoError(t, err)
+	assert.False(t, submitRes.Allowed)
+	assert.Equal(t, ReasonInvalidInput(), submitRes.Reason)
+	assert.Equal(t, registry.RegistrationState{}, got.State)
+	assert.Equal(t, 0, reg.Count(), "nil candidate must not persist")
+}
+
+// TestGate_Submit_EmptySubmitter_FailClosed: a valid contract with an empty
+// submitter is rejected at the gate (ReasonInvalidInput), not via the store's
+// validate() side-effect, and is not persisted.
+func TestGate_Submit_EmptySubmitter_FailClosed(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ name, submitter string }{
+		{"empty", ""},
+		{"whitespace", "   "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gate, reg := newGate(t)
+			got, res, err := gate.Submit(context.Background(), validTenant, validEventContract(), tc.submitter)
+			require.NoError(t, err)
+			assert.False(t, res.Allowed)
+			assert.Equal(t, ReasonInvalidInput(), res.Reason)
+			assert.Equal(t, registry.RegistrationState{}, got.State)
+			assert.Equal(t, 0, reg.Count(), "missing submitter must not persist")
+		})
+	}
+}
+
+// TestGate_CheckThenSubmit_DryRunHasNoSideEffect closes the Check side-effect-free
+// claim end-to-end: a Check followed by a Submit of the same contract persists
+// exactly once (the Check did not pre-persist, nor block the later Submit).
+func TestGate_CheckThenSubmit_DryRunHasNoSideEffect(t *testing.T) {
+	t.Parallel()
+	gate, reg := newGate(t)
+	c := validEventContract()
+
+	checkRes := gate.Check(context.Background(), validTenant, c)
+	require.True(t, checkRes.Allowed)
+	require.Equal(t, 0, reg.Count(), "Check must not persist")
+
+	_, submitRes, err := gate.Submit(context.Background(), validTenant, c, "submitter-cell")
+	require.NoError(t, err)
+	assert.True(t, submitRes.Allowed)
+	assert.Equal(t, 1, reg.Count(), "Submit after Check persists exactly once")
 }
 
 // TestGate_Check_DeprecatedContract_AllowedWithWarning covers AC1: a wire-compliant
@@ -241,6 +312,7 @@ func TestGateReason_FrozenRegistry(t *testing.T) {
 		"validator-unavailable": 1,
 		"tenant-invalid":        1,
 		"duplicate":             1,
+		"invalid-input":         1,
 	}
 	assert.Equal(t, want, got, "GateReason value set drifted")
 	for _, r := range allGateReasons {
@@ -306,6 +378,68 @@ func TestRuntimeFanoutCompleteness_PerKind(t *testing.T) {
 				Endpoints: metadata.EndpointsMeta{Server: "c"},
 			},
 			wantFlags: false,
+		},
+		{
+			name: "command complete",
+			contract: &metadata.ContractMeta{
+				ID: "command.f.v1", Kind: "command",
+				Endpoints: metadata.EndpointsMeta{Handler: "c", Invokers: []string{"d"}},
+			},
+			wantFlags: false,
+		},
+		{
+			name: "command missing invoker flags",
+			contract: &metadata.ContractMeta{
+				ID: "command.g.v1", Kind: "command",
+				Endpoints: metadata.EndpointsMeta{Handler: "c"},
+			},
+			wantFlags: true,
+		},
+		{
+			name: "projection complete",
+			contract: &metadata.ContractMeta{
+				ID: "projection.h.v1", Kind: "projection",
+				Endpoints: metadata.EndpointsMeta{Provider: "c", Readers: []string{"d"}},
+			},
+			wantFlags: false,
+		},
+		{
+			name: "projection missing reader flags",
+			contract: &metadata.ContractMeta{
+				ID: "projection.i.v1", Kind: "projection",
+				Endpoints: metadata.EndpointsMeta{Provider: "c"},
+			},
+			wantFlags: true,
+		},
+		{
+			name: "webhook complete (provider=ownerCell via CH-01, consumer=receivers)",
+			contract: &metadata.ContractMeta{
+				ID: "webhook.j.v1", Kind: "webhook", OwnerCell: "c",
+				Endpoints: metadata.EndpointsMeta{Receivers: []string{"d"}},
+			},
+			wantFlags: false,
+		},
+		{
+			name: "webhook missing receiver flags",
+			contract: &metadata.ContractMeta{
+				ID: "webhook.k.v1", Kind: "webhook", OwnerCell: "c",
+			},
+			wantFlags: true,
+		},
+		{
+			name: "grpc complete (consumer exempt, server present)",
+			contract: &metadata.ContractMeta{
+				ID: "grpc.l.v1", Kind: "grpc",
+				Endpoints: metadata.EndpointsMeta{Server: "c"},
+			},
+			wantFlags: false,
+		},
+		{
+			name: "grpc missing server flags",
+			contract: &metadata.ContractMeta{
+				ID: "grpc.m.v1", Kind: "grpc",
+			},
+			wantFlags: true,
 		},
 	}
 	for _, tc := range cases {

--- a/framework/kernel/governance/gate_test.go
+++ b/framework/kernel/governance/gate_test.go
@@ -1,0 +1,323 @@
+package governance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/framework/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/framework/kernel/metadata"
+	"github.com/ghbvf/gocell/framework/kernel/registry"
+	"github.com/ghbvf/gocell/framework/pkg/tenant"
+)
+
+// gateTestEpoch is the fixed clock instant for gate tests (deterministic
+// registrar timestamps). TEST-TIME-LITERAL-01: a package-level const.
+var gateTestEpoch = time.Date(2026, 6, 18, 0, 0, 0, 0, time.UTC)
+
+// validTenant is a canonical lowercase dashed UUID accepted by tenant.Validate.
+const validTenant = tenant.TenantID("11111111-1111-1111-1111-111111111111")
+
+func newGate(t *testing.T) (*RegistrationGate, *registry.ContractRegistrar) {
+	t.Helper()
+	clk := clockmock.New(gateTestEpoch)
+	reg := registry.NewContractRegistrar(clk)
+	return NewRegistrationGate(reg, clk), reg
+}
+
+// validEventContract is a fully-formed event contract: owner + lifecycle +
+// provider (publisher) + a consumer (subscriber). It passes every gate rule.
+func validEventContract() *metadata.ContractMeta {
+	return &metadata.ContractMeta{
+		ID:        "event.registry.thing-happened.v1",
+		Kind:      "event",
+		OwnerCell: "registrycore",
+		Lifecycle: "active",
+		Endpoints: metadata.EndpointsMeta{
+			Publisher:   "registrycore",
+			Subscribers: []string{"othercell"},
+		},
+	}
+}
+
+func hasCode(results []ValidationResult, code RuleCode) bool {
+	for i := range results {
+		if results[i].Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+// TestGate_NewRegistrationGate_NilStoreFailFast asserts the strong-dep guard:
+// a nil store panics at construction (no degraded/noop mode).
+func TestGate_NewRegistrationGate_NilStoreFailFast(t *testing.T) {
+	t.Parallel()
+	clk := clockmock.New(gateTestEpoch)
+	assert.Panics(t, func() { NewRegistrationGate(nil, clk) },
+		"nil store must fail-fast at construction")
+}
+
+// TestGate_Check_DeprecatedContract_AllowedWithWarning covers AC1: a wire-compliant
+// contract carrying a non-blocking advisory (deprecated lifecycle) returns
+// {Allowed:true, Warnings:[…]} and is NOT persisted (dry-run).
+func TestGate_Check_DeprecatedContract_AllowedWithWarning(t *testing.T) {
+	t.Parallel()
+	gate, reg := newGate(t)
+	c := validEventContract()
+	c.Lifecycle = "deprecated"
+
+	res := gate.Check(context.Background(), validTenant, c)
+
+	assert.True(t, res.Allowed, "deprecated lifecycle is allowed (advisory, not blocking)")
+	assert.Equal(t, ReasonAllowed(), res.Reason)
+	assert.Empty(t, res.Result, "no blocking errors")
+	require.NotEmpty(t, res.Warnings, "deprecated registration must surface a warning")
+	assert.True(t, hasCode(res.Warnings, codeREG02), "warning must be REG-02")
+	assert.Equal(t, 0, reg.Count(), "Check is dry-run: nothing persisted")
+}
+
+// TestGate_Check_ValidContract_AllowedNoFindings: a fully valid active contract
+// passes with no findings at all.
+func TestGate_Check_ValidContract_AllowedNoFindings(t *testing.T) {
+	t.Parallel()
+	gate, reg := newGate(t)
+
+	res := gate.Check(context.Background(), validTenant, validEventContract())
+
+	assert.True(t, res.Allowed)
+	assert.Equal(t, ReasonAllowed(), res.Reason)
+	assert.Empty(t, res.Result)
+	assert.Empty(t, res.Warnings)
+	assert.Equal(t, 0, reg.Count())
+}
+
+// TestGate_Submit_InvalidContract_DeniedNotPersisted covers AC2: a contract that
+// violates a governance rule is rejected before persistence — there is no
+// "submitted but invalid" intermediate state — and the denial carries a
+// machine-readable reason + finding code.
+func TestGate_Submit_InvalidContract_DeniedNotPersisted(t *testing.T) {
+	t.Parallel()
+	gate, reg := newGate(t)
+	c := validEventContract()
+	c.OwnerCell = "" // CH-01 violation
+
+	got, res, err := gate.Submit(context.Background(), validTenant, c, "submitter-cell")
+
+	require.NoError(t, err, "a governance denial is a verdict, not a Go error")
+	assert.False(t, res.Allowed)
+	assert.Equal(t, ReasonValidationFailed(), res.Reason)
+	assert.True(t, hasCode(res.Result, codeCH01), "machine-readable reason: CH-01 in Result")
+	assert.Equal(t, registry.RegistrationState{}, got.State, "denied: no registration returned")
+	assert.Equal(t, 0, reg.Count(), "denied contract MUST NOT enter submitted")
+}
+
+// TestGate_ValidatorUnavailable_FailClosed covers AC3: when the validation run
+// cannot complete (ctx canceled), the gate denies (fail-closed), never fail-open.
+func TestGate_ValidatorUnavailable_FailClosed(t *testing.T) {
+	t.Parallel()
+	gate, reg := newGate(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-canceled
+
+	res := gate.Check(ctx, validTenant, validEventContract())
+
+	assert.False(t, res.Allowed, "interrupted validation must NEVER fail open")
+	assert.Equal(t, ReasonValidatorUnavailable(), res.Reason)
+	assert.Equal(t, 0, reg.Count())
+}
+
+// TestGate_FanoutIncomplete_FailClosed covers AC4: a runtime contract missing its
+// publisher, subscriber, or owner is rejected fail-closed (owner→CH-01;
+// publisher/subscriber→REG-01) — the runtime compensation for the in-tree
+// reverse-coverage archtests being vacuous over runtime contracts.
+func TestGate_FanoutIncomplete_FailClosed(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		mutate   func(*metadata.ContractMeta)
+		wantCode RuleCode
+	}{
+		{"missing owner", func(c *metadata.ContractMeta) { c.OwnerCell = "" }, codeCH01},
+		{"missing publisher", func(c *metadata.ContractMeta) { c.Endpoints.Publisher = "" }, codeREG01},
+		{"missing subscriber", func(c *metadata.ContractMeta) { c.Endpoints.Subscribers = nil }, codeREG01},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gate, reg := newGate(t)
+			c := validEventContract()
+			tc.mutate(c)
+
+			res := gate.Check(context.Background(), validTenant, c)
+
+			assert.False(t, res.Allowed, "incomplete fanout must fail-closed")
+			assert.Equal(t, ReasonValidationFailed(), res.Reason)
+			assert.True(t, hasCode(res.Result, tc.wantCode), "expected finding %s", tc.wantCode)
+			assert.Equal(t, 0, reg.Count())
+		})
+	}
+}
+
+// TestGate_TenantInvalid_FailClosed asserts the FR-002 "缺租户 → deny": an empty,
+// nil-UUID, or non-canonical tenant is denied without running validation.
+func TestGate_TenantInvalid_FailClosed(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		tnt  tenant.TenantID
+	}{
+		{"empty", ""},
+		{"nil uuid", "00000000-0000-0000-0000-000000000000"},
+		{"non-canonical", "not-a-uuid"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gate, reg := newGate(t)
+
+			res := gate.Check(context.Background(), tc.tnt, validEventContract())
+
+			assert.False(t, res.Allowed)
+			assert.Equal(t, ReasonTenantInvalid(), res.Reason)
+			assert.Empty(t, res.Result, "tenant denial short-circuits before validation")
+			assert.Equal(t, 0, reg.Count())
+		})
+	}
+}
+
+// TestGate_Submit_HappyPath: a valid contract under a valid tenant is persisted
+// at the submitted state and the gate returns Allowed.
+func TestGate_Submit_HappyPath(t *testing.T) {
+	t.Parallel()
+	gate, reg := newGate(t)
+	c := validEventContract()
+
+	got, res, err := gate.Submit(context.Background(), validTenant, c, "submitter-cell")
+
+	require.NoError(t, err)
+	assert.True(t, res.Allowed)
+	assert.Equal(t, ReasonAllowed(), res.Reason)
+	assert.Equal(t, registry.StateSubmitted(), got.State)
+	assert.Equal(t, c.ID, got.ID)
+	assert.Equal(t, "submitter-cell", got.Submitter)
+	assert.Equal(t, 1, reg.Count(), "valid contract enters submitted exactly once")
+}
+
+// TestGate_Submit_Duplicate_FailClosed: re-submitting an id already registered is
+// a fail-closed conflict (ReasonDuplicate) and does not double-persist.
+func TestGate_Submit_Duplicate_FailClosed(t *testing.T) {
+	t.Parallel()
+	gate, reg := newGate(t)
+	c := validEventContract()
+
+	_, first, err := gate.Submit(context.Background(), validTenant, c, "submitter-cell")
+	require.NoError(t, err)
+	require.True(t, first.Allowed)
+
+	_, second, err := gate.Submit(context.Background(), validTenant, c, "submitter-cell")
+
+	require.Error(t, err, "store surfaces the duplicate conflict")
+	assert.False(t, second.Allowed)
+	assert.Equal(t, ReasonDuplicate(), second.Reason)
+	assert.Equal(t, 1, reg.Count(), "duplicate must not double-persist")
+}
+
+// TestGateReason_FrozenRegistry pins the closed GateReason value set and proves it
+// is non-vacuous (anti-vacuity for the sealed-type closure). Mirrors
+// registry.TestRegistrationState_FrozenRegistry / transport TransportOutcome.
+func TestGateReason_FrozenRegistry(t *testing.T) {
+	t.Parallel()
+	got := make(map[string]int, len(allGateReasons))
+	for _, r := range allGateReasons {
+		got[r.String()]++
+	}
+	want := map[string]int{
+		"allowed":               1,
+		"validation-failed":     1,
+		"validator-unavailable": 1,
+		"tenant-invalid":        1,
+		"duplicate":             1,
+	}
+	assert.Equal(t, want, got, "GateReason value set drifted")
+	for _, r := range allGateReasons {
+		assert.False(t, r.IsZero(), "%q reported IsZero", r)
+		assert.True(t, r.isRegistered(), "%q not registered", r)
+	}
+}
+
+// TestGateReason_ZeroValueFailClosed: a forged zero reason renders fail-closed.
+func TestGateReason_ZeroValueFailClosed(t *testing.T) {
+	t.Parallel()
+	var zero GateReason
+	assert.Equal(t, GateReasonUnknown, zero.String())
+	assert.True(t, zero.IsZero())
+	assert.False(t, zero.isRegistered())
+}
+
+// TestRuntimeFanoutCompleteness_PerKind directly exercises the REG-01 rule across
+// kinds: provider completeness applies to all; consumer completeness applies only
+// to event/command/projection/webhook (http/grpc/saga exempt).
+func TestRuntimeFanoutCompleteness_PerKind(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		contract  *metadata.ContractMeta
+		wantFlags bool
+	}{
+		{
+			name: "event complete",
+			contract: &metadata.ContractMeta{
+				ID: "event.a.v1", Kind: "event",
+				Endpoints: metadata.EndpointsMeta{Publisher: "c", Subscribers: []string{"d"}},
+			},
+			wantFlags: false,
+		},
+		{
+			name: "event missing consumer flags",
+			contract: &metadata.ContractMeta{
+				ID: "event.b.v1", Kind: "event",
+				Endpoints: metadata.EndpointsMeta{Publisher: "c"},
+			},
+			wantFlags: true,
+		},
+		{
+			name: "http no clients is fine (external consumers)",
+			contract: &metadata.ContractMeta{
+				ID: "http.c.v1", Kind: "http",
+				Endpoints: metadata.EndpointsMeta{Server: "c"},
+			},
+			wantFlags: false,
+		},
+		{
+			name: "http missing server flags",
+			contract: &metadata.ContractMeta{
+				ID: "http.d.v1", Kind: "http",
+			},
+			wantFlags: true,
+		},
+		{
+			name: "saga no consumers exempt",
+			contract: &metadata.ContractMeta{
+				ID: "saga.e.v1", Kind: "saga",
+				Endpoints: metadata.EndpointsMeta{Server: "c"},
+			},
+			wantFlags: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			v := NewValidator(singleContractProject(tc.contract), "", clockmock.New(gateTestEpoch))
+			findings := v.runtimeFanoutCompleteness()
+			if tc.wantFlags {
+				assert.True(t, hasCode(findings, codeREG01), "expected REG-01 finding")
+			} else {
+				assert.Empty(t, findings, "complete fanout should produce no REG-01 findings")
+			}
+		})
+	}
+}

--- a/framework/kernel/governance/rulecodes.go
+++ b/framework/kernel/governance/rulecodes.go
@@ -241,4 +241,21 @@ const (
 	// COMMAND — command contract format (rules_command.go).
 	codeCOMMANDCONTRACTSCHEMAREF01        RuleCode = "COMMAND-CONTRACT-SCHEMA-REF-01"
 	codeCOMMANDCONTRACTCONSISTENCYLEVEL01 RuleCode = "COMMAND-CONTRACT-CONSISTENCY-LEVEL-01"
+
+	// REG — runtime contract registration gate (gate.go, 303-US3 #2234).
+	// REG-01 is the runtime fanout-completeness compensation emitted by
+	// (*Validator).runtimeFanoutCompleteness. It is GATE-ONLY: deliberately NOT
+	// registered in allRules (its emitter is not a validate*/checkDEP*/checkCH*
+	// rule), so `gocell validate` / `gocell check` never run it and in-tree static
+	// governance does not regress (FR-004). It exists here so the gate's
+	// newError call passes GOVERNANCE-RULE-CODE-CONST-SINGLE-SOURCE-01; the
+	// allRules↔golden freeze (TestAllRulesMatchGolden) is unaffected because that
+	// test pins registered rule codes, and an unregistered const is permitted.
+	codeREG01 RuleCode = "REG-01"
+	// REG-02 is the gate-only deprecated-registration ADVISORY (a warning, not a
+	// blocking error): submitting a contract whose lifecycle is "deprecated" is
+	// allowed but surfaced as a non-blocking warning, mirroring the canonical K8s
+	// AdmissionResponse warning for a deprecated API version (research.md §2.2).
+	// Same gate-only / not-in-allRules posture as REG-01.
+	codeREG02 RuleCode = "REG-02"
 )

--- a/framework/kernel/metadata/runtime_normalize.go
+++ b/framework/kernel/metadata/runtime_normalize.go
@@ -1,0 +1,41 @@
+package metadata
+
+// NormalizeRuntimeContract canonicalizes a standalone, runtime-submitted contract
+// (303-US3 #2234) to the parser-equivalent field state that governance
+// declaration rules expect. A runtime candidate is a bare ContractMeta that never
+// went through parseContract + the project-wide derive passes, so the fields those
+// passes populate are absent — and a gate that validates the raw candidate would
+// both miss declaration checks and mis-fire derived-field checks. This helper
+// applies the per-contract subset of that normalization so the runtime
+// registration gate (and the US4 submit decoder) validate the SAME canonical shape
+// as in-tree `gocell validate`, instead of a hand-canonicalized one-off:
+//
+//   - Transports: default per-kind when unset, reusing defaultTransportsForKind —
+//     the SAME single source parseContract uses (so FMT-39 transport↔kind validates
+//     identically for runtime and in-tree contracts).
+//   - event Subscribers: derived from ActorSubscribers (the only subscriber source
+//     a standalone contract has — there are no sibling slices to merge), mirroring
+//     deriveEventSubscribers' actor-only path. Without this an actorSubscribers-only
+//     runtime event is falsely rejected as having no consumer.
+//
+// It mutates c in place (the canonical form of the passed candidate); callers that
+// must not mutate their input (e.g. a dry-run gate Check) normalize a copy. It is a
+// no-op for nil c.
+//
+// Scope boundary: webhook Receivers/Dispatchers are also yaml:"-" derived fields,
+// but unlike event subscribers they have NO user-authored source on ContractMeta
+// (in-tree they come solely from slice webhook contractUsages). How a runtime
+// webhook declares its receivers is a webhook-runtime path question owned by the
+// US4 submit decoder, not this per-contract normalize — so it is deliberately not
+// synthesized here.
+func NormalizeRuntimeContract(c *ContractMeta) {
+	if c == nil {
+		return
+	}
+	if c.Transports == nil {
+		c.Transports = defaultTransportsForKind(c.Kind)
+	}
+	if c.Kind == "event" {
+		c.Endpoints.Subscribers = dedupSorted(append([]string(nil), c.Endpoints.ActorSubscribers...))
+	}
+}

--- a/tools/archtest/internal/registrarsubmitcallerfixture/fixture.go
+++ b/tools/archtest/internal/registrarsubmitcallerfixture/fixture.go
@@ -1,0 +1,22 @@
+//go:build archtest_fixture
+
+// Package registrarsubmitcallerfixture is the RED fixture for
+// REGISTRAR-SUBMIT-CALLER-01.
+//
+// It calls registry.ContractRegistrar.Submit DIRECTLY from a package that is NOT
+// the governance registration gate — the exact bypass the funnel forbids:
+// reaching the sealed `submitted` state without passing the governance gate. The
+// caller-allowlist scan must fire on this call; total==0 means the scanner is
+// fail-open.
+package registrarsubmitcallerfixture
+
+import (
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/registry"
+)
+
+// Violation submits a registration without going through the governance gate.
+func Violation() (registry.ContractRegistration, error) {
+	r := registry.NewContractRegistrar(clock.Real())
+	return r.Submit(registry.SubmitInput{ID: "x", Kind: "event", Submitter: "y"})
+}

--- a/tools/archtest/registrar_submit_caller_01_test.go
+++ b/tools/archtest/registrar_submit_caller_01_test.go
@@ -1,0 +1,199 @@
+//go:build archtest
+
+// registrar_submit_caller_01_test.go — locks the caller-allowlist of the runtime
+// contract-registration state machine's entry point: every production call to
+// registry.ContractRegistrar.Submit must originate from the governance
+// registration gate (kernel/governance), never hand-written elsewhere.
+//
+//   - INVARIANT: REGISTRAR-SUBMIT-CALLER-01
+//
+// This is the structural backing of the 303-US3 (#2234) invariant "an invalid
+// contract never enters the sealed `submitted` state": the only way to create a
+// `submitted` registration is ContractRegistrar.Submit, and the only sanctioned
+// caller is governance.RegistrationGate, which validates the candidate first and
+// fail-closes on any error. A direct ContractRegistrar.Submit call from a cell
+// handler or anywhere else would re-admit the ungated "submitted but invalid"
+// path the gate exists to eliminate.
+//
+// # AI-robust rating
+//
+//   - MEDIUM (caller-allowlist, type-aware scan) — a GO-LANGUAGE CEILING, not a
+//     deferred TODO. A genuinely-Hard sealed-construction funnel (Submit requires
+//     a token only the gate can mint) is blocked by kernel layering: a token
+//     sealed in registry cannot be minted by governance, and registry cannot
+//     import governance (cycle). Go cannot express "only kernel/governance may
+//     call this exported method", so the caller-allowlist archtest is the ceiling
+//     — same permanent posture documented for COMMAND-ASYNC-EMIT-CALLER-01 /
+//     CROSSCELLOBS-MINTER-FUNNEL-01 / #851 / #893 / #1282. No fake Hard-upgrade
+//     issue is opened. The complementary HARD half is the sealed RegistrationState
+//     (registry.state.go): `submitted` cannot be forged, only reached via the
+//     transition table from Submit.
+//
+// # Tool blind spots
+//
+//  1. _test.go files are EXCLUDED from the Production() scan (TypedOpts.Tests
+//     defaults false) — registry's own registrar_test.go calls Submit directly and
+//     is intentionally not flagged. Test callers are a funnel-consistency note, not
+//     a production bypass.
+//  2. Build-tag-gated production files under a non-default tag are not scanned by
+//     the default-tags Production scan (same posture as sibling caller funnels).
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	registrarPkgPath = PlatformFrameworkModulePath + "/kernel/registry"
+	// registrationGatePkgPath is the SOLE sanctioned caller of
+	// ContractRegistrar.Submit — the governance registration gate (gate.go).
+	registrationGatePkgPath   = PlatformFrameworkModulePath + "/kernel/governance"
+	registrarSubmitFixturePkg = "./tools/archtest/internal/registrarsubmitcallerfixture"
+)
+
+// isRegistrarSubmitCall reports whether call resolves to
+// (*registry.ContractRegistrar).Submit. Resolution is via go/types
+// (info.Uses[sel.Sel]), so it is alias- and dot-import-proof; the receiver type
+// is pinned to ContractRegistrar so a same-named Submit on a different registry
+// type would not match.
+func isRegistrarSubmitCall(info *types.Info, call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel == nil || sel.Sel.Name != "Submit" {
+		return false
+	}
+	if info == nil {
+		return false // fail-closed: cannot confirm without type info
+	}
+	fn, ok := info.Uses[sel.Sel].(*types.Func)
+	if !ok || fn.Pkg() == nil || fn.Pkg().Path() != registrarPkgPath {
+		return false
+	}
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok || sig.Recv() == nil {
+		return false
+	}
+	return registrarReceiverName(sig.Recv().Type()) == "ContractRegistrar"
+}
+
+// registrarReceiverName returns the named-type name of a (possibly pointer)
+// receiver type, or "".
+func registrarReceiverName(t types.Type) string {
+	if p, ok := t.(*types.Pointer); ok {
+		t = p.Elem()
+	}
+	if n, ok := t.(*types.Named); ok {
+		return n.Obj().Name()
+	}
+	return ""
+}
+
+// TestRegistrarSubmitCaller01 asserts that no production package other than the
+// governance registration gate calls registry.ContractRegistrar.Submit.
+func TestRegistrarSubmitCaller01(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		if p.Pkg.Path() == registrationGatePkgPath {
+			return nil // sanctioned caller: the governance registration gate
+		}
+		var d []Diagnostic
+		for _, file := range p.Files {
+			rel := p.Rel(file)
+			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+				if !isRegistrarSubmitCall(p.TypesInfo, call) {
+					return
+				}
+				pos := p.Fset.Position(call.Pos())
+				d = append(d, Diagnostic{
+					Rel:  rel,
+					Line: pos.Line,
+					Message: fmt.Sprintf(
+						"REGISTRAR-SUBMIT-CALLER-01: %s calls registry.ContractRegistrar.Submit directly. "+
+							"A runtime contract MUST enter the `submitted` state only through the governance "+
+							"registration gate (kernel/governance.RegistrationGate.Submit), which validates the "+
+							"candidate and fail-closes on error. A direct Submit re-admits the ungated "+
+							"\"submitted but invalid\" path the gate eliminates (303-US3 #2234).",
+						rel),
+				})
+			})
+		}
+		return d
+	})
+
+	// Anti-vacuity: the governance gate must actually call ContractRegistrar.Submit,
+	// else this funnel guards nothing (the Production scan would never observe a
+	// sanctioned caller and any future bypass would still be the ONLY caller).
+	if sanctioned := countGateRegistrarSubmitCalls(t); sanctioned == 0 {
+		diags = append(diags, Diagnostic{
+			Message: "REGISTRAR-SUBMIT-CALLER-01 anti-vacuity: kernel/governance does not call " +
+				"registry.ContractRegistrar.Submit — the gate is no longer the registration entry, " +
+				"so the caller funnel guards nothing. Either the gate was removed/renamed or the " +
+				"scanner regressed.",
+		})
+	}
+
+	Report(t, "REGISTRAR-SUBMIT-CALLER-01", diags)
+}
+
+// countGateRegistrarSubmitCalls returns the number of ContractRegistrar.Submit
+// calls in the governance package (the sanctioned-caller anti-vacuity anchor).
+func countGateRegistrarSubmitCalls(t *testing.T) int {
+	t.Helper()
+	var found int
+	_ = Run(t, Typed(TypedOpts{}, []string{"./framework/kernel/governance"}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		for _, file := range p.Files {
+			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+				if isRegistrarSubmitCall(p.TypesInfo, call) {
+					found++
+				}
+			})
+		}
+		return nil
+	})
+	return found
+}
+
+// TestRegistrarSubmitCaller01_RedFixture verifies the scanner fires against a
+// hand-written package that calls ContractRegistrar.Submit directly (bypassing the
+// gate). total==0 means the scanner is fail-open.
+func TestRegistrarSubmitCaller01_RedFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var found int
+	_ = Run(t, Fixture(FixtureOpts{Tests: false}, []string{registrarSubmitFixturePkg}),
+		func(p *Pass) []Diagnostic {
+			if !p.Typed() {
+				return nil
+			}
+			for _, file := range p.Files {
+				EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+					if isRegistrarSubmitCall(p.TypesInfo, call) {
+						found++
+					}
+				})
+			}
+			return nil
+		})
+
+	assert.GreaterOrEqual(t, found, 1,
+		"REGISTRAR-SUBMIT-CALLER-01 RED fixture self-check FAILED: expected ≥ 1 violation from "+
+			"registrarsubmitcallerfixture (direct ContractRegistrar.Submit); got %d. found==0 means the "+
+			"scanner is fail-open — check info.Uses resolves under the archtest_fixture tag.", found)
+}

--- a/tools/archtest/registrar_submit_caller_01_test.go
+++ b/tools/archtest/registrar_submit_caller_01_test.go
@@ -52,7 +52,12 @@ const (
 	registrarPkgPath = PlatformFrameworkModulePath + "/kernel/registry"
 	// registrationGatePkgPath is the SOLE sanctioned caller of
 	// ContractRegistrar.Submit — the governance registration gate (gate.go).
-	registrationGatePkgPath   = PlatformFrameworkModulePath + "/kernel/governance"
+	registrationGatePkgPath = PlatformFrameworkModulePath + "/kernel/governance"
+	// registrarSubmitFixturePkg is the RED-fixture package. Its path is
+	// deliberately NOT registrationGatePkgPath, so the main scan's allowlist does
+	// not falsely exempt the fixture's bypass call. If the fixture is ever moved
+	// under kernel/governance the RED self-check would silently false-pass — keep
+	// it outside the gate package.
 	registrarSubmitFixturePkg = "./tools/archtest/internal/registrarsubmitcallerfixture"
 )
 

--- a/tools/archtest/registrar_submit_caller_01_test.go
+++ b/tools/archtest/registrar_submit_caller_01_test.go
@@ -15,15 +15,22 @@
 // handler or anywhere else would re-admit the ungated "submitted but invalid"
 // path the gate exists to eliminate.
 //
+// The allowlist is ENTRY-LEVEL, not package-level: the single sanctioned callsite
+// is the one inside (*RegistrationGate).Submit in kernel/governance. Any OTHER
+// callsite — including another function/method INSIDE kernel/governance — is
+// flagged, because the invariant is "only the gate entry", and the governance
+// package is large (a package-level allowlist would authorize far more than the
+// one entry the invariant protects).
+//
 // # AI-robust rating
 //
 //   - MEDIUM (caller-allowlist, type-aware scan) — a GO-LANGUAGE CEILING, not a
 //     deferred TODO. A genuinely-Hard sealed-construction funnel (Submit requires
 //     a token only the gate can mint) is blocked by kernel layering: a token
 //     sealed in registry cannot be minted by governance, and registry cannot
-//     import governance (cycle). Go cannot express "only kernel/governance may
-//     call this exported method", so the caller-allowlist archtest is the ceiling
-//     — same permanent posture documented for COMMAND-ASYNC-EMIT-CALLER-01 /
+//     import governance (cycle). Go cannot express "only (*RegistrationGate).Submit
+//     may call this exported method", so the caller-allowlist archtest is the
+//     ceiling — same permanent posture documented for COMMAND-ASYNC-EMIT-CALLER-01 /
 //     CROSSCELLOBS-MINTER-FUNNEL-01 / #851 / #893 / #1282. No fake Hard-upgrade
 //     issue is opened. The complementary HARD half is the sealed RegistrationState
 //     (registry.state.go): `submitted` cannot be forged, only reached via the
@@ -37,11 +44,18 @@
 //     a production bypass.
 //  2. Build-tag-gated production files under a non-default tag are not scanned by
 //     the default-tags Production scan (same posture as sibling caller funnels).
+//  3. The scan walks top-level FuncDecls (and the func literals nested in them); a
+//     Submit call in a package-level var initializer (outside any FuncDecl) is not
+//     reached. Implausible — Submit needs a *ContractRegistrar receiver value and
+//     returns two values — and consistent with the AST-scan surface of sibling
+//     funnels.
 package archtest
 
 import (
 	"fmt"
 	"go/ast"
+	"go/parser"
+	"go/token"
 	"go/types"
 	"testing"
 
@@ -97,79 +111,122 @@ func registrarReceiverName(t types.Type) string {
 	return ""
 }
 
-// TestRegistrarSubmitCaller01 asserts that no production package other than the
-// governance registration gate calls registry.ContractRegistrar.Submit.
+// recvTypeName returns the (de-pointered) receiver type name of a method
+// declaration, or "" for a free function / unparsable receiver.
+func recvTypeName(fd *ast.FuncDecl) string {
+	if fd.Recv == nil || len(fd.Recv.List) != 1 {
+		return ""
+	}
+	t := fd.Recv.List[0].Type
+	if star, ok := t.(*ast.StarExpr); ok {
+		t = star.X
+	}
+	if id, ok := t.(*ast.Ident); ok {
+		return id.Name
+	}
+	return ""
+}
+
+// isGateSubmitMethodDecl reports whether fd is the sanctioned gate entry method
+// (*RegistrationGate).Submit — the ONE callsite allowed to reach
+// ContractRegistrar.Submit. Callers must additionally confirm fd lives in the
+// governance package (a same-named type elsewhere would not be the gate).
+func isGateSubmitMethodDecl(fd *ast.FuncDecl) bool {
+	return fd.Name != nil && fd.Name.Name == "Submit" && recvTypeName(fd) == "RegistrationGate"
+}
+
+// TestRegistrarSubmitCaller01 asserts that the ONLY production callsite of
+// registry.ContractRegistrar.Submit is inside (*RegistrationGate).Submit — an
+// entry-level allowlist, not a package-level one (any other callsite, even inside
+// kernel/governance, is flagged).
 func TestRegistrarSubmitCaller01(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping packages.Load-based archtest in -short mode")
 	}
 
+	var sanctionedCallsites int
 	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
 		if !p.Typed() {
 			return nil
 		}
-		if p.Pkg.Path() == registrationGatePkgPath {
-			return nil // sanctioned caller: the governance registration gate
-		}
+		gatePkg := p.Pkg.Path() == registrationGatePkgPath
 		var d []Diagnostic
 		for _, file := range p.Files {
 			rel := p.Rel(file)
-			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-				if !isRegistrarSubmitCall(p.TypesInfo, call) {
-					return
-				}
-				pos := p.Fset.Position(call.Pos())
-				d = append(d, Diagnostic{
-					Rel:  rel,
-					Line: pos.Line,
-					Message: fmt.Sprintf(
-						"REGISTRAR-SUBMIT-CALLER-01: %s calls registry.ContractRegistrar.Submit directly. "+
-							"A runtime contract MUST enter the `submitted` state only through the governance "+
-							"registration gate (kernel/governance.RegistrationGate.Submit), which validates the "+
-							"candidate and fail-closes on error. A direct Submit re-admits the ungated "+
-							"\"submitted but invalid\" path the gate eliminates (303-US3 #2234).",
-						rel),
+			EachInChildren[ast.FuncDecl](file, func(fd *ast.FuncDecl) {
+				sanctioned := gatePkg && isGateSubmitMethodDecl(fd)
+				EachInSubtree[ast.CallExpr](fd, func(call *ast.CallExpr) {
+					if !isRegistrarSubmitCall(p.TypesInfo, call) {
+						return
+					}
+					if sanctioned {
+						sanctionedCallsites++
+						return // the single allowed callsite
+					}
+					pos := p.Fset.Position(call.Pos())
+					d = append(d, Diagnostic{
+						Rel:  rel,
+						Line: pos.Line,
+						Message: fmt.Sprintf(
+							"REGISTRAR-SUBMIT-CALLER-01: %s calls registry.ContractRegistrar.Submit outside "+
+								"(*RegistrationGate).Submit. A runtime contract MUST enter `submitted` only through "+
+								"the governance registration gate, which validates the candidate and fail-closes on "+
+								"error. Any other callsite — even inside kernel/governance — re-admits the ungated "+
+								"\"submitted but invalid\" path the gate eliminates (303-US3 #2234).",
+							rel),
+					})
 				})
 			})
 		}
 		return d
 	})
 
-	// Anti-vacuity: the governance gate must actually call ContractRegistrar.Submit,
-	// else this funnel guards nothing (the Production scan would never observe a
-	// sanctioned caller and any future bypass would still be the ONLY caller).
-	if sanctioned := countGateRegistrarSubmitCalls(t); sanctioned == 0 {
+	// Anti-vacuity: EXACTLY ONE sanctioned callsite must exist — the single
+	// store.Submit call inside (*RegistrationGate).Submit. 0 = the gate no longer
+	// persists (the funnel guards nothing); >1 = the gate grew a second Submit
+	// callsite that must be reviewed (the invariant is "the one gate entry", not
+	// "the gate package").
+	if sanctionedCallsites != 1 {
 		diags = append(diags, Diagnostic{
-			Message: "REGISTRAR-SUBMIT-CALLER-01 anti-vacuity: kernel/governance does not call " +
-				"registry.ContractRegistrar.Submit — the gate is no longer the registration entry, " +
-				"so the caller funnel guards nothing. Either the gate was removed/renamed or the " +
-				"scanner regressed.",
+			Message: fmt.Sprintf("REGISTRAR-SUBMIT-CALLER-01 anti-vacuity: expected EXACTLY 1 "+
+				"registry.ContractRegistrar.Submit callsite inside (*RegistrationGate).Submit, found %d "+
+				"(0 = gate no longer the registration entry → funnel vacuous; >1 = unreviewed second entry).",
+				sanctionedCallsites),
 		})
 	}
 
 	Report(t, "REGISTRAR-SUBMIT-CALLER-01", diags)
 }
 
-// countGateRegistrarSubmitCalls returns the number of ContractRegistrar.Submit
-// calls in the governance package (the sanctioned-caller anti-vacuity anchor).
-func countGateRegistrarSubmitCalls(t *testing.T) int {
-	t.Helper()
-	var found int
-	_ = Run(t, Typed(TypedOpts{}, []string{"./framework/kernel/governance"}), func(p *Pass) []Diagnostic {
-		if !p.Typed() {
-			return nil
-		}
-		for _, file := range p.Files {
-			EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-				if isRegistrarSubmitCall(p.TypesInfo, call) {
-					found++
-				}
-			})
-		}
-		return nil
+// TestIsGateSubmitMethodDecl unit-tests the entry-level discriminator directly: it
+// must accept (*RegistrationGate).Submit and reject a same-package non-gate
+// function / a Submit on a different receiver — the function-level refinement a
+// same-package RED fixture cannot exercise (fixtures live in their own package).
+func TestIsGateSubmitMethodDecl(t *testing.T) {
+	t.Parallel()
+	const src = `package governance
+type RegistrationGate struct{}
+type Other struct{}
+func (g *RegistrationGate) Submit() {}
+func (g *RegistrationGate) Check() {}
+func (o *Other) Submit() {}
+func Submit() {}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "x.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := map[string]bool{}
+	EachInChildren[ast.FuncDecl](f, func(fd *ast.FuncDecl) {
+		key := recvTypeName(fd) + "." + fd.Name.Name
+		got[key] = isGateSubmitMethodDecl(fd)
 	})
-	return found
+	assert.True(t, got["RegistrationGate.Submit"], "(*RegistrationGate).Submit must be sanctioned")
+	assert.False(t, got["RegistrationGate.Check"], "non-Submit gate method must not be sanctioned")
+	assert.False(t, got["Other.Submit"], "Submit on a different receiver must not be sanctioned")
+	assert.False(t, got[".Submit"], "free function Submit must not be sanctioned")
 }
 
 // TestRegistrarSubmitCaller01_RedFixture verifies the scanner fires against a

--- a/tools/archtest/reverse_coverage_invariants.go
+++ b/tools/archtest/reverse_coverage_invariants.go
@@ -24,6 +24,20 @@ package archtest
 // structure that do not exist in an external module. Running against an
 // external repo produces vacuous-green or false-red. Enforced in GoCell via
 // the corresponding Test* functions.
+//
+// # Runtime-registered contracts — VACUOUS BY DESIGN (epic #303 / #2234)
+//
+// Every invariant in this file statically enumerates contracts from
+// contract.yaml + generated/contracts paths at BUILD time. Contracts registered
+// at RUNTIME via the contract registry (epic #303, out-of-tree cells) do not
+// exist at build time, so DEAD-CONTRACT-01 / IMPL-DECL-COVER-01 /
+// EMIT-DECL-COVER-01 / DEAD-CODE-01 (and HANDLER-DECL-COVER-01) are VACUOUS over
+// them. This is the dual-track design declared in ADR 202606162119-303
+// §"与扇出 archtest 的关系" — NOT a coverage gap. The equivalent runtime
+// compensation is the governance registration gate's REG-01 fanout-completeness
+// check (kernel/governance.(*Validator).runtimeFanoutCompleteness, #2234), which
+// validates publisher/subscriber/owner completeness at register time. Do not read
+// these archtests' silence on runtime-registered contracts as coverage.
 
 import (
 	"go/ast"


### PR DESCRIPTION
## Summary

新增运行时 governance gate（`kernel/governance.RegistrationGate`）：把现有 `Validator` 包成 K8s AdmissionResponse 式 `{Allowed, Result, Warnings, Reason}`，提供 `Check`(dry-run 不落库) + `Submit`(落库前同步校验) 两个共用同一校验路径的入口，`FailurePolicy=Fail` fail-closed。

## Why / 背景

Epic #303 dual-track 治理：in-tree cell 由编译期静态治理守（Hard trust root）；out-of-tree（运行时注册、进程外）cell 编译期不可枚举，需 runtime governance gate 补偿——「把 `gocell validate` 从 CI 搬到注册端点」。#2233（US2）已落地 sealed 状态机，`StateSubmitted` 语义是「经 gate 接纳并记录」；本 PR（US3）补上那道 gate。预期结果：**非法契约连 submitted 都不进**（无「submitted 但 invalid」中间态），合法契约经 `Submit` 才进入状态机。

设计要点：
- **单契约校验**：gate 构造单契约 `ProjectMeta`，跑内在声明规则（CH-01 owner / CH-02 lifecycle / CH-03 http schemaRefs）+ 新增 **REG-01** runtime 扇出完整性（publisher/subscriber 齐全，复用 `ContractRegistry.Provider/Consumers` kind 派发）+ **REG-02** deprecated-注册告警（K8s 式 deprecated-API warning）。刻意**不**跑 REF/TOPO/handler-scan/codegen 等 in-tree-artifact 规则——它们对进程外 runtime 契约结构性 vacuous（正是 ADR 描述的 dual-track），REG-01 即其等价 runtime 补偿。
- **fail-closed**：非法租户（`tenant.Validate` 失败）/ 校验中断或 panic / 校验错误 / duplicate 均 deny，绝不 fail-open。
- **AI-robust 诚实分层（FR-013，不伪 Hard）**：gate verdict = **Medium**（runtime guard + 包级单测，runtime 契约编译期不存在，合规性不可为编译事实）；`GateReason`/`GovernanceGateResult` 值集 = **Hard**（sealed + frozen-registry）；「submitted 只能经 gate 产生」= **Medium**，新增 caller-funnel archtest `REGISTRAR-SUBMIT-CALLER-01`（仅 `kernel/governance` 可调 `registry.ContractRegistrar.Submit`，type-aware scan + anti-vacuity + RED fixture）。sealed-construction token 被 kernel 分层阻断（registry 不能 import governance），caller-funnel 是 Go 天花板，同 `COMMAND-ASYNC-EMIT-CALLER-01` 族。

## Refs

Closes #2234 · 分解自 Epic #303 · `specs/070-runtime-contract-registry/{spec,tasks}.md`（US3 / T030-T032 / FR-002/004/013）· ADR `docs/architecture/202606162119-303`（威胁矩阵 T8/T10 + 扇出 vacuity 边界 L141-153）

- `ref: confluentinc/schema-registry rest/resources/SubjectVersionsResource.java`（/compatibility dry-run vs /versions 写入双端点共用校验）
- `ref: kubernetes/api admission/v1/types.go`（AdmissionResponse {Allowed, Result, Warnings} + FailurePolicy=Fail）

## Risk / 兼容性

- **无 wire 契约变更**（纯 kernel 校验器扩展，新增符号，未改既有签名）。
- **FR-004 零回归**：REG-01/REG-02 为 gate-only `RuleCode`（不入 `allRules`，emitter 非 `validate*/checkDEP*/checkCH*` 方法）→ `gocell validate`/`check` 行为不变（`rule_inventory` golden 不变，已验证）。
- `reverse_coverage_invariants.go` godoc 按 ADR L153 标注「runtime 契约 vacuous = 设计预期」（纯注释）。
- US3 边界：store-backend-unavailable 的 deny 路径在 US5（PG store）；本 PR in-mem store 经真实 duplicate-error 路径实证「store error → deny」分支。

## Test plan

- [x] `go build ./...`（framework + tools + corecells 模块）本地通过
- [x] `go test ./framework/kernel/governance/... ./framework/kernel/registry/...` 通过（gate 9 组 table 测试：AC1-4 + 租户/store fail-closed + happy + GateReason frozen + 扇出 per-kind 直测）
- [x] `go test -tags=archtest ./tools/archtest/...` 通过（REGISTRAR-SUBMIT-CALLER-01 GREEN + RED fixture fires；governance rule guards + reverse-coverage 不破）
- [x] `golangci-lint run --new-from-merge-base=origin/develop`（framework + tools，含 archtest tags）0 new issues
- [x] `go build -tags=integration ./...`（framework）通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
