### PR TITLE
docs(authz): 收口 RowScope 与 RLS 文档漂移

### DIFF
--- a/.claude/rules/gocell/tenancy.md
+++ b/.claude/rules/gocell/tenancy.md
@@ -85,9 +85,11 @@ app-serving role 必须非 owner 且无 bypass RLS 权限。
 - PDP fail-closed：缺 Authorizer / 缺租户 / store 不可用 / 无适用 permit → deny。内置 baseline
   是 action-scoped + role-conditioned 的 allow 规则（复刻既有 role 门禁）；baseline ≠ 降级
   allow-all。租户 policy 叠加在 baseline 上，可加 allow 也可加 deny（forbid-wins 保证 deny
-  优先）——故租户 allow 可放宽**路由门禁**，但**不能扩大数据访问**：数据可见性由 principal
-  派生的 `RowScope`（身份决定，policy 改不动）独立治理，租户给非 admin 授 `audit:read` 只让其
-  过门禁，数据层仍按 RowScope=self 只返回本人行。路由门禁是 RowScope 之上的纵深防御，不是唯一控制点。
+  优先）——故租户 allow 可放宽**路由门禁**，但**不能扩大数据访问**。读端点的数据可见性由
+  principal 派生的 `RowScope`（身份决定，policy 改不动）独立治理，租户给非 admin 授
+  `audit:read` 只让其过门禁，数据层仍按 RowScope=self 只返回本人行。写端点没有 RowScope
+  维度，隔离后盾是 typed tenant 参数 / ctx tenant 与 PostgreSQL FORCE RLS 的 tenant 边界。
+  路由门禁是数据边界之上的纵深防御，不是唯一控制点。
 - 路由门禁是 coarse allow/deny，不**执行** obligation（RowScope/FieldMask 由数据层 PEP 执行），
   但对 Allow 携带的非零 obligation **fail-closed**（拒绝而非静默丢弃）——baseline obligation
   为零，正常路径不受影响。

--- a/adapters/postgres/audit_ledger_store.go
+++ b/adapters/postgres/audit_ledger_store.go
@@ -588,11 +588,13 @@ func (s *LedgerStore) Query(
 FROM audit_entries WHERE namespace = `, ns)
 	// TENANT axis (#1618): the mandatory typed tenant t scopes results to its OWN
 	// tenant's rows PLUS tenant-less system/framework rows (tenant_id == "" —
-	// bootstrap.auth.fail and other pre-auth events have no principal tenant) —
-	// never another tenant's rows. This is the app-layer half of the dual-layer
-	// isolation (FORCE RLS on the app.tenant_id GUC is the DB-Hard primary); it is
-	// always applied (no tenant-less Query is expressible). The auditquery handler
-	// passes t from the authenticated principal.
+	// bootstrap.auth.fail and other pre-auth events have no principal tenant).
+	// The empty-tenant chain is a shared operational signal surface intentionally
+	// visible to tenant-scoped audit admins; rows carrying any other tenant_id stay
+	// excluded. This is the app-layer half of the dual-layer isolation (FORCE RLS
+	// on the app.tenant_id GUC is the DB-Hard primary); it is always applied (no
+	// tenant-less Query is expressible). The auditquery handler passes t from the
+	// authenticated principal.
 	//
 	// Index note: the `OR tenant_id=''` disjunction is served by
 	// idx_audit_namespace_ts_id (namespace equality + the ts/id keyset, ORDER BY

--- a/adapters/postgres/migrations/052_tenant_rls_force.sql
+++ b/adapters/postgres/migrations/052_tenant_rls_force.sql
@@ -40,9 +40,10 @@
 --   exact and index-friendly. The issue text wrote `::uuid`, which assumed a
 --   uuid column; casting only the setting (text = uuid) is a type error against
 --   a TEXT column, and casting the column defeats the tenant_id index — so the
---   correct, index-preserving predicate is the uncast TEXT form above. The
---   SystemTenantID (nil UUID) system-config tier is read by setting the GUC to
---   that nil UUID (strict equality), so no OR-branch is needed.
+--   correct, index-preserving predicate is the uncast TEXT form above. Internal
+--   config reads no longer use a SystemTenantID/nil-UUID tier (#1577); they pass
+--   the caller's real tenant through X-Tenant-ID and set the GUC to that canonical
+--   tenant string, so strict tenant equality remains the only branch needed.
 --
 -- WITH CHECK is stated explicitly (it defaults to USING when omitted) so the
 -- write-side guard survives a future USING-only edit.

--- a/docs/architecture/202606121400-1348-adr-pr10a-authz-wiring.md
+++ b/docs/architecture/202606121400-1348-adr-pr10a-authz-wiring.md
@@ -218,7 +218,7 @@ the shared `adminOrSuperAdmin()` baseline widens them to admit super-admin. That
 relaxation is recorded explicitly below (PR pr-review F1 corrected an earlier
 draft that mis-described it as "unchanged").
 
-- **5 permissions minted** (`pkg/authz/permission.go`): `config:read` (configread),
+- **5 permissions minted** (`framework/pkg/authz/permission.go`): `config:read` (configread),
   `config:write` (configwrite — folds create/update/delete), `config:publish`
   (configpublish), `flag:read` (featureflag — get/list/evaluate), `flag:write`
   (flagwrite). Same sealed shape as `PermAuditRead` (private singleton + accessor
@@ -227,7 +227,10 @@ draft that mis-described it as "unchanged").
 - **5 baseline rules** (`baseline.go`), one per permission, each gating the
   permission via the shared `adminOrSuperAdmin()` condition (Allow, action-scoped,
   subject.role ∈ {admin, super-admin}). D3's baseline≠downgrade and the forbid-wins
-  / RowScope-independence arguments carry over verbatim.
+  / policy-independence arguments carry over, but the data boundary differs by
+  endpoint shape: audit read endpoints are RowScope-bounded at the data PEP;
+  configcore includes write endpoints, where tenant isolation is enforced by the
+  typed tenant axis plus FORCE RLS, not by RowScope.
   **Threat model re-evaluated — subject set WIDENED, not unchanged (PR pr-review F1):**
   unlike auditquery (whose pre-migration gate was already
   `auth.AnyRole(RoleAdmin, RoleSuperAdmin)` — see §"Super-admin behavior" above),
@@ -243,8 +246,9 @@ draft that mis-described it as "unchanged").
   the project's single declared admin-hierarchy condition, shared by audit and
   config. **Net effect today is zero**: `RoleSuperAdmin` has no production token
   issuer on develop (`runtime/auth/roles.go` — type-foundation constant only), so no
-  live principal carries it. non-admins stay default-deny; a tenant `allow` can only
-  widen the *route* gate, never data visibility (governed by principal-derived RowScope).
+  live principal carries it. non-admins stay default-deny. A tenant `allow` can only
+  widen the *route* gate; it does not bypass the tenant/RLS write boundary, and on
+  read paths it still cannot widen principal-derived RowScope.
 - **5 handlers migrated** to `auth.RequirePermission(authz.Perm*)`; configcore has
   no self/ownership branch (unlike auditquery) so no custom policy func is needed —
   a one-line policy swap per slice. The 14 configcore contract 403 descriptions name
@@ -291,7 +295,7 @@ rbaccheck), draining the `PERMISSION-BASED-AUTHZ-01` allowlist to ∅ and closin
 #1348. Unlike configcore, these carry `auth.SelfOr` ownership gates, so PR-10c adds
 **one new code primitive** (the only new machinery): a self-exempt route gate.
 
-- **New gate `auth.RequirePermissionOrSelf(pathParam, perm)`** (`runtime/auth/permission.go`):
+- **New gate `auth.RequirePermissionOrSelf(pathParam, perm)`** (`framework/runtime/auth/permission.go`):
   the migration target for `auth.SelfOr(pathParam, RoleAdmin)`. It permits the request
   when the path parameter equals the caller subject (self-access), and otherwise
   **delegates to `RequirePermission(perm)`**. This is NOT a second PDP path (D5's
@@ -312,7 +316,7 @@ rbaccheck), draining the `PERMISSION-BASED-AUTHZ-01` allowlist to ∅ and closin
   not type-expressible; it fails closed, and a non-vacuous unit test pins that a
   `param != subject` non-admin request is *denied* (an inverted self-check red-fails).
   Hard-ification rides the PR-13 codegen funnel with `RequirePermission`.
-- **5 permissions minted** (`pkg/authz`): `policy:read`/`policy:write` (policymanage),
+- **5 permissions minted** (`framework/pkg/authz`): `policy:read`/`policy:write` (policymanage),
   `user:read`/`user:write` (identitymanage — "write" folds create/update/patch/delete/
   lock/unlock/change-password per the AWS-IAM Write access-level the prior uniform gate
   implied), `role:read` (rbaccheck). Same sealed shape as PR-10a/b (D4 Hard holds);
@@ -448,7 +452,7 @@ primitive — so the operator has a real near-term consumer (not speculative).
   server denies cross-tenant) is additionally covered end-to-end by `TestABACPDPGatesAccesscore`'s
   `cross_tenant_*` cases (#2026 / PR #2025 review F11).
 - **`auth.RequirePermissionForResource(pathParam, perm)` replaces `auth.RequirePermissionOrSelf`**
-  (`runtime/auth/permission.go`): it forwards the canonicalized (`httputil.ParseCanonicalUUID`)
+  (`framework/runtime/auth/permission.go`): it forwards the canonicalized (`httputil.ParseCanonicalUUID`)
   path-param value to the PDP as `resource`, enabling the ownership rule — it is **not** a self
   short-circuit (every request reaches the PDP). `RequirePermissionOrSelf` + its self-exemption are
   deleted (no shim). `isSelfAccess`/`RequireSelfOrRole`/`SelfOr` survive only for `examples/iotdevice`
@@ -591,4 +595,4 @@ archtest godocs are amended in lockstep with this scope/allowlist change.
 - Auth funnel: `.claude/rules/gocell/tenancy.md` §ABAC authz 接线
 - ABAC engine: PR-7 `docs/architecture/...adr...` ; PG policy store PR-8 `202606111300-1346-adr-abac-policy-pg-persistence.md`
 - AI-robust charter: `.claude/rules/gocell/ai-robust.md`
-- Invariant symbols/blind-spots: `tools/archtest/permission_based_authz_test.go` godoc, `runtime/auth/permission.go` godoc, `pkg/authz/permission.go` godoc
+- Invariant symbols/blind-spots: `tools/archtest/permission_based_authz_test.go` godoc, `framework/runtime/auth/permission.go` godoc, `framework/pkg/authz/permission.go` godoc

--- a/docs/guides/cell-authz-rowscope-guide.md
+++ b/docs/guides/cell-authz-rowscope-guide.md
@@ -18,11 +18,12 @@ For each non-public business endpoint:
    `auth.RequirePermissionForResource("pathParam", authz.PermXxx())`. It
    canonicalizes the path parameter and forwards it as `resource.id` for PDP
    ownership rules. Do not replace it with plain `RequirePermission`.
-4. Register the baseline grant in
-   `corecells/accesscore/slices/authorizationdecide/baseline.go` when the
-   endpoint should be available to the built-in admin/super-admin or ownership
-   model. A missing baseline means the endpoint is default-deny unless tenant
-   policy grants it.
+4. Register the baseline grant in the PDP that owns this assembly's
+   authorization rules. Platform corecells use
+   `corecells/accesscore/slices/authorizationdecide/baseline.go`; example,
+   external, or self-contained cells keep the matching baseline in their own
+   `Authorizer()`/PDP. A missing baseline means the endpoint is default-deny
+   unless tenant policy grants it.
 5. Wire the composition root so the primary listener gets an Authorizer:
    `bootstrap.WithPrimaryAuthorizer(authorizer)` or
    `bootstrap.PrimaryAuthorizerOption(cells)`. Without this, the route gate
@@ -48,6 +49,21 @@ Data visibility must be enforced where data is read:
 - Write endpoints generally have no RowScope dimension. Their isolation boundary
   is the typed tenant axis, ctx tenant propagation, and PostgreSQL FORCE RLS.
 
+## PDP Ownership
+
+`RequirePermission` calls the primary listener's injected Authorizer. The
+composition root decides which PDP owns baseline rules:
+
+| Assembly shape | Baseline owner | Wiring |
+|----------------|----------------|--------|
+| Platform corecells bundle | `corecells/accesscore/slices/authorizationdecide/baseline.go` | `bootstrap.PrimaryAuthorizerOption(cells)` discovers the accesscore Authorizer. |
+| Example or self-contained cell | The cell's local `Authorizer()`/PDP, beside the cell-specific policy code. | `bootstrap.PrimaryAuthorizerOption(cells)` discovers exactly one provider, or the root passes it via `bootstrap.WithPrimaryAuthorizer`. |
+| External assembly with its own PDP | The external PDP package that owns policy evaluation. | The composition root injects that PDP with `bootstrap.WithPrimaryAuthorizer`. |
+
+Do not copy platform accesscore baseline rules into examples just to satisfy the
+checklist. Keep each grant beside the PDP that will evaluate it, and keep only
+one primary Authorizer per assembly so startup can fail fast on ambiguous wiring.
+
 ## RowScope Values
 
 `tenant.RowScope` has four non-zero values:
@@ -70,6 +86,7 @@ principal-derived RowScope.
 | Failure | Symptom | Fix |
 |---------|---------|-----|
 | Permission minted but no baseline rule | Admin receives 403 from default-deny. | Add the matching baseline rule or document tenant-policy-only access. |
+| Baseline registered in the wrong PDP owner | Tests pass in one assembly but another route still denies. | Put the grant beside the PDP injected by that assembly's composition root. |
 | Handler uses `auth.AnyRole` | Authorization bypasses the PDP funnel and role-literal governance fails. | Use `auth.RequirePermission` or `auth.RequirePermissionForResource`. |
 | Owner endpoint uses plain `RequirePermission` | PDP sees the URL path instead of canonical `resource.id`; ownership rule does not match. | Use `RequirePermissionForResource` with the path-param name. |
 | Composition root omits the Authorizer | Every permission-gated request fails closed. | Install `WithPrimaryAuthorizer` / `PrimaryAuthorizerOption`. |
@@ -86,6 +103,10 @@ Positive examples:
   reads.
 - `cmd/corebundle/run.go` wires the primary Authorizer for the bundled
   accesscore/configcore/auditcore assembly.
+- `examples/todoorder/cells/ordercell/authorizer.go` keeps todoorder's
+  self-contained baseline in the example-owned PDP.
+- `examples/iotdevice/cells/devicecell/authorizer.go` does the same for
+  iotdevice device permissions.
 
 Primary rationale:
 

--- a/docs/guides/cell-authz-rowscope-guide.md
+++ b/docs/guides/cell-authz-rowscope-guide.md
@@ -1,0 +1,94 @@
+# Cell Authorization and RowScope Guide
+
+This guide is the consumer-facing checklist for wiring a business endpoint into
+GoCell's permission-based authorization path. ADRs explain why the model exists;
+this page explains what to change.
+
+## Endpoint Checklist
+
+For each non-public business endpoint:
+
+1. Declare a sealed permission accessor in `framework/pkg/authz/permission.go`.
+   Permissions use resource/action strings such as `config:write`; callers use
+   accessor functions such as `authz.PermConfigWrite()`, never exported vars or
+   raw strings.
+2. Attach the generated handler to the PDP route gate:
+   `auth.RequirePermission(authz.PermXxx())`.
+3. For owner/self endpoints, use
+   `auth.RequirePermissionForResource("pathParam", authz.PermXxx())`. It
+   canonicalizes the path parameter and forwards it as `resource.id` for PDP
+   ownership rules. Do not replace it with plain `RequirePermission`.
+4. Register the baseline grant in
+   `corecells/accesscore/slices/authorizationdecide/baseline.go` when the
+   endpoint should be available to the built-in admin/super-admin or ownership
+   model. A missing baseline means the endpoint is default-deny unless tenant
+   policy grants it.
+5. Wire the composition root so the primary listener gets an Authorizer:
+   `bootstrap.WithPrimaryAuthorizer(authorizer)` or
+   `bootstrap.PrimaryAuthorizerOption(cells)`. Without this, the route gate
+   fails closed.
+6. Add contract/slice coverage for 403 and for the exact permission action passed
+   to the Authorizer. Add e2e coverage when the endpoint depends on baseline
+   registration or composition-root wiring.
+
+## Route Gate vs Data Boundary
+
+`auth.RequirePermission` is a coarse allow/deny gate. It does not enforce
+obligations such as RowScope or FieldMask. If a permit carries a non-zero
+obligation that the route gate cannot discharge, the route gate denies rather
+than silently dropping it.
+
+Data visibility must be enforced where data is read:
+
+- Read/list data PEPs derive `tenant.RowVisibility` from the principal and apply
+  it to the repository query. For audit reads, a tenant policy may widen the
+  route gate, but it cannot widen the principal-derived RowScope.
+- Owner/self route grants only allow the caller through the gate. The data layer
+  still needs its own tenant/RowVisibility checks.
+- Write endpoints generally have no RowScope dimension. Their isolation boundary
+  is the typed tenant axis, ctx tenant propagation, and PostgreSQL FORCE RLS.
+
+## RowScope Values
+
+`tenant.RowScope` has four non-zero values:
+
+| Scope | Meaning | Enforcement location |
+|-------|---------|----------------------|
+| `self` | Caller sees rows whose owner/actor matches the subject. | Data PEP predicate |
+| `device` | Device-scoped variant of self-style visibility. | Data PEP predicate |
+| `tenant` | Caller sees rows in the current tenant. | Typed tenant + RLS + data predicate |
+| `all` | Cross-tenant visibility for explicit admin paths. | Dedicated audited path; serving pools fail closed where unsupported |
+
+Zero RowScope is invalid as principal visibility. Inside `authz.Obligations`,
+zero RowScope means only "this policy did not impose a row-scope obligation."
+The current evaluator merges RowScope only among matching policy permits; data
+PEPs must not assume policy obligations have already been merged with the
+principal-derived RowScope.
+
+## Common Failure Modes
+
+| Failure | Symptom | Fix |
+|---------|---------|-----|
+| Permission minted but no baseline rule | Admin receives 403 from default-deny. | Add the matching baseline rule or document tenant-policy-only access. |
+| Handler uses `auth.AnyRole` | Authorization bypasses the PDP funnel and role-literal governance fails. | Use `auth.RequirePermission` or `auth.RequirePermissionForResource`. |
+| Owner endpoint uses plain `RequirePermission` | PDP sees the URL path instead of canonical `resource.id`; ownership rule does not match. | Use `RequirePermissionForResource` with the path-param name. |
+| Composition root omits the Authorizer | Every permission-gated request fails closed. | Install `WithPrimaryAuthorizer` / `PrimaryAuthorizerOption`. |
+| Route gate assumed to enforce RowScope | A future data PEP may apply a policy-only wider scope. | Merge/enforce principal-derived RowVisibility at the data boundary. |
+
+## Examples
+
+Positive examples:
+
+- `corecells/configcore/slices/configwrite/handler.go` wires
+  `auth.RequirePermission(authz.PermConfigWrite())`.
+- `corecells/accesscore/slices/identitymanage/handler.go` uses
+  `auth.RequirePermissionForResource("id", authz.PermUserRead())` for owner
+  reads.
+- `cmd/corebundle/run.go` wires the primary Authorizer for the bundled
+  accesscore/configcore/auditcore assembly.
+
+Primary rationale:
+
+- Cedar and XACML both keep deny/default-deny and obligation handling explicit.
+- Spring Security role hierarchy is explicit configuration; GoCell likewise uses
+  explicit baseline rules rather than implicit role inheritance.

--- a/docs/guides/cell-development-guide.md
+++ b/docs/guides/cell-development-guide.md
@@ -362,9 +362,11 @@ in handlers. The minimum checklist is:
 2. Wire the generated handler with `auth.RequirePermission(perm)`.
 3. Use `auth.RequirePermissionForResource(pathParam, perm)` for owner/self
    resources so the PDP receives the canonical resource id.
-4. Add the corresponding baseline allow rule in
-   `corecells/accesscore/slices/authorizationdecide/baseline.go`, unless the
-   endpoint is intentionally tenant-policy-only.
+4. Add the corresponding baseline allow rule in the PDP that owns this
+   assembly's rules: platform corecells use
+   `corecells/accesscore/slices/authorizationdecide/baseline.go`; example,
+   external, or self-contained cells keep it in their own `Authorizer()`/PDP.
+   Document tenant-policy-only endpoints explicitly.
 5. Wire the PDP from the composition root with `bootstrap.WithPrimaryAuthorizer`
    or `bootstrap.PrimaryAuthorizerOption`.
 6. Enforce `tenant.RowVisibility` in list/get data PEPs; write endpoints rely on

--- a/docs/guides/cell-development-guide.md
+++ b/docs/guides/cell-development-guide.md
@@ -353,6 +353,27 @@ funnel. ABAC `permission`/`resource`/`action` and `internalOnly` are **not** par
 overlay yet — only `public` is live (the rest are deferred to #2008). See ADR
 `docs/architecture/202605260000-adr-grpc-transport-adapter.md` §"Amendment #1675".
 
+### 6c. Business Endpoint Authorization
+
+Business endpoints are permission-gated through the ABAC PDP, not role literals
+in handlers. The minimum checklist is:
+
+1. Add a sealed permission accessor in `framework/pkg/authz/permission.go`.
+2. Wire the generated handler with `auth.RequirePermission(perm)`.
+3. Use `auth.RequirePermissionForResource(pathParam, perm)` for owner/self
+   resources so the PDP receives the canonical resource id.
+4. Add the corresponding baseline allow rule in
+   `corecells/accesscore/slices/authorizationdecide/baseline.go`, unless the
+   endpoint is intentionally tenant-policy-only.
+5. Wire the PDP from the composition root with `bootstrap.WithPrimaryAuthorizer`
+   or `bootstrap.PrimaryAuthorizerOption`.
+6. Enforce `tenant.RowVisibility` in list/get data PEPs; write endpoints rely on
+   typed tenant inputs plus tenant RLS rather than RowScope.
+7. Add 403 contract coverage and an e2e/slice assertion for the expected
+   permission action.
+
+The full how-to lives in `docs/guides/cell-authz-rowscope-guide.md`.
+
 ### 7. Register Event Subscriptions (Optional)
 
 The sole authoritative source for subscriptions is **`slice.yaml` `contractUsages[role=subscribe]`** — cellgen generates the `reg.Subscribe(...)` call into `cell_gen.go` from this declaration. Manually starting goroutines or calling `Subscriber.Subscribe` directly is forbidden; goroutine lifecycle, error convergence, and Setup/Ready phases are all managed by EventRouter.

--- a/docs/guides/codegen-new-endpoint.md
+++ b/docs/guides/codegen-new-endpoint.md
@@ -148,8 +148,9 @@ import (
     "context"
 
     createg "github.com/ghbvf/gocell/generated/contracts/http/myapp/widgets/create/v1"
-    "github.com/ghbvf/gocell/framework/pkg/errcode"
     kcell "github.com/ghbvf/gocell/framework/kernel/cell"
+    "github.com/ghbvf/gocell/framework/pkg/authz"
+    "github.com/ghbvf/gocell/framework/pkg/errcode"
     "github.com/ghbvf/gocell/framework/runtime/auth"
 )
 
@@ -175,13 +176,39 @@ func (a CreateAdapter) Create(ctx context.Context, req *createg.Request) (create
 type Handler struct{ h *createg.Handler }
 
 func NewHandler(svc *Service) *Handler {
-    return &Handler{h: createg.NewHandler(CreateAdapter{svc}, auth.AnyRole(auth.RoleAdmin))}
+    return &Handler{h: createg.NewHandler(CreateAdapter{svc}, auth.RequirePermission(authz.PermWidgetCreate()))}
 }
 
 func (h *Handler) RegisterRoutes(mux kcell.RouteHandler) error {
     return h.h.RegisterRoutes(mux)
 }
 ```
+
+`authz.PermWidgetCreate()` stands for the sealed permission accessor you add for
+the endpoint. Business endpoints should use `auth.RequirePermission` or
+`auth.RequirePermissionForResource`; `auth.AnyRole` is not the normal endpoint
+authorization path.
+
+### Endpoint authorization checklist
+
+For any non-public business endpoint:
+
+1. Mint a sealed permission accessor in `framework/pkg/authz/permission.go`.
+2. Attach it to the generated handler with `auth.RequirePermission(perm)`.
+3. Use `auth.RequirePermissionForResource(pathParam, perm)` when the endpoint
+   grants owner/self access through PDP ownership rules.
+4. Add the matching built-in baseline rule in
+   `corecells/accesscore/slices/authorizationdecide/baseline.go`, or document why
+   the endpoint is intentionally granted only by tenant policy.
+5. Ensure the composition root wires the PDP into the primary listener through
+   `bootstrap.WithPrimaryAuthorizer` or `bootstrap.PrimaryAuthorizerOption`.
+6. For list/get data, enforce `tenant.RowVisibility` in the data PEP; the route
+   gate only decides coarse allow/deny.
+7. Cover 403 contract behavior plus an e2e or slice test that proves the route
+   uses the expected permission action.
+
+See `docs/guides/cell-authz-rowscope-guide.md` for the full workflow and
+RowScope/RLS boundary rules.
 
 ## Step 4: Wire into the Cell
 

--- a/docs/guides/codegen-new-endpoint.md
+++ b/docs/guides/codegen-new-endpoint.md
@@ -197,9 +197,11 @@ For any non-public business endpoint:
 2. Attach it to the generated handler with `auth.RequirePermission(perm)`.
 3. Use `auth.RequirePermissionForResource(pathParam, perm)` when the endpoint
    grants owner/self access through PDP ownership rules.
-4. Add the matching built-in baseline rule in
-   `corecells/accesscore/slices/authorizationdecide/baseline.go`, or document why
-   the endpoint is intentionally granted only by tenant policy.
+4. Add the matching baseline rule to the PDP that owns this assembly's policy:
+   platform corecells use
+   `corecells/accesscore/slices/authorizationdecide/baseline.go`; example,
+   external, or self-contained cells keep the grant in their own
+   `Authorizer()`/PDP. Document tenant-policy-only endpoints explicitly.
 5. Ensure the composition root wires the PDP into the primary listener through
    `bootstrap.WithPrimaryAuthorizer` or `bootstrap.PrimaryAuthorizerOption`.
 6. For list/get data, enforce `tenant.RowVisibility` in the data PEP; the route

--- a/framework/pkg/authz/obligation.go
+++ b/framework/pkg/authz/obligation.go
@@ -129,10 +129,12 @@ func (fm FieldMask) clone() FieldMask {
 //
 //   - RowScope: the row-visibility predicate the PEP must apply to list/get
 //     queries. A zero RowScope is valid here — it means "this policy does not
-//     itself constrain row scope" (the policy obligation is absent). The
-//     *effective* row scope for a request is resolved by the PR-7 evaluator,
-//     which combines all policy obligations with the principal→RowScope
-//     derivation (PR-5). Only a non-zero RowScope carries an explicit
+//     itself constrain row scope" (the policy obligation is absent). The current
+//     PR-7 evaluator combines RowScope obligations only among matching permit
+//     rules, choosing the narrowest policy-imposed scope. It does NOT yet merge
+//     those policy obligations with the principal→RowScope derivation (PR-5);
+//     data PEPs that need an effective request scope must perform that merge at
+//     the enforcement boundary. Only a non-zero RowScope carries an explicit
 //     obligation; it must be a valid tenant.RowScope value.
 //
 //   - FieldMask: the set of columns to mask in the response. An empty FieldMask
@@ -142,10 +144,10 @@ func (fm FieldMask) clone() FieldMask {
 // GoCell only models mandatory obligations in this type.
 type Obligations struct {
 	// RowScope is the row-visibility obligation. A zero value is valid and
-	// means "this policy does not impose a row-scope constraint"; the PR-7
-	// evaluator resolves the effective scope from all applicable obligations
-	// combined with the principal→RowScope derivation (PR-5). A non-zero
-	// value must pass tenant.RowScope.Validate().
+	// means "this policy does not impose a row-scope constraint"; the current
+	// evaluator merges only matching policy-permit obligations and leaves any
+	// principal-derived RowScope merge to the data PEP. A non-zero value must
+	// pass tenant.RowScope.Validate().
 	RowScope tenant.RowScope
 	// FieldMask specifies which response columns to mask. An empty FieldMask
 	// is valid (no masking required).

--- a/framework/runtime/audit/ledger/mem_store.go
+++ b/framework/runtime/audit/ledger/mem_store.go
@@ -268,7 +268,8 @@ func auditEntryNotFoundByID() error {
 // takes the explicit typed tenant t (the post-auth http.audit.get.v1 funnel, like
 // Query) rather than the ctx scope: it scans t's chain PLUS the "" system chain
 // (the mem analog of the PG `(tenant_id = ” OR tenant_id = $t)` predicate + FORCE
-// RLS), so a cross-tenant id read finds nothing.
+// RLS). The "" chain is a shared pre-auth/system signal surface; an id from a
+// different non-empty tenant still finds nothing.
 func (m *MemStore) GetByID(_ context.Context, t tenant.TenantID, vis tenant.RowVisibility, id string) (*Entry, error) {
 	if err := ValidateQueryTenant(t); err != nil {
 		return nil, err
@@ -499,8 +500,9 @@ func contentFingerprint(e *Entry) string {
 // tenantMatches mirrors the PG store's tenant predicate `(tenant_id = ” OR
 // tenant_id = $N)` exactly, where $N is the query tenant (#1618). A non-empty
 // query tenant matches its OWN tenant's chain PLUS the tenant-less
-// system/framework chain (entryTenant == "" — e.g. bootstrap.auth.fail), never
-// another tenant's rows. An EMPTY query tenant (queryTenant == "") collapses the
+// system/framework chain (entryTenant == "" — e.g. bootstrap.auth.fail). That
+// empty chain is shared operational signal, while another non-empty tenant's
+// rows never match. An EMPTY query tenant (queryTenant == "") collapses the
 // PG predicate to `tenant_id = ”` → system rows ONLY (NOT "all"): a tenant-less
 // query is fail-closed and can never read another tenant's rows. The query
 // tenant is the mandatory Store.Query t parameter, always non-empty in


### PR DESCRIPTION
## Summary

收口 authz/tenancy 文档与 godoc 漂移：区分 audit read 的 RowScope 数据边界与 config write 的 tenant/RLS 边界，补齐消费者接线 guide，并修正 052 RLS migration 的 stale SystemTenantID 注释。

## Why / 背景

- #1983：ADR、tenancy rule 和 godoc 把 RowScope/RLS、obligation 合流、`tenant_id == ""` 系统链表述压缩得不够准确。
- #1984：guides 缺少 `RequirePermission` / RowScope / PDP 接线的 how-to 单源，新增端点容易漏 baseline 或 Authorizer wiring。
- #1744：migration 052 注释仍描述 #1577 已删除的 SystemTenantID nil-UUID config tier。

## Refs

Closes #1983
Closes #1984
Closes #1744

ref: Cedar authorization default-deny / forbid-overrides docs
ref: XACML 3.0 obligations model
ref: Spring Security RoleHierarchy explicit role hierarchy source

## Risk / 兼容性

无 runtime 行为、Go API、wire contract、DDL 或 schema 变更。

`adapters/postgres/migrations/052_tenant_rls_force.sql` 仅修改 SQL 注释，不改变已应用 migration 的 DDL 语义或 schema shape。

## Test plan

- [x] `go test ./framework/pkg/authz ./framework/runtime/audit/ledger`
- [x] `go run ./cmd/gocell validate --strict`（0 errors；2 个既有 journey lifecycle warnings）
- [x] `make check-build`
- [x] `make test`
- [x] `bash hack/verify-gofumpt.sh`
- [ ] `make verify`（已完整运行；失败来自当前 develop 基线 archtest，已在干净根目录复现）

Develop 基线 archtest failures:

- `CONTRACT-PATH-QUERY-COVERAGE-01`: `contracts/http/audit/get/v1/contract.yaml` pathParam `id` 缺既有 `MustRejectPathParam` call site。
- `MANAGED-RESOURCE-COMPLETENESS-01: adapter exported types`: 当前 develop 根目录同规则失败。
- `POSTGRES-NOTFOUND-TEST-OTHER-ERROR-MIXUP-ARCHTEST-01`: `framework/runtime/audit/ledger/storetest/suite.go:1927` 既有 `_NotFound` 测试缺 typed errcode assertion。
