### PR TITLE
feat(bootstrap): #2152 relay 运行期 fan-out seam（keyed-by-instance）[1423-US6]

### DIFF
--- a/cellmodules/configcore/storage.go
+++ b/cellmodules/configcore/storage.go
@@ -94,7 +94,7 @@ func buildConfigCorePostgresOpts(clk clock.Clock, cfg configCoreModuleConfig) (c
 	}
 	return configCoreModuleResult{
 		cellOptions:   cellOpts,
-		bootstrapOpts: []bootstrap.Option{bootstrap.WithRelay(relayWorker)},
+		bootstrapOpts: []bootstrap.Option{bootstrap.WithRelay(bootstrap.DefaultInstanceKey(), relayWorker)},
 	}, nil
 }
 

--- a/docs/architecture/202605201400-adr-relay-managedresource-isolation.md
+++ b/docs/architecture/202605201400-adr-relay-managedresource-isolation.md
@@ -156,6 +156,73 @@ Repro: go test ./tools/archtest -run 'TestRELAY_NOT_MANAGEDRESOURCE_01' -count=1
 Dependent contracts (governance scan): none — ManagedResource interface signature unchanged
 ```
 
+## Amendment 2026-06-18 — #2152 PR-1：relay 运行期 fan-out（keyed-by-instance）
+
+> 本 amendment 重写上文 §Decision D2 与 §威胁矩阵中「单 relay per Bootstrap」的隐含前提。
+> 原文针对 PR #593 单 relay 边界 bug；#2152 把 relay 通道提升为按去重基建实例 keyed 的集合。
+
+### 背景
+
+#1964（PR #2151，MERGED）落地 per-cell DB 凭据/连接 seam（`cellmodules/percellpg`），但运行期
+relay 仍是单例：`WithRelay` 第二次调用 panic（单 relay 不变式），故 distinct per-cell 基建连接
+无法真正运行（percellpg 对 >1 distinct DSN fail-closed）。#2152 PR-1 建立 **bootstrap relay
+fan-out seam**：relay 通道一体重构为「按去重基建实例 keyed」集合。
+
+### 变更
+
+- **keying 维度 = sealed `InfraInstanceKey`**（`runtime/bootstrap/infra_instance_key.go`）：
+  unexported `id` 字段 → 包外不可 struct-literal 伪造非默认值（Hard sealed construction）；
+  `DefaultInstanceKey()` = 零值（colocated 单实例哨兵），`NewInfraInstanceKey(id)` 在 mint 期
+  校验 id 为 snake_case 标识符（≤32）。**该键在 PR-1 冻结，PR-2 复用给 pub/sub，不改键、不重写
+  relay 第二遍。**
+- **`WithRelay(key, r)`**：`b.relay *Relay` 单字段 → `b.relaysByInstance map[InfraInstanceKey]*Relay`。
+  同 key 重绑 panic（语义从「per Bootstrap 唯一」→「per instance key 唯一」，仍防 double-managed
+  危害）；不同 key 累加（fan-out），各 append 一个 `relayAdapter`。
+- **`relayAdapter` 结构不变**——仍包单个 relay；现在有 N 个实例。LIFO teardown（slice）天然支持 N。
+  唯一新增：非默认实例的 relay 操作 probe 经 sanctioned `healthz.RelayInstanceProbeName` 按 instance
+  id 命名空间化（`outbox_relay_poll_<id>`），避免 N relay 在全局 probe 名冲突；colocated 默认实例
+  probe 名不变（运维契约保持）。relay_adapter.go 因此进 `PROBENAME-SEALED-FUNNEL-01/A2` 内部
+  allowlist（与 emitter/projection/tailer 同族 composed-name 构造）。
+- **`pub/sub` 通道不动**（仍单例）：relay 各自在构造期已持自己的 publisher，故 relay 通道独立可 key；
+  broker（pub/sub）fan-out 归 PR-2。
+- **不在本 PR**：`percellpg` fail-closed 保留（生产 per-cell-provider 馈送未接前放行 distinct DSN 会
+  不一致）；composition `SharedDeps.PG` 单例→per-cell 线程化、`cap_wiring` 开 N 池 = follow-up issue。
+
+### `RELAY-SOLE-HOLDER-01` 重写（D4 扩展，Hard 不变）
+
+`RELAY-NOT-MANAGEDRESOURCE-01` 不变。`RELAY-SOLE-HOLDER-01`（原 PR-593 后续新增）**直接重写**为
+keyed-by-instance 不变式（不走「先保留后推翻」）：
+
+- 保留**类型级 sole-holder**：ManagedResource 实现者中只有 `relayAdapter` 类型可持 relay。N 个
+  relayAdapter **实例**合法（即 fan-out）；替代 holder **类型**仍拒。
+- **强化**：`fieldHoldsRelay` 递归 slice/array/map element——任何 MR 类型持 `[]*Relay`/`map[K]*Relay`
+  relay 集合都被拒（堵 keyed 世界出现的「替代 collection-holder MR」绕过路径）。fan-out 集合本身
+  （`Bootstrap.relaysByInstance`）合法且不被扫描：`*Bootstrap` 不实现 ManagedResource。
+- 新增 synthetic-type 单测 `TestFieldHoldsRelay_DetectsCollections` 证明 collection 递归非空挂。
+
+### 威胁矩阵（重评，supersede 上文相关行）
+
+| 威胁 | 本 amendment 后状态 |
+|------|--------------------|
+| 同一 instance key 二次 `WithRelay` | panic via panicregister.Approved（B 类）fail-fast（上文行的 keyed 化等价物） |
+| 不同 instance key `WithRelay`（fan-out） | **合法累加**（上文「静默覆盖」行在 keyed 模型下被此取代：不同实例本就该各有 relay） |
+| 替代 ManagedResource 类型持 `*Relay` 或 `[]*Relay`/`map[K]*Relay` relay 集合 | archtest `RELAY-SOLE-HOLDER-01` 红（强化后含 collection） |
+| N relay 全局 probe 名冲突 | `expandManagedResources` fail-fast；非默认实例经 `RelayInstanceProbeName` 命名空间化避免 |
+| 未来恢复 `Close` 方法绕过 type isolation | `RELAY-NOT-MANAGEDRESOURCE-01` 红（不变） |
+
+### 影响面（增量）
+
+| 文件 | 变更 |
+|------|------|
+| `runtime/bootstrap/infra_instance_key.go` | **新增** sealed `InfraInstanceKey` + 2 minter |
+| `runtime/bootstrap/bootstrap.go` | `relay` 单字段 → `relaysByInstance` keyed map |
+| `runtime/bootstrap/options_events.go` | `WithRelay(key, r)`；同-key panic；godoc |
+| `runtime/bootstrap/relay_adapter.go` | `newRelayAdapter(key, r)`；非默认实例 probe 命名空间化 |
+| `kernel/healthz/probename.go` | **新增** `RelayInstanceProbeName` composed-name 构造器 |
+| `tools/archtest/relay_isolation_test.go` | `RELAY-SOLE-HOLDER-01` keyed 重写 + collection 强化 + synthetic 单测 |
+| `tools/archtest/probename_sealed_funnel_test.go` | A2 内部 allowlist 加 relay_adapter.go |
+| `cellmodules/configcore/storage.go`、`examples/{iotdevice,ssobff}` | `WithRelay(DefaultInstanceKey(), r)` |
+
 ## 参考
 
 - 上游 backlog: `docs/backlog/20260520/202605191800-pr589-review-fixup-backlog.md`

--- a/docs/ops/readyz.md
+++ b/docs/ops/readyz.md
@@ -612,9 +612,12 @@ get an instance-scoped name:
   (a lowercase snake_case identifier ≤32 chars; composition roots SHOULD use a semantic id
   such as the owning cell id, not a physical-resource fragment). Naming is composed via the
   sanctioned `healthz.RelayInstanceProbeName` constructor.
-- **When they appear**: only when a composition root registers ≥2 relays (distinct
-  `InfraInstanceKey`s). The default single-relay colocated deployment keeps the bare names, so
-  existing dashboards/alerts on `outbox_relay_*` are unaffected.
+- **When they appear**: the suffix is keyed on the InfraInstanceKey, not on relay count — a relay
+  registered under ANY non-default key (`bootstrap.NewInfraInstanceKey(...)`) always gets the
+  `_<instanceID>` suffix; the colocated `DefaultInstanceKey()` always keeps the bare names. Today
+  every deployment uses only the default key (single colocated relay; see the NB below), so the
+  bare `outbox_relay_*` names are what dashboards/alerts see — but the contract is key-based, not
+  count-based.
 - **On-call attribution**: an unhealthy `outbox_relay_poll_<id>` identifies which infra
   instance's relay is failing (poll/reclaim/cleanup budget tripped); the bare-named probe is
   the colocated default. Two relays can never collide — bootstrap's `expandManagedResources`

--- a/docs/ops/readyz.md
+++ b/docs/ops/readyz.md
@@ -594,6 +594,38 @@ statuses:
 Ops diagnostics for `CompensationFailed` instances use the `saga_events` table
 (see `docs/ops/saga-runbook.md` §场景 2), not readyz.
 
+## Per-instance relay probes (relay fan-out, #2152) — `outbox_relay_<op>_<instanceID>`
+
+The outbox relay exposes three operation probes — `outbox_relay_poll`,
+`outbox_relay_reclaim`, `outbox_relay_cleanup` (see §Recent breaking changes / PR #1187).
+As of #2152 (PR-1) bootstrap supports **relay fan-out**: a deployment may register more
+than one relay, one per deduplicated infrastructure instance (`bootstrap.WithRelay(key, r)`).
+Because `/readyz` requires globally-unique probe names, the relays of NON-default instances
+get an instance-scoped name:
+
+| Instance | Probe names |
+|----------|-------------|
+| **colocated default** (`DefaultInstanceKey`, the only instance today) | `outbox_relay_poll` / `outbox_relay_reclaim` / `outbox_relay_cleanup` (**unchanged**) |
+| additional instance with id `<instanceID>` | `outbox_relay_poll_<instanceID>` / `outbox_relay_reclaim_<instanceID>` / `outbox_relay_cleanup_<instanceID>` |
+
+- The suffix `<instanceID>` is the instance id passed to `bootstrap.NewInfraInstanceKey`
+  (a lowercase snake_case identifier ≤32 chars; composition roots SHOULD use a semantic id
+  such as the owning cell id, not a physical-resource fragment). Naming is composed via the
+  sanctioned `healthz.RelayInstanceProbeName` constructor.
+- **When they appear**: only when a composition root registers ≥2 relays (distinct
+  `InfraInstanceKey`s). The default single-relay colocated deployment keeps the bare names, so
+  existing dashboards/alerts on `outbox_relay_*` are unaffected.
+- **On-call attribution**: an unhealthy `outbox_relay_poll_<id>` identifies which infra
+  instance's relay is failing (poll/reclaim/cleanup budget tripped); the bare-named probe is
+  the colocated default. Two relays can never collide — bootstrap's `expandManagedResources`
+  fails startup fast on a duplicate probe name.
+- This is an **ops contract**: the `<base>_<instanceID>` shape and the default-instance
+  bare-name invariant must stay in sync with dashboards and alerts.
+
+> NB: per-instance relays only become reachable once the composition root actually opens N
+> distinct per-cell pools (the `cellmodules/percellpg` feeder, a follow-up to #2152 PR-1).
+> Until then every deployment uses the single colocated default and the bare names only.
+
 ## Cross-cell remote-peer readiness probes (split topology) — `<cell>_remote_ready`
 
 In a **split topology** (a cell's cross-cell HTTP dependency is deployed in a

--- a/docs/patterns/pg-cell-template.md
+++ b/docs/patterns/pg-cell-template.md
@@ -305,7 +305,7 @@ func buildFooCoreOpts(clk clock.Clock, cfg fooCoreModuleConfig) (fooCoreModuleRe
 		}
 		return fooCoreModuleResult{
 			cellOptions:   cellOpts,
-			bootstrapOpts: []bootstrap.Option{bootstrap.WithRelay(relayWorker)},
+			bootstrapOpts: []bootstrap.Option{bootstrap.WithRelay(bootstrap.DefaultInstanceKey(), relayWorker)},
 			// provisional is empty for foocore postgres path — pool is owned by
 			// shared.PG (shared across cells); only cell-exclusive resources go here.
 		}, nil
@@ -362,14 +362,18 @@ Close）；单源把两个阶段绑定到**同一个** `Resources` 声明——�
 > steady-state 路径只在**成功**时由 `bootstrap.Run` 接管——两条路径互斥，同一资源在 bootstrap
 > managed 集合中至多出现一次。
 
-后台 worker 型资源（例如 outbox relay）走独立的 `bootstrap.WithRelay(relayWorker)` 进
-`ModuleResult.Opts`（**不**进 `Resources`、**不**经 `WithManagedResource`）。`WithRelay` 是
-relay 的 **唯一** 注册入口：相关的 `Checkers()/Worker()/Close()` 由 package-private
+后台 worker 型资源（例如 outbox relay）走独立的
+`bootstrap.WithRelay(bootstrap.DefaultInstanceKey(), relayWorker)` 进 `ModuleResult.Opts`
+（**不**进 `Resources`、**不**经 `WithManagedResource`）。`WithRelay` 第一参是
+`bootstrap.InfraInstanceKey`——共址（colocated）单池用 `bootstrap.DefaultInstanceKey()`；split
+拓扑下每个去重基建实例用 `bootstrap.NewInfraInstanceKey(<id>)` 各注册一个 relay（#2152 PR-1 fan-out）。
+`WithRelay` 是 relay 的 **唯一** 注册入口：相关的 `Checkers()/Worker()/Close()` 由 package-private
 `relayAdapter` 包装到 ManagedResource 流水线（详见 ADR
 `docs/architecture/202605201400-adr-relay-managedresource-isolation.md` + archtest
 `RELAY-NOT-MANAGEDRESOURCE-01` / `RELAY-SOLE-HOLDER-01`）——`*Relay` 自身不实现
-ManagedResource，直接传给 `WithManagedResource` 是编译期 type-mismatch，二次调用 `WithRelay`
-会通过 panic-taxonomy funnel 触发 `panicregister.Approved + errcode.Assertion(B 类)` panic。
+ManagedResource，直接传给 `WithManagedResource` 是编译期 type-mismatch；对**同一 instance key**
+二次调用 `WithRelay` 会通过 panic-taxonomy funnel 触发
+`panicregister.Approved + errcode.Assertion(B 类)` panic（不同 key 累加 = 正常 fan-out）。
 **共享** PG pool 由 `SharedDeps.PG` 持有，其 ManagedResource 在 composition root 的 base
 options 中先于所有 cell opts 注册 → LIFO 下最后 Close（晚于每个 cell 的 relay）；只有 cell
 **独占**的资源才进 `ModuleResult.Resources`。foocore 走共享 pool，故其 `Resources` 为空，
@@ -378,7 +382,7 @@ options 中先于所有 cell opts 注册 → LIFO 下最后 Close（晚于每个
 ```
 每个 module Provide 返回 ModuleResult{Cell, Opts, Resources}:
   Resources = [resX]                        // 单源——Builder 派生 steady-state + rollback
-  Opts      = [..., bootstrap.WithRelay(w)] // 后台 worker（非 ManagedResource）
+  Opts      = [..., bootstrap.WithRelay(DefaultInstanceKey(), w)] // 后台 worker（非 ManagedResource）
 
 —— 全部成功 ——
 Builder 从各 module 的 Resources 派生 WithManagedResource(resX)

--- a/examples/iotdevice/run.go
+++ b/examples/iotdevice/run.go
@@ -273,7 +273,8 @@ func runIotdevice(ctx context.Context, assemblyID string, assemblyCellIDs []stri
 	}
 	// Relay registered LAST → stopped FIRST (LIFO): the relay must stop before the
 	// pool closes (durable) so no in-flight poll touches a closed pool.
-	opts = append(opts, bootstrap.WithRelay(crs.relay))
+	// Colocated single-pod: one relay under the default infra instance (#2152 PR-1).
+	opts = append(opts, bootstrap.WithRelay(bootstrap.DefaultInstanceKey(), crs.relay))
 	app := bootstrap.New(clk, opts...)
 
 	logger.Info("iotdevice: starting on :8083; protected routes require an RS256 bearer token")

--- a/examples/ssobff/app.go
+++ b/examples/ssobff/app.go
@@ -300,7 +300,8 @@ func buildSSOBFFBootstrapOptions(
 		opts = append(opts, bootstrap.WithManagedResource(mr))
 	}
 	// LIFO close: relay registered last → stopped first; relay must stop before pool closes.
-	opts = append(opts, bootstrap.WithRelay(relayWorker))
+	// Colocated single-pod: one relay under the default infra instance (#2152 PR-1).
+	opts = append(opts, bootstrap.WithRelay(bootstrap.DefaultInstanceKey(), relayWorker))
 	// ABAC PDP injector for the primary listener (#1348 PR-10a) + the mandatory gRPC
 	// listener (accesscore registers grpc.auth.session.verify.v1 unconditionally, #1154).
 	opts = append(opts, authGRPCOpts...)

--- a/framework/kernel/healthz/probename.go
+++ b/framework/kernel/healthz/probename.go
@@ -155,23 +155,44 @@ func EmitterFailOpenProbeName(cellID string) (ProbeName, error) {
 	return NewProbeName(emitterFailOpenProbeNamePrefix + cellID)
 }
 
+// relayOperationProbeBases is the CLOSED set of base names RelayInstanceProbeName
+// accepts — the three outbox relay operation probes. Values mirror
+// runtime/outbox.{ProbePoll,ProbeReclaim,ProbeCleanup}; healthz cannot import
+// runtime/outbox (import cycle), so they are mirrored here and kept honest
+// fail-closed: a relay base rename in runtime/outbox makes the composer reject
+// the new name (relay registration then fails fast, caught by the bootstrap
+// fan-out tests), never silently composing a stale name.
+var relayOperationProbeBases = map[ProbeName]struct{}{
+	"outbox_relay_poll":    {},
+	"outbox_relay_reclaim": {},
+	"outbox_relay_cleanup": {},
+}
+
 // RelayInstanceProbeName composes the instance-scoped variant of an outbox
-// relay operation probe (base is one of outbox_relay_poll / _reclaim / _cleanup)
-// for a fanned-out relay that is NOT the colocated default infra instance, so N
-// relays expose globally-distinct probe names (#2152 PR-1). The colocated
-// default keeps the bare base name (operations contract unchanged); only
-// additional instances get the "<base>_<instanceID>" suffix.
+// relay operation probe (base MUST be one of outbox_relay_poll / _reclaim /
+// _cleanup — enforced against a closed allowlist) for a fanned-out relay that is
+// NOT the colocated default infra instance, so N relays expose globally-distinct
+// probe names (#2152 PR-1). The colocated default keeps the bare base name
+// (operations contract unchanged); only additional instances get the
+// "<base>_<instanceID>" suffix.
 //
-// instanceID is the deduplicated infra instance id (a lowercase snake_case
-// identifier minted by the composition root). It is validated against the full
-// [NewProbeName] shape via the composed result, so an invalid id surfaces at
-// relay registration rather than per-probe invocation. This is the SOLE
-// sanctioned composed-name constructor for relay-instance probes — a sibling of
-// EmitterFailOpenProbeName / ProjectionStoreReadyProbeName / SagaTailerReadyProbeName.
+// base is validated against relayOperationProbeBases so this relay-specific
+// constructor cannot mint a misleading "outbox_relay_*"-shaped name from an
+// arbitrary ProbeName. instanceID is the deduplicated infra instance id (a
+// lowercase snake_case identifier minted by the composition root), validated
+// against the full [NewProbeName] shape via the composed result, so an invalid
+// id surfaces at relay registration rather than per-probe invocation. This is
+// the SOLE sanctioned composed-name constructor for relay-instance probes — a
+// sibling of EmitterFailOpenProbeName / ProjectionStoreReadyProbeName /
+// SagaTailerReadyProbeName.
 //
 // Budget: longest relay base "outbox_relay_cleanup" (20) + "_" + instanceID
 // (≤32, runtime/bootstrap.infraInstanceIDMaxLen) = ≤53 < probeNameMaxLen (64).
 func RelayInstanceProbeName(base ProbeName, instanceID string) (ProbeName, error) {
+	if _, ok := relayOperationProbeBases[base]; !ok {
+		return "", errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"healthz: relay instance probe base must be an outbox relay operation probe (outbox_relay_poll/reclaim/cleanup)")
+	}
 	if instanceID == "" {
 		return "", errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			"healthz: relay instance probe id must not be empty")

--- a/framework/kernel/healthz/probename.go
+++ b/framework/kernel/healthz/probename.go
@@ -155,6 +155,27 @@ func EmitterFailOpenProbeName(cellID string) (ProbeName, error) {
 	return NewProbeName(emitterFailOpenProbeNamePrefix + cellID)
 }
 
+// RelayInstanceProbeName composes the instance-scoped variant of an outbox
+// relay operation probe (base is one of outbox_relay_poll / _reclaim / _cleanup)
+// for a fanned-out relay that is NOT the colocated default infra instance, so N
+// relays expose globally-distinct probe names (#2152 PR-1). The colocated
+// default keeps the bare base name (operations contract unchanged); only
+// additional instances get the "<base>_<instanceID>" suffix.
+//
+// instanceID is the deduplicated infra instance id (a lowercase snake_case
+// identifier minted by the composition root). It is validated against the full
+// [NewProbeName] shape via the composed result, so an invalid id surfaces at
+// relay registration rather than per-probe invocation. This is the SOLE
+// sanctioned composed-name constructor for relay-instance probes — a sibling of
+// EmitterFailOpenProbeName / ProjectionStoreReadyProbeName / SagaTailerReadyProbeName.
+func RelayInstanceProbeName(base ProbeName, instanceID string) (ProbeName, error) {
+	if instanceID == "" {
+		return "", errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			"healthz: relay instance probe id must not be empty")
+	}
+	return NewProbeName(string(base) + "_" + instanceID)
+}
+
 // remoteCellReadyProbeNameSuffix is the terminal segment of the cross-cell
 // remote-peer readiness probe name ("<cellID>_remote_ready"). It is a
 // dependency-availability probe (the remote peer's listener is TCP-reachable),

--- a/framework/kernel/healthz/probename.go
+++ b/framework/kernel/healthz/probename.go
@@ -168,6 +168,9 @@ func EmitterFailOpenProbeName(cellID string) (ProbeName, error) {
 // relay registration rather than per-probe invocation. This is the SOLE
 // sanctioned composed-name constructor for relay-instance probes — a sibling of
 // EmitterFailOpenProbeName / ProjectionStoreReadyProbeName / SagaTailerReadyProbeName.
+//
+// Budget: longest relay base "outbox_relay_cleanup" (20) + "_" + instanceID
+// (≤32, runtime/bootstrap.infraInstanceIDMaxLen) = ≤53 < probeNameMaxLen (64).
 func RelayInstanceProbeName(base ProbeName, instanceID string) (ProbeName, error) {
 	if instanceID == "" {
 		return "", errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,

--- a/framework/kernel/healthz/probename_test.go
+++ b/framework/kernel/healthz/probename_test.go
@@ -202,6 +202,25 @@ func TestRelayInstanceProbeName_Invalid(t *testing.T) {
 	}
 }
 
+// TestRelayInstanceProbeName_InvalidBase verifies the base allowlist (F2 #2338):
+// a non-relay-operation base must be rejected, so this relay-specific composer
+// cannot mint a misleading "outbox_relay_*"-shaped name from an arbitrary
+// ProbeName. The three real relay bases must be accepted.
+func TestRelayInstanceProbeName_InvalidBase(t *testing.T) {
+	t.Parallel()
+
+	for _, bad := range []ProbeName{"postgres_ready", "outbox_relay", "outbox_relay_poll_extra", "config_watcher", ""} {
+		if _, err := RelayInstanceProbeName(bad, "poola"); err == nil {
+			t.Errorf("RelayInstanceProbeName(base=%q) expected error, got nil", bad)
+		}
+	}
+	for _, ok := range []ProbeName{"outbox_relay_poll", "outbox_relay_reclaim", "outbox_relay_cleanup"} {
+		if _, err := RelayInstanceProbeName(ok, "poola"); err != nil {
+			t.Errorf("RelayInstanceProbeName(base=%q) unexpected error: %v", ok, err)
+		}
+	}
+}
+
 func TestProjectionStoreReadyProbeName(t *testing.T) {
 	t.Parallel()
 

--- a/framework/kernel/healthz/probename_test.go
+++ b/framework/kernel/healthz/probename_test.go
@@ -145,6 +145,63 @@ func TestEmitterFailOpenProbeName_InvalidCellID(t *testing.T) {
 	}
 }
 
+func TestRelayInstanceProbeName_Valid(t *testing.T) {
+	t.Parallel()
+
+	got, err := RelayInstanceProbeName(ProbeName("outbox_relay_poll"), "poola")
+	if err != nil {
+		t.Fatalf("RelayInstanceProbeName unexpected error: %v", err)
+	}
+	if want := ProbeName("outbox_relay_poll_poola"); got != want {
+		t.Errorf("RelayInstanceProbeName = %q, want %q", got, want)
+	}
+}
+
+// TestRelayInstanceProbeName_MaxBudget exercises the worst-case composed length:
+// the longest relay base ("outbox_relay_cleanup", 20) + "_" + a 32-char instance
+// id (runtime/bootstrap.infraInstanceIDMaxLen) = 53 chars, which must stay within
+// probeNameMaxLen (64). This is the executable proof behind the "unreachable
+// panic" claim in runtime/bootstrap/relay_adapter.go: any id accepted at key mint
+// composes into a valid probe name.
+func TestRelayInstanceProbeName_MaxBudget(t *testing.T) {
+	t.Parallel()
+
+	id := strings.Repeat("a", 32)
+	got, err := RelayInstanceProbeName(ProbeName("outbox_relay_cleanup"), id)
+	if err != nil {
+		t.Fatalf("RelayInstanceProbeName(longest base, 32-char id) unexpected error: %v", err)
+	}
+	if want := ProbeName("outbox_relay_cleanup_" + id); got != want {
+		t.Errorf("RelayInstanceProbeName(max budget) = %q, want %q", got, want)
+	}
+	if len(string(got)) > probeNameMaxLen {
+		t.Fatalf("composed name %d chars exceeds probeNameMaxLen %d", len(string(got)), probeNameMaxLen)
+	}
+}
+
+func TestRelayInstanceProbeName_Invalid(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		id   string
+	}{
+		{"empty", ""},
+		{"hyphen", "pool-a"},
+		{"uppercase", "PoolA"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := RelayInstanceProbeName(ProbeName("outbox_relay_poll"), tc.id)
+			if err == nil {
+				t.Errorf("RelayInstanceProbeName(id=%q) expected error, got nil", tc.id)
+			}
+		})
+	}
+}
+
 func TestProjectionStoreReadyProbeName(t *testing.T) {
 	t.Parallel()
 

--- a/framework/runtime/bootstrap/bootstrap.go
+++ b/framework/runtime/bootstrap/bootstrap.go
@@ -154,8 +154,12 @@ type Bootstrap struct {
 	routerReadyTimeout     time.Duration
 	routerReadyTimeoutSet  bool
 	subscriptionValidators []cell.SubscriptionValidator
-	relay                  *runtimeoutbox.Relay                   // optional: wired by WithRelay; nil = no relay depth metric
-	configEventCollector   metricsmiddleware.ConfigEventCollector // optional: settlement observer injected via WrapConfigEventSubscriber
+	// relaysByInstance holds the fanned-out relays keyed by deduplicated infra
+	// instance (#2152 PR-1). Empty = no relay; each entry gets its own
+	// relayAdapter in managedResources. Colocated registers one under
+	// DefaultInstanceKey (behavior unchanged); split registers one per instance.
+	relaysByInstance     map[InfraInstanceKey]*runtimeoutbox.Relay
+	configEventCollector metricsmiddleware.ConfigEventCollector // optional: settlement observer injected via WrapConfigEventSubscriber
 
 	// --- lifecycle: kernel/cell Lifecycle + ManagedResource + shutdown budgets ---
 	lifecycle                Lifecycle

--- a/framework/runtime/bootstrap/infra_instance_key.go
+++ b/framework/runtime/bootstrap/infra_instance_key.go
@@ -55,14 +55,19 @@ type InfraInstanceKey struct {
 
 // NewInfraInstanceKey mints the key for a deduplicated infrastructure instance.
 // Composition roots call it once per distinct instance with a stable, probe-safe
-// id (e.g. a DSN-derived lowercase snake_case identifier). It panics through the
-// panic-taxonomy funnel on an empty or malformed id: minting a key with an
-// unusable instance id is a composition-time programmer error, not a runtime
-// condition. Use DefaultInstanceKey for the single colocated instance.
+// id. Prefer a SEMANTIC identifier (e.g. the owning cell id like "accesscore")
+// over a physical-resource identifier (host/role/credential fragments): the id
+// is embedded in per-instance relay probe names that surface on /readyz?verbose
+// (RelayInstanceProbeName), so a semantic id both reads better for on-call
+// attribution and avoids leaking infrastructure topology onto the health wire.
+// It panics through the panic-taxonomy funnel on an empty or malformed id:
+// minting a key with an unusable instance id is a composition-time programmer
+// error, not a runtime condition. Use DefaultInstanceKey for the single
+// colocated instance.
 func NewInfraInstanceKey(id string) InfraInstanceKey {
 	if id == "" || len(id) > infraInstanceIDMaxLen || !infraInstanceIDPattern.MatchString(id) {
 		panic(panicregister.Approved("bootstrap-infra-instance-key-invalid",
-			errcode.Assertion("bootstrap: NewInfraInstanceKey id must be a non-empty lowercase snake_case identifier (<=32 chars)")))
+			errcode.Assertion("bootstrap: NewInfraInstanceKey id %q must be a non-empty lowercase snake_case identifier (<=32 chars)", id)))
 	}
 	return InfraInstanceKey{id: id}
 }

--- a/framework/runtime/bootstrap/infra_instance_key.go
+++ b/framework/runtime/bootstrap/infra_instance_key.go
@@ -1,0 +1,77 @@
+package bootstrap
+
+// infra_instance_key.go — sealed identity for a deduplicated infrastructure
+// instance, the keying dimension of bootstrap's runtime fan-out (#2152 PR-1).
+//
+// A colocated assembly has exactly ONE infra instance (the shared pool/broker),
+// so every relay registers under DefaultInstanceKey and behavior is unchanged.
+// A split assembly mints one key per distinct deduplicated instance (e.g. a
+// per-cell DSN-derived id) so each instance's relay fans out independently.
+//
+// PR-1 keys the relay channel only (each relay already holds its own publisher,
+// so the relay collection is independent of the publisher/subscriber channels).
+// PR-2 (broker instance dedup) reuses THIS SAME key type to fan out the
+// publisher/subscriber channels — the keying dimension is frozen here and not
+// rewritten downstream.
+//
+// ref: runtime/transport.TransportMode — sealed value via an unexported field +
+// constructor accessors; external packages cannot mint a non-default value.
+
+import (
+	"regexp"
+
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/panicregister"
+)
+
+// infraInstanceIDPattern constrains a non-default instance id to a lowercase
+// snake_case identifier (no leading digit, no consecutive/trailing underscore,
+// no hyphen/uppercase). The constraint exists so the id composes directly into a
+// valid healthz probe name ("<base>_<id>"): a fanned-out relay exposes
+// per-instance health probes via healthz.RelayInstanceProbeName, which fails on a
+// non-snake_case id. Keeping the contract at the key mint surfaces a bad id at
+// the source rather than at relay registration.
+var infraInstanceIDPattern = regexp.MustCompile(`^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$`)
+
+// infraInstanceIDMaxLen bounds the id so the longest composed relay probe name
+// ("outbox_relay_cleanup_" = 21 + id) stays within healthz probeNameMaxLen (64).
+const infraInstanceIDMaxLen = 32
+
+// InfraInstanceKey identifies a single deduplicated infrastructure instance
+// (one DB pool / broker connection that one or more colocated cells share).
+//
+// It is a sealed value type: the id field is unexported, so an external package
+// cannot forge a key for a specific instance via a struct literal — the only
+// way to obtain a non-default key is NewInfraInstanceKey. The zero value is the
+// colocated default (DefaultInstanceKey), which IS openly constructable because
+// the single colocated instance is not a guarded identity. The type is
+// comparable, so it is used directly as a map key in the fan-out collection.
+type InfraInstanceKey struct {
+	// id is the stable identifier of the deduplicated instance. Empty id is the
+	// colocated default sentinel (DefaultInstanceKey); a non-default key always
+	// carries a validated non-empty snake_case id.
+	id string
+}
+
+// NewInfraInstanceKey mints the key for a deduplicated infrastructure instance.
+// Composition roots call it once per distinct instance with a stable, probe-safe
+// id (e.g. a DSN-derived lowercase snake_case identifier). It panics through the
+// panic-taxonomy funnel on an empty or malformed id: minting a key with an
+// unusable instance id is a composition-time programmer error, not a runtime
+// condition. Use DefaultInstanceKey for the single colocated instance.
+func NewInfraInstanceKey(id string) InfraInstanceKey {
+	if id == "" || len(id) > infraInstanceIDMaxLen || !infraInstanceIDPattern.MatchString(id) {
+		panic(panicregister.Approved("bootstrap-infra-instance-key-invalid",
+			errcode.Assertion("bootstrap: NewInfraInstanceKey id must be a non-empty lowercase snake_case identifier (<=32 chars)")))
+	}
+	return InfraInstanceKey{id: id}
+}
+
+// DefaultInstanceKey is the colocated single-instance sentinel: the zero value.
+// Colocated composition roots register their one relay under this key, so the
+// fan-out collection holds exactly one entry and behavior is identical to the
+// pre-fan-out single-relay world. It never collides with a NewInfraInstanceKey
+// value (which always carries a non-empty id).
+func DefaultInstanceKey() InfraInstanceKey {
+	return InfraInstanceKey{}
+}

--- a/framework/runtime/bootstrap/infra_instance_key_test.go
+++ b/framework/runtime/bootstrap/infra_instance_key_test.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -84,4 +85,17 @@ func TestNewInfraInstanceKey_RejectsMalformedID(t *testing.T) {
 		assert.NotPanics(t, func() { _ = NewInfraInstanceKey(id) },
 			"NewInfraInstanceKey(%q) must accept a valid snake_case id", id)
 	}
+}
+
+// TestNewInfraInstanceKey_LengthBoundary pins the exact infraInstanceIDMaxLen
+// (32) edge: a 32-char id is accepted, a 33-char id panics. Without the precise
+// boundary, silently bumping the cap (which feeds the relay probe-name budget,
+// 21 + id <= 64) would not be caught.
+func TestNewInfraInstanceKey_LengthBoundary(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() { _ = NewInfraInstanceKey(strings.Repeat("a", infraInstanceIDMaxLen)) },
+		"a %d-char id (== infraInstanceIDMaxLen) must be accepted", infraInstanceIDMaxLen)
+	assert.Panics(t, func() { _ = NewInfraInstanceKey(strings.Repeat("a", infraInstanceIDMaxLen+1)) },
+		"a %d-char id (> infraInstanceIDMaxLen) must panic", infraInstanceIDMaxLen+1)
 }

--- a/framework/runtime/bootstrap/infra_instance_key_test.go
+++ b/framework/runtime/bootstrap/infra_instance_key_test.go
@@ -1,0 +1,87 @@
+package bootstrap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestInfraInstanceKey_Equality verifies the sealed key behaves as a value
+// identity: same id compares equal, different id compares unequal, and the
+// type is usable as a Go map key (comparable). This is the foundation of the
+// per-instance relay fan-out collection (#2152 PR-1).
+func TestInfraInstanceKey_Equality(t *testing.T) {
+	t.Parallel()
+
+	a1 := NewInfraInstanceKey("accesscore")
+	a2 := NewInfraInstanceKey("accesscore")
+	b := NewInfraInstanceKey("auditcore")
+
+	if a1 != a2 {
+		t.Fatalf("NewInfraInstanceKey(%q) must equal an identical-id key", "accesscore")
+	}
+	if a1 == b {
+		t.Fatalf("distinct ids must produce distinct keys: %v == %v", a1, b)
+	}
+
+	// Usable as a map key (the relay fan-out collection keys on this type).
+	m := map[InfraInstanceKey]int{a1: 1, b: 2}
+	if m[a2] != 1 {
+		t.Fatalf("key with identical id must hit the same map slot; got %d", m[a2])
+	}
+	if len(m) != 2 {
+		t.Fatalf("two distinct keys must occupy two slots; got %d", len(m))
+	}
+}
+
+// TestDefaultInstanceKey_IsZeroValueAndDistinct verifies the colocated sentinel:
+// DefaultInstanceKey() is the zero value (so a struct-zero key resolves to the
+// single colocated instance), is stable across calls, and never collides with a
+// minted non-default key (which always carries a non-empty id).
+func TestDefaultInstanceKey_IsZeroValueAndDistinct(t *testing.T) {
+	t.Parallel()
+
+	var zero InfraInstanceKey
+	d1 := DefaultInstanceKey()
+	d2 := DefaultInstanceKey()
+	if d1 != zero {
+		t.Fatal("DefaultInstanceKey() must be the zero value (colocated sentinel)")
+	}
+	if d1 != d2 {
+		t.Fatal("DefaultInstanceKey() must be stable across calls")
+	}
+	if DefaultInstanceKey() == NewInfraInstanceKey("accesscore") {
+		t.Fatal("a real instance key must not collide with the default sentinel")
+	}
+}
+
+// TestNewInfraInstanceKey_RejectsMalformedID verifies the mint-time contract:
+// the id must be a non-empty lowercase snake_case identifier (<=32 chars) so it
+// composes into a valid healthz probe name. Malformed ids panic at the source.
+func TestNewInfraInstanceKey_RejectsMalformedID(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"empty":               "",
+		"hyphen":              "pool-a",
+		"uppercase":           "PoolA",
+		"leading digit":       "1pool",
+		"trailing underscore": "pool_",
+		"double underscore":   "pool__a",
+		"whitespace":          "pool a",
+		"too long":            "this_identifier_is_far_too_long_to_be_valid",
+	}
+	for name, id := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Panics(t, func() { _ = NewInfraInstanceKey(id) },
+				"NewInfraInstanceKey(%q) must panic on a malformed instance id", id)
+		})
+	}
+
+	// Valid ids must NOT panic.
+	for _, id := range []string{"accesscore", "pool_a", "pool0", "a"} {
+		assert.NotPanics(t, func() { _ = NewInfraInstanceKey(id) },
+			"NewInfraInstanceKey(%q) must accept a valid snake_case id", id)
+	}
+}

--- a/framework/runtime/bootstrap/managed_resource_test.go
+++ b/framework/runtime/bootstrap/managed_resource_test.go
@@ -406,7 +406,7 @@ func TestManagedResource_CloseErrorPropagatesToPhase10(t *testing.T) {
 
 // ---------------------------------------------------------------------------
 // Relay-via-WithRelay tests (TM2/TM3/TM4)
-// These tests use WithRelay(relay) — *Relay does not satisfy ManagedResource
+// These tests use WithRelay(DefaultInstanceKey(), relay) — *Relay does not satisfy ManagedResource
 // at the type level (see relay_adapter.go + ADR
 // docs/architecture/202605201400-adr-relay-managedresource-isolation.md), so
 // WithManagedResource(relay) is a compile-time type-mismatch and the relay
@@ -479,7 +479,7 @@ func TestWithRelay_RegistersProbes(t *testing.T) {
 		WithListener(cell.InternalListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}, WithListenerNet(newLocalListener(t))),
 		WithListener(cell.HealthListener, healthLn.Addr().String(), []auth.ListenerAuth{auth.AuthNone{}}, WithListenerNet(healthLn)),
 		WithShutdownTimeout(testtime.D2s),
-		WithRelay(relay),
+		WithRelay(DefaultInstanceKey(), relay),
 		WithHealthRoutes(WithReadyzVerboseToken(testVerboseToken)),
 	)
 
@@ -550,7 +550,7 @@ func TestWithRelay_TrippedBudget_Returns503(t *testing.T) {
 		WithListener(cell.InternalListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}, WithListenerNet(newLocalListener(t))),
 		WithListener(cell.HealthListener, healthLn.Addr().String(), []auth.ListenerAuth{auth.AuthNone{}}, WithListenerNet(healthLn)),
 		WithShutdownTimeout(testtime.D2s),
-		WithRelay(relay),
+		WithRelay(DefaultInstanceKey(), relay),
 		WithHealthRoutes(WithReadyzVerboseToken(testVerboseToken)),
 	)
 
@@ -649,7 +649,7 @@ func TestWithRelay_DisabledBudget_SkipsChecker(t *testing.T) {
 		WithListener(cell.InternalListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}, WithListenerNet(newLocalListener(t))),
 		WithListener(cell.HealthListener, healthLn.Addr().String(), []auth.ListenerAuth{auth.AuthNone{}}, WithListenerNet(healthLn)),
 		WithShutdownTimeout(testtime.D2s),
-		WithRelay(relay),
+		WithRelay(DefaultInstanceKey(), relay),
 		WithHealthRoutes(WithReadyzVerboseToken(testVerboseToken)),
 	)
 

--- a/framework/runtime/bootstrap/metrics_wiring_test.go
+++ b/framework/runtime/bootstrap/metrics_wiring_test.go
@@ -437,7 +437,7 @@ func TestAutoWireOutboxRejectCollector_RealProvider_NoRelayWiring(t *testing.T) 
 	b := New(
 		clock.Real(),
 		WithMetricsProvider(spy),
-		WithRelay(relay),
+		WithRelay(DefaultInstanceKey(), relay),
 	)
 
 	err := b.autoWireOutboxRejectCollector()

--- a/framework/runtime/bootstrap/options_events.go
+++ b/framework/runtime/bootstrap/options_events.go
@@ -177,7 +177,7 @@ func WithRelay(key InfraInstanceKey, r *runtimeoutbox.Relay) Option {
 		}
 		if _, exists := b.relaysByInstance[key]; exists {
 			panic(panicregister.Approved("bootstrap-relay-rebind",
-				errcode.Assertion("bootstrap: WithRelay called twice for the same infra instance key; one relay per instance")))
+				errcode.Assertion("bootstrap: WithRelay called twice for infra instance key %q; one relay per instance", key.id)))
 		}
 		if b.relaysByInstance == nil {
 			b.relaysByInstance = make(map[InfraInstanceKey]*runtimeoutbox.Relay, 1)

--- a/framework/runtime/bootstrap/options_events.go
+++ b/framework/runtime/bootstrap/options_events.go
@@ -164,7 +164,7 @@ func WithSubscriptionValidator(v ...cell.SubscriptionValidator) Option {
 //
 // Must be called before Run(). Typical usage:
 //
-//	relay := runtimeoutbox.NewRelay(store, pub, cfg)
+//	relay := runtimeoutbox.NewRelay(clk, store, pub, cfg)
 //	relay.WithPendingDepthObserver(pendingDepthCollector)
 //	bootstrap.New(
 //	    bootstrap.WithRelay(bootstrap.DefaultInstanceKey(), relay), // colocated: one relay

--- a/framework/runtime/bootstrap/options_events.go
+++ b/framework/runtime/bootstrap/options_events.go
@@ -138,44 +138,53 @@ func WithSubscriptionValidator(v ...cell.SubscriptionValidator) Option {
 	}
 }
 
-// WithRelay registers the relay BOTH for outbox wiring AND for lifecycle
-// (Start/Stop driven through the package-private relayAdapter). Calling
-// WithRelay is the ONLY supported path to integrate a relay; passing it to
-// WithManagedResource is a compile-time type-mismatch — *runtimeoutbox.Relay
-// does not implement kernel/lifecycle.ManagedResource. See ADR
+// WithRelay registers a relay for the deduplicated infrastructure instance
+// identified by key, BOTH for outbox wiring AND for lifecycle (Start/Stop driven
+// through the package-private relayAdapter). Calling WithRelay is the ONLY
+// supported path to integrate a relay; passing it to WithManagedResource is a
+// compile-time type-mismatch — *runtimeoutbox.Relay does not implement
+// kernel/lifecycle.ManagedResource. See ADR
 // docs/architecture/202605201400-adr-relay-managedresource-isolation.md and
 // archtest RELAY-NOT-MANAGEDRESOURCE-01.
 //
-// Calling WithRelay more than once is a programmer error and panics through
-// the panic-taxonomy funnel (panicregister.Approved + errcode.Assertion, B
-// class): the second call would silently overwrite b.relay while leaving the
-// earlier relay registered in managedResources, hiding a double-managed
-// resource that the previous runtime guard could not catch once the active
-// b.relay pointer moved.
+// Relay fan-out is keyed by InfraInstanceKey (#2152 PR-1): a colocated assembly
+// registers its one relay under DefaultInstanceKey (behavior unchanged); a
+// split assembly registers one relay per distinct instance key, each wrapped in
+// its own relayAdapter so every instance's outbox drains independently.
+//
+// Calling WithRelay more than once with the SAME instance key is a programmer
+// error and panics through the panic-taxonomy funnel (panicregister.Approved +
+// errcode.Assertion, B class): the second call would silently overwrite the
+// relay stored under that key while leaving the earlier relay's adapter
+// registered in managedResources, hiding a double-managed resource. Distinct
+// keys accumulate — that is the sanctioned fan-out.
 //
 // Nil inputs are silently ignored (cumulative builder noop pattern,
-// runtime-api.md §Option 范式分层): the relay remains unset, and
-// autoWireOutboxRejectCollector skips relay-specific wiring.
+// runtime-api.md §Option 范式分层): no relay is registered for that key.
 //
 // Must be called before Run(). Typical usage:
 //
 //	relay := runtimeoutbox.NewRelay(store, pub, cfg)
 //	relay.WithPendingDepthObserver(pendingDepthCollector)
 //	bootstrap.New(
-//	    bootstrap.WithRelay(relay), // sole sanctioned entry; no WithManagedResource needed
+//	    bootstrap.WithRelay(bootstrap.DefaultInstanceKey(), relay), // colocated: one relay
 //	    ...
 //	)
-func WithRelay(r *runtimeoutbox.Relay) Option {
+func WithRelay(key InfraInstanceKey, r *runtimeoutbox.Relay) Option {
 	return func(b *Bootstrap) {
 		if r == nil {
 			return
 		}
-		if b.relay != nil {
+		if _, exists := b.relaysByInstance[key]; exists {
 			panic(panicregister.Approved("bootstrap-relay-rebind",
-				errcode.Assertion("bootstrap: WithRelay called more than once; only one relay may be registered per Bootstrap")))
+				errcode.Assertion("bootstrap: WithRelay called twice for the same infra instance key; one relay per instance")))
 		}
-		b.relay = r
-		b.managedResources = append(b.managedResources, newRelayAdapter(r)) // auto-lifecycle via sole sanctioned holder
+		if b.relaysByInstance == nil {
+			b.relaysByInstance = make(map[InfraInstanceKey]*runtimeoutbox.Relay, 1)
+		}
+		b.relaysByInstance[key] = r
+		// One relayAdapter per instance (sole sanctioned holder); auto-lifecycle.
+		b.managedResources = append(b.managedResources, newRelayAdapter(key, r))
 	}
 }
 

--- a/framework/runtime/bootstrap/phases_events_test.go
+++ b/framework/runtime/bootstrap/phases_events_test.go
@@ -431,22 +431,7 @@ func TestPhase6_SubscriptionsWithConsumerBase_Succeeds(t *testing.T) {
 
 // newEventsTestRelay creates a minimal Relay suitable for WithRelay lifecycle tests.
 func newEventsTestRelay() *runtimeoutbox.Relay {
-	cfg := runtimeoutbox.RelayConfig{
-		PollInterval:         testtime.FastPoll,
-		ReclaimInterval:      testtime.D10ms,
-		BatchSize:            10,
-		MaxAttempts:          3,
-		BaseRetryDelay:       testtime.D1ms,
-		MaxRetryDelay:        testtime.D10ms,
-		ClaimTTL:             testtime.D100ms,
-		RetentionPeriod:      testtime.D1h,
-		DeadRetentionPeriod:  testtime.D24h,
-		CleanupWaitFloor:     testtime.FastPoll,
-		PollFailureBudget:    3,
-		ReclaimFailureBudget: 3,
-		CleanupFailureBudget: 3,
-	}
-	return runtimeoutbox.NewRelay(clock.Real(), outboxtest.NewFakeStore(), &outbox.DiscardPublisher{}, cfg)
+	return runtimeoutbox.NewRelay(clock.Real(), outboxtest.NewFakeStore(), &outbox.DiscardPublisher{}, testRelayConfig())
 }
 
 // TestWithRelay_AutoLifecycle_AdapterAddedToManagedResources verifies that
@@ -460,7 +445,7 @@ func TestWithRelay_AutoLifecycle_AdapterAddedToManagedResources(t *testing.T) {
 	relay := newEventsTestRelay()
 	b := New(
 		clock.Real(),
-		WithRelay(relay),
+		WithRelay(DefaultInstanceKey(), relay),
 	)
 
 	// The wrapping adapter must appear in managedResources, pointing at the
@@ -476,7 +461,7 @@ func TestWithRelay_AutoLifecycle_AdapterAddedToManagedResources(t *testing.T) {
 	assert.True(t, found,
 		"WithRelay must wrap the relay in *relayAdapter and append it to managedResources; "+
 			"current managedResources len=%d", len(b.managedResources))
-	assert.Same(t, relay, b.relay, "WithRelay must also store the relay on b.relay for outbox wiring")
+	assert.Same(t, relay, b.relaysByInstance[DefaultInstanceKey()], "WithRelay must store the relay under its instance key for outbox wiring")
 }
 
 // TestWithRelay_AutoLifecycle_CloseCalledDuringTeardown verifies that the relay
@@ -490,7 +475,7 @@ func TestWithRelay_AutoLifecycle_CloseCalledDuringTeardown(t *testing.T) {
 	relay := newEventsTestRelay()
 	b := New(
 		clock.Real(),
-		WithRelay(relay),
+		WithRelay(DefaultInstanceKey(), relay),
 	)
 
 	require.NoError(t, b.expandManagedResources(),
@@ -510,26 +495,10 @@ func TestWithRelay_AutoLifecycle_CloseCalledDuringTeardown(t *testing.T) {
 		"WithRelay must populate managedResourceTeardowns via expandManagedResources")
 }
 
-// TestWithRelay_Rebind_Panics verifies that calling WithRelay more than once
-// is an unrecoverable programmer error: it panics through the panic-taxonomy
-// funnel (panicregister.Approved). Without this guard, the second call would
-// overwrite b.relay while leaving the earlier adapter in managedResources —
-// the exact "early double-managed relay invisible" hole that motivated this
-// PR (see ADR docs/architecture/202605201400-adr-relay-managedresource-isolation.md).
-func TestWithRelay_Rebind_Panics(t *testing.T) {
-	t.Parallel()
-
-	r1 := newEventsTestRelay()
-	r2 := newEventsTestRelay()
-
-	assert.Panics(t, func() {
-		_ = New(
-			clock.Real(),
-			WithRelay(r1),
-			WithRelay(r2),
-		)
-	}, "WithRelay called twice must panic via panicregister.Approved + errcode.Assertion")
-}
+// The keyed rebind guard (same instance key panics; distinct keys accumulate)
+// is covered by TestWithRelay_SameInstanceKey_Rebind_Panics and
+// TestWithRelay_DistinctInstanceKeys_BothRegistered in relay_fanout_test.go
+// (#2152 PR-1, RELAY-SOLE-HOLDER-01 keyed-by-instance rewrite).
 
 // TestWithManagedResource_Relay_CompileTimeMismatch is a compile-time-only
 // assertion fixture: the line below is intentionally commented out. If it

--- a/framework/runtime/bootstrap/relay_adapter.go
+++ b/framework/runtime/bootstrap/relay_adapter.go
@@ -19,6 +19,8 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/healthz"
 	kernellifecycle "github.com/ghbvf/gocell/framework/kernel/lifecycle"
 	kworker "github.com/ghbvf/gocell/framework/kernel/worker"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/panicregister"
 	runtimeoutbox "github.com/ghbvf/gocell/framework/runtime/outbox"
 )
 
@@ -27,20 +29,52 @@ import (
 // ManagedResource on the relay surface itself.
 type relayAdapter struct {
 	relay *runtimeoutbox.Relay
+	// namespaced holds per-instance-renamed probes for a non-default infra
+	// instance (#2152 PR-1). nil for the colocated default key, where Probes()
+	// forwards the relay's bare-named probes live (operations contract
+	// unchanged). For a fanned-out instance it is pre-built so N relays expose
+	// globally-distinct probe names (expandManagedResources fails fast on a
+	// duplicate name).
+	namespaced []healthz.Probe
 }
 
 // Compile-time check: the adapter — and only the adapter — implements ManagedResource.
 var _ kernellifecycle.ManagedResource = (*relayAdapter)(nil)
 
-// newRelayAdapter wraps r so the bootstrap managed-resource pipeline can drive
-// its lifecycle. Package-private so external callers cannot construct it; the
-// only entry point is WithRelay.
-func newRelayAdapter(r *runtimeoutbox.Relay) *relayAdapter {
-	return &relayAdapter{relay: r}
+// newRelayAdapter wraps r for the infra instance identified by key so the
+// bootstrap managed-resource pipeline can drive its lifecycle. Package-private
+// so external callers cannot construct it; the only entry point is WithRelay.
+//
+// For a non-default key the relay's probe names are scoped by the instance id
+// (outbox_relay_poll → outbox_relay_poll_<id>) so multiple fanned-out relays do
+// not collide on the global probe-name namespace. The colocated default keeps
+// the bare names.
+func newRelayAdapter(key InfraInstanceKey, r *runtimeoutbox.Relay) *relayAdapter {
+	a := &relayAdapter{relay: r}
+	if key == DefaultInstanceKey() {
+		return a
+	}
+	base := r.Probes()
+	a.namespaced = make([]healthz.Probe, len(base))
+	for i, p := range base {
+		name, err := healthz.RelayInstanceProbeName(p.Name(), key.id)
+		if err != nil {
+			// Unreachable: key.id is a validated snake_case identifier (mint-time
+			// contract of NewInfraInstanceKey), so the composed name is always valid.
+			panic(panicregister.Approved("bootstrap-relay-probe-name",
+				errcode.Assertion("bootstrap: relay instance probe name composition failed for a validated key")))
+		}
+		a.namespaced[i] = healthz.NewProbe(name, p.Check)
+	}
+	return a
 }
 
-// Probes forwards to the relay's typed failure-budget probes.
+// Probes forwards to the relay's typed failure-budget probes, instance-scoped
+// when this adapter wraps a non-default infra instance.
 func (a *relayAdapter) Probes() []healthz.Probe {
+	if a.namespaced != nil {
+		return a.namespaced
+	}
 	return a.relay.Probes()
 }
 

--- a/framework/runtime/bootstrap/relay_fanout_test.go
+++ b/framework/runtime/bootstrap/relay_fanout_test.go
@@ -1,0 +1,170 @@
+package bootstrap
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/framework/kernel/assembly"
+	"github.com/ghbvf/gocell/framework/kernel/auth"
+	"github.com/ghbvf/gocell/framework/kernel/cell"
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/outbox"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/testtime"
+	runtimeoutbox "github.com/ghbvf/gocell/framework/runtime/outbox"
+	"github.com/ghbvf/gocell/framework/runtime/outbox/outboxtest"
+)
+
+// testRelayConfig is the shared fast-poll RelayConfig used by the bootstrap
+// relay lifecycle/fan-out tests. Extracted so newEventsTestRelay and
+// newDrainingRelay do not duplicate the 13-field literal.
+func testRelayConfig() runtimeoutbox.RelayConfig {
+	return runtimeoutbox.RelayConfig{
+		PollInterval:         testtime.FastPoll,
+		ReclaimInterval:      testtime.D10ms,
+		BatchSize:            10,
+		MaxAttempts:          3,
+		BaseRetryDelay:       testtime.D1ms,
+		MaxRetryDelay:        testtime.D10ms,
+		ClaimTTL:             testtime.D100ms,
+		RetentionPeriod:      testtime.D1h,
+		DeadRetentionPeriod:  testtime.D24h,
+		CleanupWaitFloor:     testtime.FastPoll,
+		PollFailureBudget:    3,
+		ReclaimFailureBudget: 3,
+		CleanupFailureBudget: 3,
+	}
+}
+
+// newDrainingRelay builds a relay bound to the supplied store so a test can
+// seed the store and observe that relay drain it. The DiscardPublisher always
+// succeeds, so claimed entries transition to StatePublished.
+func newDrainingRelay(store *outboxtest.FakeStore) *runtimeoutbox.Relay {
+	return runtimeoutbox.NewRelay(clock.Real(), store, &outbox.DiscardPublisher{}, testRelayConfig())
+}
+
+// seedPendingEntry writes a single pending outbox entry into store.
+func seedPendingEntry(t *testing.T, ctx context.Context, store *outboxtest.FakeStore, eventType string) {
+	t.Helper()
+	e, err := outbox.NewEntry(clock.Real(), ctx, eventType, []byte("{}"))
+	require.NoError(t, err)
+	require.NoError(t, store.Write(ctx, e))
+}
+
+// TestWithRelay_SameInstanceKey_Rebind_Panics verifies the keyed rebind guard:
+// registering two relays under the SAME InfraInstanceKey is a programmer error
+// (the second would overwrite the first while leaving its adapter in
+// managedResources — a double-managed relay). It panics through the
+// panic-taxonomy funnel, identical to the pre-fan-out single-relay guard but
+// now scoped per instance key (#2152 PR-1, RELAY-SOLE-HOLDER-01 keyed rewrite).
+func TestWithRelay_SameInstanceKey_Rebind_Panics(t *testing.T) {
+	t.Parallel()
+
+	r1 := newEventsTestRelay()
+	r2 := newEventsTestRelay()
+
+	assert.Panics(t, func() {
+		_ = New(
+			clock.Real(),
+			WithRelay(DefaultInstanceKey(), r1),
+			WithRelay(DefaultInstanceKey(), r2),
+		)
+	}, "WithRelay called twice with the same instance key must panic via panicregister.Approved + errcode.Assertion")
+}
+
+// TestWithRelay_DistinctInstanceKeys_BothRegistered verifies the core fan-out
+// seam: two relays under DISTINCT instance keys both register — each stored
+// under its key and each wrapped in its own relayAdapter in managedResources —
+// and both expand into the LIFO teardown pipeline. This is the N>1 relay
+// behavior that lifts the old single-relay invariant.
+func TestWithRelay_DistinctInstanceKeys_BothRegistered(t *testing.T) {
+	t.Parallel()
+
+	r1 := newEventsTestRelay()
+	r2 := newEventsTestRelay()
+	k1 := NewInfraInstanceKey("poola")
+	k2 := NewInfraInstanceKey("poolb")
+
+	b := New(
+		clock.Real(),
+		WithRelay(k1, r1),
+		WithRelay(k2, r2),
+	)
+
+	require.Same(t, r1, b.relaysByInstance[k1], "relay r1 must be stored under key poola")
+	require.Same(t, r2, b.relaysByInstance[k2], "relay r2 must be stored under key poolb")
+	require.Len(t, b.relaysByInstance, 2, "two distinct instance keys must yield two relay entries")
+
+	adapters := 0
+	for _, mr := range b.managedResources {
+		if ad, ok := mr.(*relayAdapter); ok && (ad.relay == r1 || ad.relay == r2) {
+			adapters++
+		}
+	}
+	require.Equal(t, 2, adapters, "each distinct-key relay must get its own relayAdapter in managedResources")
+
+	// Both relays must flow through the managed-resource teardown pipeline.
+	require.NoError(t, b.expandManagedResources())
+	require.GreaterOrEqual(t, len(b.managedResourceTeardowns), 2,
+		"both relays must register a LIFO teardown")
+	ctx := context.Background()
+	for _, td := range b.managedResourceTeardowns {
+		require.NoError(t, td.fn(ctx), "teardown %q must not fail", td.name)
+	}
+}
+
+// TestWithRelay_TwoDistinctInstances_EachDrainsOwnStore is the end-to-end
+// "真 2-池" proof: two relays bound to two DISTINCT outbox stores are registered
+// under two distinct instance keys, the full Bootstrap is run, and EACH relay
+// drains ITS OWN seeded store to completion. This坐实s "distinct DSN → 各自
+// relay → 端到端可跑" at the bootstrap seam (#2152 PR-1; broker fan-out stays
+// PR-2 — the shared in-proc bus is irrelevant here since each relay holds its
+// own publisher). Deterministic via FakeStore.WaitFor (no timing coupling).
+func TestWithRelay_TwoDistinctInstances_EachDrainsOwnStore(t *testing.T) {
+	ctx := context.Background()
+	clk := clock.Real()
+
+	storeA := outboxtest.NewFakeStore()
+	storeB := outboxtest.NewFakeStore()
+	seedPendingEntry(t, ctx, storeA, "test.fanout.a")
+	seedPendingEntry(t, ctx, storeB, "test.fanout.b")
+
+	asm := assembly.New(clk, assembly.Config{ID: "test-relay-fanout", DurabilityMode: outbox.DurabilityDemo})
+	require.NoError(t, asm.Register(newTestCell("cell-1")))
+
+	healthLn := newLocalListener(t)
+	b := New(
+		clk,
+		WithAssembly(asm),
+		WithListener(cell.PrimaryListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}, WithListenerNet(newLocalListener(t))),
+		WithListener(cell.InternalListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}, WithListenerNet(newLocalListener(t))),
+		WithListener(cell.HealthListener, healthLn.Addr().String(), []auth.ListenerAuth{auth.AuthNone{}}, WithListenerNet(healthLn)),
+		WithShutdownTimeout(testtime.D2s),
+		WithRelay(NewInfraInstanceKey("poola"), newDrainingRelay(storeA)),
+		WithRelay(NewInfraInstanceKey("poolb"), newDrainingRelay(storeB)),
+	)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() { done <- b.Run(runCtx) }()
+	waitForHealthy(t, healthLn.Addr().String())
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, testtime.EventuallyDefault)
+	defer waitCancel()
+	published := func(rows []outboxtest.FakeRow) bool {
+		return len(rows) == 1 && rows[0].Status == outbox.StatePublished
+	}
+	require.NoError(t, storeA.WaitFor(waitCtx, published), "relay under key poola must drain its own store")
+	require.NoError(t, storeB.WaitFor(waitCtx, published), "relay under key poolb must drain its own store")
+
+	cancel()
+	select {
+	case runErr := <-done:
+		assert.NoError(t, runErr)
+	case <-time.After(testtime.SelectShutdown):
+		t.Fatal("bootstrap did not shut down in time")
+	}
+}

--- a/framework/runtime/bootstrap/relay_fanout_test.go
+++ b/framework/runtime/bootstrap/relay_fanout_test.go
@@ -118,10 +118,25 @@ func TestWithRelay_DistinctInstanceKeys_BothRegistered(t *testing.T) {
 	// k1-before-k2 registration order is exactly what makes k2 tear down first.
 	require.Less(t, idx1, idx2, "k1 relay adapter must be registered before k2 (so LIFO teardown closes k2 first)")
 
-	// Both relays must flow through the managed-resource teardown pipeline.
+	// Both relays must flow through the managed-resource teardown pipeline, and
+	// each non-default instance's relay must expose INSTANCE-SCOPED probe names on
+	// the readyz health-checker set (the per-instance readyz wire contract, F3
+	// #2338) — proving the namespacing reaches bootstrap registration, not just
+	// the relayAdapter helper.
 	require.NoError(t, b.expandManagedResources())
 	require.GreaterOrEqual(t, len(b.managedResourceTeardowns), 2,
 		"both relays must register a LIFO teardown")
+
+	probeNames := make(map[string]bool, len(b.healthCheckers))
+	for _, hc := range b.healthCheckers {
+		probeNames[string(hc.name)] = true
+	}
+	for _, op := range []string{"outbox_relay_poll", "outbox_relay_reclaim", "outbox_relay_cleanup"} {
+		require.True(t, probeNames[op+"_poola"], "non-default instance poola must expose suffixed probe %q", op+"_poola")
+		require.True(t, probeNames[op+"_poolb"], "non-default instance poolb must expose suffixed probe %q", op+"_poolb")
+		require.False(t, probeNames[op], "non-default instances must NOT expose the bare probe %q (it is reserved for DefaultInstanceKey)", op)
+	}
+
 	ctx := context.Background()
 	for _, td := range b.managedResourceTeardowns {
 		require.NoError(t, td.fn(ctx), "teardown %q must not fail", td.name)

--- a/framework/runtime/bootstrap/relay_fanout_test.go
+++ b/framework/runtime/bootstrap/relay_fanout_test.go
@@ -98,13 +98,25 @@ func TestWithRelay_DistinctInstanceKeys_BothRegistered(t *testing.T) {
 	require.Same(t, r2, b.relaysByInstance[k2], "relay r2 must be stored under key poolb")
 	require.Len(t, b.relaysByInstance, 2, "two distinct instance keys must yield two relay entries")
 
-	adapters := 0
-	for _, mr := range b.managedResources {
+	idx1, idx2, adapters := -1, -1, 0
+	for i, mr := range b.managedResources {
 		if ad, ok := mr.(*relayAdapter); ok && (ad.relay == r1 || ad.relay == r2) {
 			adapters++
+			if ad.relay == r1 {
+				idx1 = i
+			} else {
+				idx2 = i
+			}
 		}
 	}
 	require.Equal(t, 2, adapters, "each distinct-key relay must get its own relayAdapter in managedResources")
+
+	// LIFO teardown: the later-registered instance (k2) must close FIRST. The adapters
+	// are appended in registration order (k1 before k2); expandManagedResources preserves
+	// that order into managedResourceTeardowns, and Run() iterates them in reverse (the
+	// LIFO reversal itself is covered by TestRunState_Rollback_ExecutesTeardownsLIFO). So
+	// k1-before-k2 registration order is exactly what makes k2 tear down first.
+	require.Less(t, idx1, idx2, "k1 relay adapter must be registered before k2 (so LIFO teardown closes k2 first)")
 
 	// Both relays must flow through the managed-resource teardown pipeline.
 	require.NoError(t, b.expandManagedResources())

--- a/tests/integration/l2atomicity/harness_test.go
+++ b/tests/integration/l2atomicity/harness_test.go
@@ -510,7 +510,7 @@ func runBootstrap(
 			bootstrap.WithListenerNet(lns.health)),
 		bootstrap.WithPublisher(eb), bootstrap.WithSubscriber(eb),
 		bootstrap.WithConsumerBase(newTestConsumerBase(t, clock.Real())),
-		bootstrap.WithRelay(relayWorker),
+		bootstrap.WithRelay(bootstrap.DefaultInstanceKey(), relayWorker),
 		// accesscore registers grpc.auth.session.verify.v1 unconditionally
 		// (cell_gen.go, PR-11 #1154). A gRPC listener must be wired or bootstrap
 		// fail-fasts with checkOrphanGRPCServices. HTTP-focused tests don't call

--- a/tools/archtest/probename_sealed_funnel_test.go
+++ b/tools/archtest/probename_sealed_funnel_test.go
@@ -524,7 +524,13 @@ var a2FunnelInternalAllowlist = map[string]struct{}{
 	// SagaTailerReadyProbeName constructor (cellID+projectionID runtime composition,
 	// not a const) and passes the result to NewProbe — same funnel-internal shape
 	// as kernel/projection/probe.go (#1609 PR-04).
-	"runtime/saga/tailer/probe.go":                             {},
+	"runtime/saga/tailer/probe.go": {},
+	// relayAdapter.Probes scopes a fanned-out relay's operation probes by infra
+	// instance id via the sanctioned RelayInstanceProbeName constructor (instance
+	// id runtime composition, not a const) and passes the results to NewProbe —
+	// same funnel-internal shape as emitter.go / kernel/projection/probe.go
+	// (#2152 PR-1, relay fan-out).
+	"runtime/bootstrap/relay_adapter.go":                       {},
 	"runtime/bootstrap/bootstrap_phases.go":                    {},
 	"runtime/bootstrap/phases_lifecycle.go":                    {},
 	"runtime/observability/healthz/healthztest/conformance.go": {},

--- a/tools/archtest/relay_isolation_test.go
+++ b/tools/archtest/relay_isolation_test.go
@@ -78,11 +78,14 @@
 //   - Embedded *Relay is the same shape as a named pointer field in
 //     go/types (`Field(i).Anonymous() == true`, same Type()); the field
 //     walk does not need to special-case embedding.
-//   - Collection holders: `[]*Relay`, `[N]*Relay`, `map[K]*Relay` (and
-//     nested combinations) are caught by recursing into element/value
-//     types. A relay in a map KEY position (`map[*Relay]V`) is NOT
-//     inspected — holding a relay as a key is nonsensical and never a
-//     real lifecycle-holder shape.
+//   - Collection holders: `[]*Relay`, `[N]*Relay`, `map[K]*Relay`, the
+//     pointer-to-collection forms `*[]*Relay` / `*map[K]*Relay`, and nested
+//     combinations are all caught — fieldHoldsRelay recurses through every
+//     pointer / slice / array / map-value layer (the Pointer case delegates to
+//     itself, so a non-Named element no longer bails the walk). A relay in a
+//     map KEY position (`map[*Relay]V`) is NOT inspected (only the value) —
+//     holding a relay as a key is nonsensical and never a real lifecycle-holder
+//     shape; that miss is asserted in TestFieldHoldsRelay_DetectsCollections.
 //   - Indirect-via-interface (e.g. a struct holds
 //     `interface{ Worker(); Close(...)... }`) is NOT inspected by this
 //     rule — but reaching such a wrapper to a real `*Relay` still
@@ -205,22 +208,24 @@ func TestRELAY_NOT_MANAGEDRESOURCE_01(t *testing.T) {
 		relayIsoLifecyclePkgPath, relayIsoMRTypeName)
 }
 
-// fieldHoldsRelay reports whether t reaches *relayNamed (pointer field or
-// embedded *Relay) or relayNamed (value field / embedded Relay), including
-// when held inside a slice/array/map element (e.g. `[]*Relay`,
-// `map[K]*Relay`) — the collection-holder shape that fan-out makes idiomatic
-// (#2152 PR-1). Type identity is checked via *types.Named.Obj() rather than
-// types.Identical so the comparison is robust against repeated calls to
-// types.NewNamed and instantiation. Map KEY position is intentionally not
-// inspected — a relay as a map key is never a real lifecycle-holder shape.
+// fieldHoldsRelay reports whether t reaches relayNamed through any chain of
+// pointer / slice / array / map-value indirection — covering `*Relay`, `Relay`,
+// `[]*Relay`, `map[K]*Relay`, AND pointer-to-collection forms like `*[]*Relay`
+// or `*map[K]*Relay` (the holder shapes that fan-out makes idiomatic, #2152
+// PR-1). Every recursing case (including Pointer) delegates to itself, so the
+// Named base case is the single relay-identity check; adding a holder shape
+// requires no new identity comparison. Type identity is checked via
+// *types.Named.Obj() rather than types.Identical so the comparison is robust
+// against repeated calls to types.NewNamed and instantiation.
+//
+// Map KEY position is intentionally NOT inspected (only ty.Elem(), the value):
+// a relay used as a map key is never a real lifecycle-holder shape (you hold a
+// relay to drive Start/Stop, not to look one up). That blind spot is documented
+// in the RELAY-SOLE-HOLDER-01 godoc and asserted-as-miss in the unit test.
 func fieldHoldsRelay(ft types.Type, relayNamed *types.Named) bool {
 	switch ty := ft.(type) {
 	case *types.Pointer:
-		inner, ok := ty.Elem().(*types.Named)
-		if !ok {
-			return false
-		}
-		return inner.Obj() == relayNamed.Obj()
+		return fieldHoldsRelay(ty.Elem(), relayNamed)
 	case *types.Named:
 		return ty.Obj() == relayNamed.Obj()
 	case *types.Slice:
@@ -262,6 +267,12 @@ func TestFieldHoldsRelay_DetectsCollections(t *testing.T) {
 		{"map value pointer", types.NewMap(strKey, ptrRelay)},
 		{"nested slice of slice", types.NewSlice(types.NewSlice(ptrRelay))},
 		{"map of slice", types.NewMap(strKey, types.NewSlice(ptrRelay))},
+		// Pointer-to-collection forms (F1 #2338): the Pointer branch must recurse,
+		// not bail on a non-Named element, else `*[]*Relay` / `*map[K]*Relay`
+		// silently bypass the sole-holder guard.
+		{"pointer to slice of pointer", types.NewPointer(types.NewSlice(ptrRelay))},
+		{"pointer to map value pointer", types.NewPointer(types.NewMap(strKey, ptrRelay))},
+		{"pointer to pointer", types.NewPointer(ptrRelay)},
 	}
 	for _, c := range holds {
 		require.True(t, fieldHoldsRelay(c.typ, relayNamed),

--- a/tools/archtest/relay_isolation_test.go
+++ b/tools/archtest/relay_isolation_test.go
@@ -38,23 +38,35 @@
 //
 // # RELAY-SOLE-HOLDER-01
 //
-// Among all production named struct types satisfying
-// `kernel/lifecycle.ManagedResource`, the ONLY type permitted to hold a
-// `*runtime/outbox.Relay` field (named, embedded, or by value) is
-// `runtime/bootstrap.relayAdapter`. Any other satisfying-and-holding type
-// would constitute an alternative sanctioned-holder path, breaking the
-// §"single sanctioned holder" Hard 范本
-// (.claude/rules/gocell/ai-robust.md) even when the upstream
+// Keyed-by-instance holder invariant (#2152 PR-1). Bootstrap's relay channel
+// fans out into a keyed collection — one relay per deduplicated infra instance,
+// each wrapped in its OWN `runtime/bootstrap.relayAdapter` — so the old
+// "single relay per Bootstrap" framing is lifted. What survives, and is the
+// type-level guard here, is the SOLE-HOLDER-TYPE property: among all production
+// named struct types satisfying `kernel/lifecycle.ManagedResource`, the ONLY
+// type permitted to hold a `*runtime/outbox.Relay` — directly (named, embedded,
+// or by value) OR inside a slice/array/map element — is
+// `runtime/bootstrap.relayAdapter`. N relayAdapter INSTANCES are fine (that is
+// the fan-out); an alternative satisfying-AND-holding TYPE is not, as it would
+// be a second sanctioned-holder path, breaking the §"single sanctioned holder"
+// Hard 范本 (.claude/rules/gocell/ai-robust.md) even when the upstream
 // `newRelayAdapter` constructor stays package-private.
+//
+// The fan-out collection itself (`Bootstrap.relaysByInstance
+// map[InfraInstanceKey]*Relay`) is legal and NOT flagged: `*Bootstrap` does not
+// satisfy ManagedResource, so it never enters the candidate set. The collection
+// scan below exists so that a NEW ManagedResource holding a relay COLLECTION
+// (`[]*Relay` / `map[K]*Relay`) — the natural bypass once fan-out makes relay
+// collections idiomatic — is rejected exactly like a bare `*Relay` field.
 //
 // AI-robust grade: Hard (downstream). The production type universe is
 // walked via `Run(t, Production(...))`; for each `*types.Named` whose
 // underlying is `*types.Struct` and whose pointer method set satisfies
-// `ManagedResource`, every struct field is inspected and any
-// `*Relay` / `Relay` field that does not live in `relayAdapter` fails the
-// test. Upstream Hard is again the package-private `newRelayAdapter`
-// constructor — external packages cannot construct an alternative
-// wrapper that holds the relay.
+// `ManagedResource`, every struct field is inspected (recursing into
+// slice/array/map element types) and any `*Relay` / `Relay` reached that does
+// not live in `relayAdapter` fails the test. Upstream Hard is again the
+// package-private `newRelayAdapter` constructor — external packages cannot
+// construct an alternative wrapper that holds the relay.
 //
 // Blind-spot inventory (tool: `types.Implements` + `*types.Struct`
 // field walk):
@@ -66,6 +78,11 @@
 //   - Embedded *Relay is the same shape as a named pointer field in
 //     go/types (`Field(i).Anonymous() == true`, same Type()); the field
 //     walk does not need to special-case embedding.
+//   - Collection holders: `[]*Relay`, `[N]*Relay`, `map[K]*Relay` (and
+//     nested combinations) are caught by recursing into element/value
+//     types. A relay in a map KEY position (`map[*Relay]V`) is NOT
+//     inspected — holding a relay as a key is nonsensical and never a
+//     real lifecycle-holder shape.
 //   - Indirect-via-interface (e.g. a struct holds
 //     `interface{ Worker(); Close(...)... }`) is NOT inspected by this
 //     rule — but reaching such a wrapper to a real `*Relay` still
@@ -77,11 +94,14 @@
 //     (production loader filters `<module>/generated/`).
 //   - Reverse self-check: `runtime/bootstrap.relayAdapter` MUST appear
 //     in the satisfying-AND-holding set, otherwise the filter is
-//     vacuous and the test passes silently.
+//     vacuous and the test passes silently. The synthetic-type unit test
+//     `TestFieldHoldsRelay_DetectsCollections` separately proves the
+//     collection recursion is live (not vacuous).
 
 package archtest
 
 import (
+	"go/token"
 	"go/types"
 	"testing"
 
@@ -185,11 +205,14 @@ func TestRELAY_NOT_MANAGEDRESOURCE_01(t *testing.T) {
 		relayIsoLifecyclePkgPath, relayIsoMRTypeName)
 }
 
-// fieldHoldsRelay reports whether t resolves to *relayNamed (pointer field
-// or embedded *Relay) or relayNamed (value field / embedded Relay).
-// Type identity is checked via *types.Named.Obj() rather than
+// fieldHoldsRelay reports whether t reaches *relayNamed (pointer field or
+// embedded *Relay) or relayNamed (value field / embedded Relay), including
+// when held inside a slice/array/map element (e.g. `[]*Relay`,
+// `map[K]*Relay`) — the collection-holder shape that fan-out makes idiomatic
+// (#2152 PR-1). Type identity is checked via *types.Named.Obj() rather than
 // types.Identical so the comparison is robust against repeated calls to
-// types.NewNamed and instantiation.
+// types.NewNamed and instantiation. Map KEY position is intentionally not
+// inspected — a relay as a map key is never a real lifecycle-holder shape.
 func fieldHoldsRelay(ft types.Type, relayNamed *types.Named) bool {
 	switch ty := ft.(type) {
 	case *types.Pointer:
@@ -200,8 +223,64 @@ func fieldHoldsRelay(ft types.Type, relayNamed *types.Named) bool {
 		return inner.Obj() == relayNamed.Obj()
 	case *types.Named:
 		return ty.Obj() == relayNamed.Obj()
+	case *types.Slice:
+		return fieldHoldsRelay(ty.Elem(), relayNamed)
+	case *types.Array:
+		return fieldHoldsRelay(ty.Elem(), relayNamed)
+	case *types.Map:
+		return fieldHoldsRelay(ty.Elem(), relayNamed)
 	}
 	return false
+}
+
+// TestFieldHoldsRelay_DetectsCollections proves the collection recursion added
+// for the keyed relay fan-out (#2152 PR-1) is live: a synthetic ManagedResource
+// holding a relay inside a slice/array/map element must be detected exactly like
+// a bare *Relay field, while a collection of an unrelated type must not be. This
+// is the synthetic RED/GREEN backstop for the production type-walk (which today
+// finds zero collection holders, so without this the recursion would be
+// untested).
+func TestFieldHoldsRelay_DetectsCollections(t *testing.T) {
+	t.Parallel()
+
+	relayObj := types.NewTypeName(token.NoPos, nil, relayIsoRelayTypeName, nil)
+	relayNamed := types.NewNamed(relayObj, types.NewStruct(nil, nil), nil)
+	otherObj := types.NewTypeName(token.NoPos, nil, "NotARelay", nil)
+	otherNamed := types.NewNamed(otherObj, types.NewStruct(nil, nil), nil)
+
+	ptrRelay := types.NewPointer(relayNamed)
+	strKey := types.Typ[types.String]
+
+	holds := []struct {
+		name string
+		typ  types.Type
+	}{
+		{"bare pointer", ptrRelay},
+		{"value", relayNamed},
+		{"slice of pointer", types.NewSlice(ptrRelay)},
+		{"array of pointer", types.NewArray(ptrRelay, 3)},
+		{"map value pointer", types.NewMap(strKey, ptrRelay)},
+		{"nested slice of slice", types.NewSlice(types.NewSlice(ptrRelay))},
+		{"map of slice", types.NewMap(strKey, types.NewSlice(ptrRelay))},
+	}
+	for _, c := range holds {
+		require.True(t, fieldHoldsRelay(c.typ, relayNamed),
+			"fieldHoldsRelay must detect a relay held as %s", c.name)
+	}
+
+	misses := []struct {
+		name string
+		typ  types.Type
+	}{
+		{"unrelated pointer", types.NewPointer(otherNamed)},
+		{"slice of unrelated", types.NewSlice(types.NewPointer(otherNamed))},
+		{"map of unrelated", types.NewMap(strKey, types.NewPointer(otherNamed))},
+		{"relay in map KEY only", types.NewMap(ptrRelay, otherNamed)},
+	}
+	for _, c := range misses {
+		require.False(t, fieldHoldsRelay(c.typ, relayNamed),
+			"fieldHoldsRelay must NOT flag %s", c.name)
+	}
 }
 
 // structHoldsRelay reports whether the struct underlying named declares any


### PR DESCRIPTION
## Summary

把 bootstrap 的 relay 运行期 fan-out 从单例提升为「按去重基建实例 keyed」的集合，lift 单 relay 不变式（#2152 PR-1，三 PR 中的基础 seam）。

## Why / 背景

#1964（PR #2151，MERGED）落地 per-cell DB 凭据/连接 seam（`cellmodules/percellpg`），但运行期 relay 仍是单例：`WithRelay` 第二次调用 panic，故 distinct per-cell 基建连接无法真正运行（percellpg 对 >1 distinct DSN fail-closed，显式指向「#1963 / #2152」）。本 PR 建立 bootstrap 端的 relay fan-out seam，使 N 个 relay（每去重基建实例一个）可注册并各自驱动自己的 outbox，端到端可跑。

## 改动

- **sealed `InfraInstanceKey`**（新）：unexported `id` 字段（包外不可伪造非默认值，Hard）；mint 期校验 snake_case ≤32；`DefaultInstanceKey()` = 零值哨兵。**keying 维度从 PR-1 冻结，PR-2 复用给 pub/sub。**
- **`WithRelay(key, r)`**：`b.relay` 单字段 → `b.relaysByInstance map`。同 key 重绑 panic（语义从「per Bootstrap 唯一」→「per instance key 唯一」），不同 key 累加（fan-out），各 append 一个 `relayAdapter`。
- **per-instance probe 命名空间化**（实现期发现的必需子改动）：N relay 的操作 probe（`outbox_relay_poll/reclaim/cleanup`）全局名冲突会 fail-fast 启动。非默认实例经新增 sanctioned `healthz.RelayInstanceProbeName` 命名空间化（`<base>_<id>`），colocated 默认实例 probe 名**不变**（运维契约保持）。relay_adapter.go 进 `PROBENAME-SEALED-FUNNEL-01/A2` 内部 allowlist（与 emitter/projection/tailer 同族 composed-name 构造）。
- **`RELAY-SOLE-HOLDER-01` 重写**：keyed-by-instance 框架（N relayAdapter 实例合法；替代 holder 类型仍拒）+ 强化 `fieldHoldsRelay` 递归 slice/array/map element（堵 keyed 世界「替代 collection-holder MR」绕过），含 synthetic-type 单测。
- **ADR `202605201400`** 加 2026-06-18 amendment（威胁矩阵重评）。

## Refs

Closes #2152
ref: uber-go/fx app.go — Option 模式 / LIFO 生命周期
ADR: `docs/architecture/202605201400-adr-relay-managedresource-isolation.md` §Amendment 2026-06-18

## Risk / 兼容性

- **破坏式 Go API**：`bootstrap.WithRelay` 签名 `(r)` → `(key, r)`。所有 in-repo 调用方同 PR 原子更新（configcore / iotdevice / ssobff / l2atomicity 集成测试），删旧签名不留别名（pre-GA 无外部消费方）。
- **无 wire / contract / schema 变更**；无 migration。
- **pub/sub 通道不动**（仍单例）：relay 各自构造期已持自己的 publisher，故 relay 通道独立可 key；broker（pub/sub）fan-out 归 **PR-2**，复用同一 `InfraInstanceKey`。
- **`percellpg` fail-closed 保留**（不动）：生产 per-cell-provider 馈送（`SharedDeps.PG` 单例→per-cell 线程化 + `cap_wiring` 开 N 池）未接前放行 distinct DSN 会不一致，故留 **follow-up issue** 跟踪。
- 3 个 archtest 失败（`adapters/softca` / audit ledger NotFound / `http.audit.get.v1` pathParam）**pre-existing on base `c695ac748`**，与本 PR 无关。

## Test plan

- [x] `go build ./...`（framework / cellmodules / examples / cmd/corebundle）+ `-tags=integration` 编译通过
- [x] `go test ./framework/runtime/bootstrap/... ./framework/kernel/healthz/...` 通过（含真 2-池端到端 `TestWithRelay_TwoDistinctInstances_EachDrainsOwnStore`、distinct-key fan-out、同-key rebind panic、InfraInstanceKey 校验）
- [x] archtest `RELAY-SOLE-HOLDER|RELAY-NOT-MANAGEDRESOURCE|FieldHoldsRelay|PROBENAME-SEALED-FUNNEL` 通过
- [x] `golangci-lint run` 0 issues（framework / configcore / iotdevice / ssobff / tools archtest；tests/integration 仅 pre-existing）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
