### PR TITLE
refactor(packagesload): #2165 WorkspaceCache 单源下沉，metricschema/typeseval 共用进程内缓存

### DIFF
--- a/docs/architecture/202605190000-adr-archtest-in-process-warmup.md
+++ b/docs/architecture/202605190000-adr-archtest-in-process-warmup.md
@@ -121,9 +121,21 @@ PR #584 CI 首次运行 shard 12 触发 slowgate fail：`TestArchtestVerifyCover
 - 改造 3 `TAGGROUP-LOOP-FORBIDS-TYPED-RUN-01` = typed-function-call funnel **Hard**（对齐 ai-robust.md §"Hard 范本" 第 2 条 panic 范本同构 + staticcheck SA4000 同构）
 - 改造 1 (TestMain) / 改造 2 (两次 Load) = perf refactor，不在 ai-robust.md §适用范围
 
+## Amendment 2026-06-18 — #2165 缓存实现下沉 packagesload
+
+`SharedResolver` / `LoadProductionPackages` 的进程内缓存实现（原 typeseval 私有
+`sharedCache map[string]*Resolver` + `singleflight.Group`）下沉为 `tools/packagesload`
+的 `WorkspaceCache`（无界 map + singleflight），metricschema 的 OBS-01 扫描经同一
+`packagesload.LoadWorkspaceCached` 共用——去除 typeseval 与 metricschema 间的平行缓存实现，
+单源化（#2165）。**行为/威胁矩阵不变**：仍是同构 singleflight 摊销 + TestMain 预热路径，
+warm 命中后 wall/RSS 同前；本 ADR 改造 1（TestMain warm-up）经 `LoadProductionPackages` →
+`packagesload.LoadFlatCached` 继续命中。`Resolver` 退为每调用新建的薄 wrapper，缓存命中以
+共享底层 `[]*packages.Package` 表达（非共享 wrapper）。perf refactor，不在 ai-robust.md §适用范围。
+
 ## 参考
 
 - ADR `docs/architecture/202605120000-adr-archtest-process-isolation.md`（前置 ADR — process isolation 与本 ADR 叠加非冲突）
+- `tools/packagesload/cache.go` — `WorkspaceCache` 单源缓存实现（#2165）
 - `tools/archtest/internal/typeseval/typeseval.go` — SharedResolver godoc 同 PR 补"为什么保留 patterns 维度"段
 - `tools/archtest/taggroup_loop_no_typed_run_test.go` — 改造 3 实现
 - `tools/archtest/internal/taggrouploopfixtures/` — 改造 3 fixture self-check

--- a/docs/architecture/202605190000-adr-archtest-in-process-warmup.md
+++ b/docs/architecture/202605190000-adr-archtest-in-process-warmup.md
@@ -132,6 +132,12 @@ warm 命中后 wall/RSS 同前；本 ADR 改造 1（TestMain warm-up）经 `Load
 `packagesload.LoadFlatCached` 继续命中。`Resolver` 退为每调用新建的薄 wrapper，缓存命中以
 共享底层 `[]*packages.Package` 表达（非共享 wrapper）。perf refactor，不在 ai-robust.md §适用范围。
 
+**RSS 峰值不变（不要误读为"合并缓存=省内存"）**：`LoadFlatCached`（warm-up 路径，kind `F`）与
+`LoadWorkspaceCached`（`SharedResolver` 路径，kind `W`）的 cache key **kind 前缀不同**，二者加载
+不同 package 集、**不共享 entry**——与下沉前 typeseval 私有缓存按 `ModeWorkspace`/`ModeModule`
+分键的语义等价。故 §"威胁矩阵/资源边界变化"的 RSS 峰值（≈2× 全模块）维持不变，本次只是把缓存
+**实现**单源化，不改变峰值内存。
+
 ## 参考
 
 - ADR `docs/architecture/202605120000-adr-archtest-process-isolation.md`（前置 ADR — process isolation 与本 ADR 叠加非冲突）

--- a/tools/archtest/internal/typeseval/production_resolver.go
+++ b/tools/archtest/internal/typeseval/production_resolver.go
@@ -73,7 +73,7 @@ func LoadProductionPackages(workspaceRoot string, modules []workspace.Module, te
 			generatedPrefixes[i] = m.ImportPath + "/generated/"
 		}
 	}
-	resolver, err := sharedResolverMode(packagesload.ModeWorkspace, workspaceRoot, tests, tags, patterns...)
+	resolver, err := resolverFrom(packagesload.LoadFlatCached(workspaceRoot, typesevalCfg(tests, tags), patterns...))
 	if err != nil {
 		return nil, fmt.Errorf("typeseval: load production packages: %w", err)
 	}

--- a/tools/archtest/internal/typeseval/typeseval.go
+++ b/tools/archtest/internal/typeseval/typeseval.go
@@ -31,9 +31,7 @@ import (
 	"go/constant"
 	"go/types"
 	"strings"
-	"sync"
 
-	"golang.org/x/sync/singleflight"
 	"golang.org/x/tools/go/packages"
 
 	"github.com/ghbvf/gocell/tools/packagesload"
@@ -111,131 +109,53 @@ const loadMode = packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
 // the second value so callers can fail fast on type-check errors without
 // re-walking.
 //
-// The cross-module workspace scan ([LoadProductionPackages]) uses the ModeWorkspace
-// variant ([loadPackagesMode]); this ModeModule form is the one the Typed / Fixture /
-// StandaloneModule scopes route through. Its ModeModule path delegates to the shared
-// packagesload.LoadWorkspace, so a satellite parent prefix ("./cmd/...", "./adapters/...",
-// "./examples/...") is expanded to its go.work members and loaded in workspace mode —
-// the single-module name refers to the GOWORK mode requested, not a guarantee that
-// only one module loads. The signature is held stable so the pass / production funnel
-// meta-archtests keep matching it.
+// This is the UNCACHED form, delegating to the shared satellite-aware loader
+// packagesload.LoadWorkspace, so a satellite parent prefix ("./cmd/...",
+// "./adapters/...", "./examples/...") is expanded to its go.work members and
+// loaded in workspace mode — the single-module name refers to the GOWORK mode
+// requested, not a guarantee that only one module loads. [SharedResolver] is the
+// cached counterpart (#2165). The signature is held stable so the pass /
+// production funnel meta-archtests keep matching it.
 func LoadPackages(modRoot string, tests bool, tags []string, patterns ...string) ([]*packages.Package, []packages.Error, error) {
-	return loadPackagesMode(packagesload.ModeModule, modRoot, tests, tags, patterns...)
+	return packagesload.LoadWorkspace(modRoot, typesevalCfg(tests, tags), patterns...)
 }
 
-// loadPackagesMode is the shared body of LoadPackages; mode selects the GOWORK
-// semantics (see tools/packagesload). The ModeModule path routes through the shared
-// satellite-aware loader packagesload.LoadWorkspace, which expands multi-member
-// satellite parent-prefixes ("./cmd/...", "./adapters/...", "./examples/...") to
-// their go.work members so they are actually scanned (the grouping logic this used
-// to carry inline, consolidated into the single sanctioned loader — #2147).
-// ModeWorkspace is the cross-module production scan, loaded flat from the root
-// without parent-prefix expansion.
-func loadPackagesMode(
-	mode packagesload.Mode, dir string, tests bool, tags []string, patterns ...string,
-) ([]*packages.Package, []packages.Error, error) {
+// typesevalCfg builds the packages.Config shared by every archtest typed scope:
+// the #1499 no-NeedDeps loadMode plus the tests flag and optional -tags. Those
+// fields (Mode/Tests/BuildFlags) are exactly the ones the packagesload cache
+// keys on, so two loads with the same (tests, tags, patterns) share a cache entry.
+func typesevalCfg(tests bool, tags []string) packages.Config {
 	cfg := packages.Config{Mode: loadMode, Tests: tests}
 	if len(tags) > 0 {
 		cfg.BuildFlags = []string{"-tags=" + strings.Join(tags, ",")}
 	}
-	if mode == packagesload.ModeModule {
-		return packagesload.LoadWorkspace(dir, cfg, patterns...)
-	}
-	// Explicit ModeWorkspace: the cross-module workspace production scan loads flat
-	// from the root (no satellite parent-prefix expansion).
-	cfg.Dir = dir
-	pkgs, err := packagesload.Load(mode, &cfg, patterns...)
-	if err != nil {
-		return nil, nil, fmt.Errorf("packages.Load: %w", err)
-	}
-	var errs []packages.Error
-	packages.Visit(pkgs, nil, func(p *packages.Package) {
-		for i := range p.Errors {
-			p.Errors[i].Msg = dir + ": " + p.Errors[i].Msg
-		}
-		errs = append(errs, p.Errors...)
-	})
-	return pkgs, errs, nil
+	return cfg
 }
 
-var (
-	sharedMu    sync.Mutex
-	sharedCache = map[string]*Resolver{}
-	sharedGroup singleflight.Group
-)
-
-// SharedResolver returns a process-wide cached Resolver keyed on
-// (modRoot, tests, tags, patterns). Successive callers with the same key
-// reuse the loaded packages. Errors are not cached — a transient failure
-// does not poison subsequent calls.
+// SharedResolver returns a Resolver backed by the process-wide packagesload
+// cache (#2165), keyed on (modRoot, tests, tags, patterns). Successive callers
+// with the same key reuse the satellite-aware cached load instead of re-running
+// packages.Load. Errors are not cached, so a transient failure does not poison
+// subsequent calls. The returned *Resolver is a thin wrapper minted per call;
+// two calls share the same underlying packages on a cache hit (the property
+// that matters: no re-load), not the same wrapper.
 //
-// Cache keys are formed by joining modRoot, the tests flag, the tag list,
-// and each pattern with NUL bytes. NUL is illegal in POSIX paths and Go
-// import patterns, so collisions are impossible even when patterns
-// themselves contain "|" or ",".
-//
-// Concurrency: the cache is read and written under sharedMu, but the
-// expensive LoadPackages call runs without the lock. singleflight
-// deduplicates concurrent loads of the same key so only one packages.Load
-// is in flight per key, while loads for different keys run in parallel.
-//
-// 为什么 cacheKey 保留 patterns 维度而不剥离：archtest 调用方实测分布显示
-// 主模块 subpath patterns（./cells/.../, ./cmd/.../, ./runtime/.../ 等）
-// 占 83.5%，"./..." 仅占 16.5%。每个 subpath patterns 加载不同 package 集
-// 合，必须区分 cacheKey。"./..." 形态的 cacheKey 合并已由
-// LoadProductionPackages typed wrapper 完成（固定 patterns="./..."）。
+// The cache lives in tools/packagesload (the single sanctioned package-load
+// cache); typeseval holds no cache state of its own.
 // ref: ADR docs/architecture/202605190000-adr-archtest-in-process-warmup.md
 func SharedResolver(modRoot string, tests bool, tags []string, patterns ...string) (*Resolver, error) {
-	return sharedResolverMode(packagesload.ModeModule, modRoot, tests, tags, patterns...)
+	return resolverFrom(packagesload.LoadWorkspaceCached(modRoot, typesevalCfg(tests, tags), patterns...))
 }
 
-// sharedResolverMode is the mode-parameterized body of SharedResolver. The cache
-// key includes mode so a ModeModule load and a ModeWorkspace load of the same
-// (dir, tests, tags, patterns) never alias. SharedResolver fixes ModeModule
-// (the only public form, kept stable for the funnel meta-archtests); the
-// ModeWorkspace path is reached solely via LoadProductionPackages for the
-// cross-module workspace production scan.
-func sharedResolverMode(mode packagesload.Mode, dir string, tests bool, tags []string, patterns ...string) (*Resolver, error) {
-	testsFlag := "0"
-	if tests {
-		testsFlag = "1"
-	}
-	key := fmt.Sprintf("%d", mode) + "\x00" + dir + "\x00" + testsFlag + "\x00" +
-		strings.Join(tags, "\x00") + "\x00" + strings.Join(patterns, "\x00")
-
-	sharedMu.Lock()
-	if r, ok := sharedCache[key]; ok {
-		sharedMu.Unlock()
-		return r, nil
-	}
-	sharedMu.Unlock()
-
-	v, err, _ := sharedGroup.Do(key, func() (any, error) {
-		// Re-check inside the singleflight group: another caller may have
-		// populated the cache between our miss and entering Do.
-		sharedMu.Lock()
-		if r, ok := sharedCache[key]; ok {
-			sharedMu.Unlock()
-			return r, nil
-		}
-		sharedMu.Unlock()
-
-		pkgs, errs, err := loadPackagesMode(mode, dir, tests, tags, patterns...)
-		if err != nil {
-			return nil, err
-		}
-		if len(errs) > 0 {
-			return nil, fmt.Errorf("packages.Load: %d error(s): first=%w", len(errs), errs[0])
-		}
-		r := &Resolver{pkgs: pkgs}
-
-		sharedMu.Lock()
-		sharedCache[key] = r
-		sharedMu.Unlock()
-		return r, nil
-	})
+// resolverFrom wraps a (cached) load result into a *Resolver, mapping a Go load
+// error or any non-empty packages.Error into a fail-fast error (a partial load
+// is a scan failure). Shared by SharedResolver and LoadProductionPackages.
+func resolverFrom(pkgs []*packages.Package, errs []packages.Error, err error) (*Resolver, error) {
 	if err != nil {
 		return nil, err
 	}
-	return v.(*Resolver), nil
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("packages.Load: %d error(s): first=%w", len(errs), errs[0])
+	}
+	return &Resolver{pkgs: pkgs}, nil
 }

--- a/tools/archtest/internal/typeseval/typeseval.go
+++ b/tools/archtest/internal/typeseval/typeseval.go
@@ -113,9 +113,12 @@ const loadMode = packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
 // packagesload.LoadWorkspace, so a satellite parent prefix ("./cmd/...",
 // "./adapters/...", "./examples/...") is expanded to its go.work members and
 // loaded in workspace mode — the single-module name refers to the GOWORK mode
-// requested, not a guarantee that only one module loads. [SharedResolver] is the
-// cached counterpart (#2165). The signature is held stable so the pass /
-// production funnel meta-archtests keep matching it.
+// requested, not a guarantee that only one module loads. The signature is held
+// stable so the pass / production funnel meta-archtests keep matching it.
+//
+// Prefer [SharedResolver] (the cached counterpart, #2165) in new code; this
+// uncached form exists only for that signature-stability requirement — a fresh
+// caller that wants memoization must not reach for LoadPackages.
 func LoadPackages(modRoot string, tests bool, tags []string, patterns ...string) ([]*packages.Package, []packages.Error, error) {
 	return packagesload.LoadWorkspace(modRoot, typesevalCfg(tests, tags), patterns...)
 }
@@ -141,7 +144,9 @@ func typesevalCfg(tests bool, tags []string) packages.Config {
 // that matters: no re-load), not the same wrapper.
 //
 // The cache lives in tools/packagesload (the single sanctioned package-load
-// cache); typeseval holds no cache state of its own.
+// cache); typeseval holds no cache state of its own. SharedResolver wraps the
+// raw cached load [packagesload.LoadWorkspaceCached], mapping any packages.Error
+// into a fail-fast scan error via [resolverFrom].
 // ref: ADR docs/architecture/202605190000-adr-archtest-in-process-warmup.md
 func SharedResolver(modRoot string, tests bool, tags []string, patterns ...string) (*Resolver, error) {
 	return resolverFrom(packagesload.LoadWorkspaceCached(modRoot, typesevalCfg(tests, tags), patterns...))

--- a/tools/archtest/internal/typeseval/typeseval_test.go
+++ b/tools/archtest/internal/typeseval/typeseval_test.go
@@ -8,7 +8,6 @@ import (
 	"go/types"
 	"path/filepath"
 	"runtime"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -171,24 +170,6 @@ func init() { fmt.Println(Topic) }
 	assert.False(t, ok, "nil TypesInfo should not panic")
 }
 
-// cacheKey rebuilds the SharedResolver cache key for test cleanup. Tests in
-// this file all pass nil tags, so the cache key collapses to the simpler
-// shape (mode + root + tests-flag + empty + patterns).
-func cacheKey(root string, tests bool, patterns ...string) string {
-	testsFlag := "0"
-	if tests {
-		testsFlag = "1"
-	}
-	out := "0" + "\x00" + root + "\x00" + testsFlag + "\x00" + "\x00"
-	for i, p := range patterns {
-		if i > 0 {
-			out += "\x00"
-		}
-		out += p
-	}
-	return out
-}
-
 func TestLoadPackages_HappyPath(t *testing.T) {
 	root := findArchTestModuleRoot(t)
 	pkgs, errs, err := LoadPackages(root, false, nil, "./tools/archtest/internal/typeseval/...")
@@ -286,167 +267,42 @@ func TestLoadPackages_TestsFlagIncludesTestFiles(t *testing.T) {
 	assert.True(t, hasTestFile, "tests=true must load typeseval_test.go via test variant")
 }
 
-func TestSharedResolver_Singleton(t *testing.T) {
+// TestSharedResolver_DelegatesToCache verifies SharedResolver is backed by the
+// process-wide packagesload cache (#2165): a repeated call with the same key
+// reuses the loaded packages (identical underlying *packages.Package pointers),
+// even though each call mints a fresh *Resolver wrapper. The cache mechanics
+// (singleflight dedup, failure-not-cached, key isolation) are covered directly
+// in tools/packagesload/cache_test.go; this guards the typeseval delegation.
+func TestSharedResolver_DelegatesToCache(t *testing.T) {
 	root := findArchTestModuleRoot(t)
 	pattern := "./tools/archtest/internal/typeseval/..."
-	t.Cleanup(func() {
-		sharedMu.Lock()
-		delete(sharedCache, cacheKey(root, false, pattern))
-		sharedMu.Unlock()
-	})
 
 	r1, err := SharedResolver(root, false, nil, pattern)
 	require.NoError(t, err)
 	r2, err := SharedResolver(root, false, nil, pattern)
 	require.NoError(t, err)
-	assert.Same(t, r1, r2, "SharedResolver should return cached singleton for same key")
+
+	require.NotEmpty(t, r1.Packages())
+	require.Same(t, r1.Packages()[0], r2.Packages()[0],
+		"SharedResolver must reuse the packagesload cache; a repeat call re-loaded packages")
+
+	// A distinct pattern loads an independent package set.
+	rOther, err := SharedResolver(root, false, nil, "./framework/pkg/...")
+	require.NoError(t, err)
+	namesTypeseval := packageNames(r1)
+	assert.Contains(t, namesTypeseval, "typeseval")
+	assert.NotEqual(t, namesTypeseval, packageNames(rOther),
+		"distinct patterns must load distinct package sets")
 }
 
-// TestSharedResolver_ConcurrentInit verifies that concurrent callers with a
-// cache-miss key all receive the same *Resolver and the race detector stays
-// clean. Each goroutine uses the same unique pattern so only one Load occurs.
-//
-// This is also the regression guard for singleflight deduplication: if the
-// loader were called once per goroutine (no singleflight) each call would
-// build its own *Resolver and the assert.Same would fail — N distinct
-// pointers would race-write to sharedCache, and the goroutines that
-// already returned would never see the "winning" Resolver. The current
-// SharedResolver releases sharedMu during LoadPackages and lets
-// singleflight collapse the in-flight calls; this test panics-out under
-// `-race` if either property regresses.
-func TestSharedResolver_ConcurrentInit(t *testing.T) {
+// TestSharedResolver_BadPatternErrors verifies resolverFrom maps a load that
+// surfaces packages.Error into a fail-fast error (a partial load is a scan
+// failure), returning a nil *Resolver.
+func TestSharedResolver_BadPatternErrors(t *testing.T) {
 	root := findArchTestModuleRoot(t)
-	pattern := "./tools/archtest/internal/typeseval/..."
-	key := cacheKey(root, false, pattern)
-
-	// Pre-clean so this test always exercises the miss path.
-	sharedMu.Lock()
-	delete(sharedCache, key)
-	sharedMu.Unlock()
-
-	t.Cleanup(func() {
-		sharedMu.Lock()
-		delete(sharedCache, key)
-		sharedMu.Unlock()
-	})
-
-	const N = 8
-	results := make([]*Resolver, N)
-	errs := make([]error, N)
-	var wg sync.WaitGroup
-	wg.Add(N)
-	for i := range N {
-		go func() {
-			defer wg.Done()
-			results[i], errs[i] = SharedResolver(root, false, nil, pattern)
-		}()
-	}
-	wg.Wait()
-
-	for i, err := range errs {
-		require.NoError(t, err, "goroutine %d got error", i)
-	}
-	for i := 1; i < N; i++ {
-		assert.Same(t, results[0], results[i], "goroutine %d got different *Resolver", i)
-	}
-}
-
-// TestSharedResolver_DifferentKeysIsolated verifies that two calls to
-// SharedResolver with distinct pattern sets return different *Resolver
-// instances backed by independently loaded package sets.
-func TestSharedResolver_DifferentKeysIsolated(t *testing.T) {
-	root := findArchTestModuleRoot(t)
-	patternA := "./tools/archtest/internal/typeseval/..."
-	patternB := "./framework/pkg/..."
-	keyA := cacheKey(root, false, patternA)
-	keyB := cacheKey(root, false, patternB)
-
-	// Pre-clean to avoid cross-test pollution from the Singleton test.
-	sharedMu.Lock()
-	delete(sharedCache, keyA)
-	delete(sharedCache, keyB)
-	sharedMu.Unlock()
-	t.Cleanup(func() {
-		sharedMu.Lock()
-		delete(sharedCache, keyA)
-		delete(sharedCache, keyB)
-		sharedMu.Unlock()
-	})
-
-	rA, err := SharedResolver(root, false, nil, patternA)
-	require.NoError(t, err)
-	rB, err := SharedResolver(root, false, nil, patternB)
-	require.NoError(t, err)
-
-	assert.NotSame(t, rA, rB, "different patterns must return distinct *Resolver instances")
-
-	namesA := packageNames(rA)
-	namesB := packageNames(rB)
-	assert.Contains(t, namesA, "typeseval", "rA should contain typeseval package")
-	assert.NotEqual(t, namesA, namesB, "resolvers with different patterns should have different package sets")
-}
-
-// TestSharedResolver_TestsFlagDistinctCacheKey verifies that toggling the
-// tests flag yields a distinct cache entry, so a tests=false load does not
-// inadvertently serve a tests=true caller (or vice versa).
-func TestSharedResolver_TestsFlagDistinctCacheKey(t *testing.T) {
-	root := findArchTestModuleRoot(t)
-	pattern := "./tools/archtest/internal/typeseval/..."
-	keyOff := cacheKey(root, false, pattern)
-	keyOn := cacheKey(root, true, pattern)
-
-	sharedMu.Lock()
-	delete(sharedCache, keyOff)
-	delete(sharedCache, keyOn)
-	sharedMu.Unlock()
-	t.Cleanup(func() {
-		sharedMu.Lock()
-		delete(sharedCache, keyOff)
-		delete(sharedCache, keyOn)
-		sharedMu.Unlock()
-	})
-
-	rOff, err := SharedResolver(root, false, nil, pattern)
-	require.NoError(t, err)
-	rOn, err := SharedResolver(root, true, nil, pattern)
-	require.NoError(t, err)
-	assert.NotSame(t, rOff, rOn, "tests=false and tests=true must produce distinct cache entries")
-}
-
-// TestSharedResolver_FailureNotCached verifies that a failed SharedResolver
-// call does not poison the cache: a subsequent call with the same key must
-// also attempt to load (and fail again), not return a nil *Resolver silently.
-func TestSharedResolver_FailureNotCached(t *testing.T) {
-	root := findArchTestModuleRoot(t)
-	// A pattern that will never match any package in the module.
-	badPattern := "./tools/archtest/testdata/nonexistent/..."
-	key := cacheKey(root, false, badPattern)
-
-	// Pre-clean so this test always exercises the miss path.
-	sharedMu.Lock()
-	delete(sharedCache, key)
-	sharedMu.Unlock()
-	t.Cleanup(func() {
-		sharedMu.Lock()
-		delete(sharedCache, key)
-		sharedMu.Unlock()
-	})
-
-	// First call: must fail.
-	r1, err1 := SharedResolver(root, false, nil, badPattern)
-	assert.Nil(t, r1, "first call with bad pattern should return nil resolver")
-	assert.Error(t, err1, "first call with bad pattern should return an error")
-
-	// Cache must not have been populated.
-	sharedMu.Lock()
-	_, cached := sharedCache[key]
-	sharedMu.Unlock()
-	assert.False(t, cached, "failed SharedResolver must not write to sharedCache")
-
-	// Second call with same key: must also fail (not return a silent nil).
-	r2, err2 := SharedResolver(root, false, nil, badPattern)
-	assert.Nil(t, r2, "second call with bad pattern should still return nil resolver")
-	assert.Error(t, err2, "failure result must not be cached — second call must also return an error")
+	r, err := SharedResolver(root, false, nil, "./tools/archtest/testdata/nonexistent/...")
+	assert.Nil(t, r, "a load with packages.Error must return a nil resolver")
+	assert.Error(t, err, "a load with packages.Error must map to a fail-fast error")
 }
 
 // packageNames returns the set of package names from the resolver's loaded packages.

--- a/tools/metricschema/schema.go
+++ b/tools/metricschema/schema.go
@@ -259,17 +259,19 @@ func Marshal(schema *Schema) ([]byte, error) {
 }
 
 // loadPackages loads the OBS-01 production scan patterns through the shared
-// satellite-aware loader packagesload.LoadWorkspace, which resolves the satellite
-// prefixes obs01ProductionPatterns emits — the multi-member parents ("./cmd/...",
-// "./adapters/...", "./examples/...", #2147) expanded to their members, and the
-// top-level single-module roots ("./corecells/...", "./cellmodules/...", #2164)
-// resolved as workspace members — so OBS-01 scans that production code. It keeps only
-// this project's packages
+// satellite-aware loader (packagesload.LoadWorkspaceCached), which resolves the
+// satellite prefixes obs01ProductionPatterns emits — the multi-member parents
+// ("./cmd/...", "./adapters/...", "./examples/...", #2147) expanded to their
+// members, and the top-level single-module roots ("./corecells/...",
+// "./cellmodules/...", #2164) resolved as workspace members — so OBS-01 scans
+// that production code. It keeps only this project's packages
 // (packageHasProjectFile), deduped by import path (preferring the syntax-rich copy),
-// and fails closed on any load error.
+// and fails closed on any load error. The load is memoized in the process-wide
+// packagesload cache (#2165), so a repeated scan of the same (root, patterns)
+// reuses the loaded packages.
 func loadPackages(ctx context.Context, root string, patterns ...string) ([]*packages.Package, error) {
 	cfg := packages.Config{Context: ctx, Mode: packageLoadMode(false)}
-	pkgs, loadErrs, err := packagesload.LoadWorkspace(root, cfg, patterns...)
+	pkgs, loadErrs, err := packagesload.LoadWorkspaceCached(root, cfg, patterns...)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/metricschema/schema_test.go
+++ b/tools/metricschema/schema_test.go
@@ -173,6 +173,35 @@ func TestPrometheusConstructor_RecognizesPromwrapFunnel(t *testing.T) {
 		"expected promwrap to export constructor functions; package path / loader regression?")
 }
 
+// TestLoadPackages_CachesRepeatLoads guards #2165: loadPackages routes through
+// the process-wide packagesload cache, so repeating the same (root, patterns)
+// load in one process reuses the loaded packages instead of re-running
+// packages.Load. Two loads of the same pattern must hand back the SAME
+// *packages.Package pointer for a given import path (cache hit, no re-load).
+func TestLoadPackages_CachesRepeatLoads(t *testing.T) {
+	root := repoRoot(t)
+	pkgs1, err := loadPackages(t.Context(), root, promwrapPkg)
+	require.NoError(t, err)
+	pkgs2, err := loadPackages(t.Context(), root, promwrapPkg)
+	require.NoError(t, err)
+
+	var p1, p2 any
+	for _, p := range pkgs1 {
+		if p.PkgPath == promwrapPkg {
+			p1 = p
+		}
+	}
+	for _, p := range pkgs2 {
+		if p.PkgPath == promwrapPkg {
+			p2 = p
+		}
+	}
+	require.NotNil(t, p1, "promwrap package missing from first load")
+	require.NotNil(t, p2, "promwrap package missing from second load")
+	require.Same(t, p1, p2,
+		"loadPackages must reuse the process-wide cache (#2165); repeat load re-ran packages.Load")
+}
+
 func TestMarshalOmitsLineNumbers(t *testing.T) {
 	schema := &Schema{
 		AssemblyID: "fixture",

--- a/tools/packagesload/cache.go
+++ b/tools/packagesload/cache.go
@@ -11,17 +11,27 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
+// cache-key kind discriminators: which loader produced (and would re-serve) the
+// entry. A "W" entry and an "F" entry for the same (root, cfg, patterns) load
+// different package sets, so they never alias.
+const (
+	cacheKindWorkspace = "W" // satellite-aware LoadWorkspace
+	cacheKindFlat      = "F" // flat ModeWorkspace LoadFlat
+)
+
 // WorkspaceCache memoizes [LoadWorkspace] / [LoadFlat] results across calls
 // within a process: repeated identical loads run packages.Load once and reuse
 // the loaded packages, collapsing concurrent identical loads via singleflight.
 //
-// Single source (#2165): this is the ONLY package-load cache in GoCell tooling.
-// Both the OBS-01 metric scan (tools/metricschema) and the archtest typed façade
-// (tools/archtest/internal/typeseval) route their cached loads here — no package
-// re-implements a parallel singleflight+map cache. The loading itself is already
-// Hard-funneled by PACKAGES-LOAD-FUNNEL-01 (packages.Load reachable only from
-// this package), so a re-introduced parallel cache could not bypass the loader,
-// only fail to reuse this cache (a perf regression, not a correctness gap).
+// Single source (#2165): this is the sanctioned single package-load cache in
+// GoCell tooling. Both the OBS-01 metric scan (tools/metricschema) and the
+// archtest typed façade (tools/archtest/internal/typeseval) route their cached
+// loads here, rather than each re-implementing a parallel singleflight+map cache.
+// The loading itself is Hard-funneled by PACKAGES-LOAD-FUNNEL-01 (packages.Load
+// reachable only from this package), so a re-introduced parallel cache could not
+// bypass the loader (Hard) — it could only fail to reuse this cache (a perf
+// regression, not a correctness gap). The "single cache" boundary is documented,
+// not separately enforced.
 //
 // Unbounded by design: entries are held for the process lifetime. The consumers
 // are short-lived batch processes (`gocell generate`, the archtest gate) that
@@ -31,12 +41,15 @@ import (
 // triggers re-loads (the regression this fixes), a safe-large cap never evicts.
 type WorkspaceCache struct {
 	mu    sync.Mutex
-	items map[string]cacheEntry
+	items map[string][]*packages.Package // CLEAN loads only (len(errs)==0); never an errored result
 	group singleflight.Group
 }
 
-// cacheEntry is a completed, clean load (len(errs)==0) retained for reuse.
-type cacheEntry struct {
+// loadResult is the transient carrier passed through singleflight so co-flight
+// waiters see the same (pkgs, errs). Only the pkgs of a CLEAN load reach the
+// items map — errs never persist, so an errored load can never be served from
+// cache (type-level fail-closed).
+type loadResult struct {
 	pkgs []*packages.Package
 	errs []packages.Error
 }
@@ -45,7 +58,7 @@ type cacheEntry struct {
 // production routes through the process-wide [LoadWorkspaceCached] /
 // [LoadFlatCached].
 func NewWorkspaceCache() *WorkspaceCache {
-	return &WorkspaceCache{items: map[string]cacheEntry{}}
+	return &WorkspaceCache{items: map[string][]*packages.Package{}}
 }
 
 // LoadWorkspace is the cached form of the package-level [LoadWorkspace] (the
@@ -54,7 +67,7 @@ func NewWorkspaceCache() *WorkspaceCache {
 func (c *WorkspaceCache) LoadWorkspace(
 	root string, cfg packages.Config, patterns ...string,
 ) ([]*packages.Package, []packages.Error, error) {
-	key := cacheKeyFor("W", cfg, root, patterns)
+	key := cacheKeyFor(cacheKindWorkspace, cfg, root, patterns)
 	return c.loadKeyed(key, func() ([]*packages.Package, []packages.Error, error) {
 		return LoadWorkspace(root, cfg, patterns...)
 	})
@@ -63,18 +76,23 @@ func (c *WorkspaceCache) LoadWorkspace(
 // LoadFlat is the cached form of a flat ModeWorkspace [Load] from root (no
 // satellite parent-prefix expansion) — the cross-module workspace production
 // scan typeseval's LoadProductionPackages performs.
+//
+// Keyed distinctly from [WorkspaceCache.LoadWorkspace] (kind "F" vs "W"): the
+// two load different package sets, so a warm-up via LoadFlat does NOT pre-heat
+// LoadWorkspace callers (SharedResolver) and vice versa — each holds its own entry.
 func (c *WorkspaceCache) LoadFlat(
 	root string, cfg packages.Config, patterns ...string,
 ) ([]*packages.Package, []packages.Error, error) {
-	key := cacheKeyFor("F", cfg, root, patterns)
+	key := cacheKeyFor(cacheKindFlat, cfg, root, patterns)
 	return c.loadKeyed(key, func() ([]*packages.Package, []packages.Error, error) {
 		return loadFlat(root, cfg, patterns...)
 	})
 }
 
 // loadFlat performs a flat ModeWorkspace load from root and collects the
-// dir-prefixed packages.Errors, mirroring [LoadWorkspace]'s return shape. cfg is
-// taken by value; Dir is owned here.
+// dir-prefixed packages.Errors, mirroring [LoadWorkspace]'s return shape (the
+// prefix is the flat root, matching the pre-#2165 typeseval ModeWorkspace path).
+// cfg is taken by value; Dir is owned here.
 func loadFlat(root string, cfg packages.Config, patterns ...string) ([]*packages.Package, []packages.Error, error) {
 	cfg.Dir = root
 	pkgs, err := Load(ModeWorkspace, &cfg, patterns...)
@@ -91,59 +109,67 @@ func loadFlat(root string, cfg packages.Config, patterns ...string) ([]*packages
 	return pkgs, errs, nil
 }
 
-// loadKeyed returns the cached result for key, or runs loader once — collapsing
-// concurrent identical loads via singleflight — and caches a CLEAN result. A Go
-// error or any non-empty packages.Error is NOT cached: both are fail-closed
-// failures for callers (metricschema / typeseval both treat non-empty errs as a
-// scan failure), so the next call re-loads rather than serving a poisoned entry.
+// loadKeyed returns the cached packages for key, or runs loader once —
+// collapsing concurrent identical loads via singleflight — and caches only a
+// CLEAN result. A Go error or any non-empty packages.Error is NOT persisted:
+// both are fail-closed failures for callers (metricschema / typeseval both treat
+// non-empty errs as a scan failure), so the NEXT independent call re-loads
+// rather than serving a poisoned entry. Concurrent co-flight waiters of a failed
+// load share that one failure result; only persistence is suppressed.
+//
+// On a cache HIT no load runs, so the caller's cfg.Context is irrelevant — a
+// canceled ctx does not interrupt a hit; ctx only governs the first real load.
+// The singleflight "shared" bool is intentionally discarded: a build-time batch
+// tool has no need to distinguish a self-load from a collapsed one.
 func (c *WorkspaceCache) loadKeyed(
 	key string, loader func() ([]*packages.Package, []packages.Error, error),
 ) ([]*packages.Package, []packages.Error, error) {
-	if e, ok := c.get(key); ok {
-		return e.pkgs, e.errs, nil
+	if pkgs, ok := c.get(key); ok {
+		return pkgs, nil, nil
 	}
 	v, err, _ := c.group.Do(key, func() (any, error) {
 		// Re-check: another caller may have filled the cache between our miss
 		// and entering Do.
-		if e, ok := c.get(key); ok {
-			return e, nil
+		if pkgs, ok := c.get(key); ok {
+			return loadResult{pkgs: pkgs}, nil
 		}
 		pkgs, errs, err := loader()
 		if err != nil {
 			return nil, err
 		}
-		e := cacheEntry{pkgs: pkgs, errs: errs}
 		if len(errs) == 0 {
-			c.put(key, e)
+			c.put(key, pkgs)
 		}
-		return e, nil
+		return loadResult{pkgs: pkgs, errs: errs}, nil
 	})
 	if err != nil {
 		return nil, nil, err
 	}
-	e := v.(cacheEntry)
-	return e.pkgs, e.errs, nil
+	r := v.(loadResult)
+	return r.pkgs, r.errs, nil
 }
 
-func (c *WorkspaceCache) get(key string) (cacheEntry, bool) {
+func (c *WorkspaceCache) get(key string) ([]*packages.Package, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	e, ok := c.items[key]
-	return e, ok
+	pkgs, ok := c.items[key]
+	return pkgs, ok
 }
 
-func (c *WorkspaceCache) put(key string, e cacheEntry) {
+func (c *WorkspaceCache) put(key string, pkgs []*packages.Package) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.items[key] = e
+	c.items[key] = pkgs
 }
 
 // cacheKeyFor builds the cache key from the result-determining inputs: kind
-// ("W" satellite-aware / "F" flat), cfg.Mode, cfg.Tests, cfg.BuildFlags, root,
-// and the patterns (sorted — pattern order never changes the loaded package
-// SET, and callers dedup/sort downstream). cfg.Context (per-call) and cfg.Dir
-// (loader-owned) are deliberately EXCLUDED. NUL separates fields; it cannot
-// occur in a filesystem path or go import pattern, so collisions are impossible.
+// ([cacheKindWorkspace] "W" satellite-aware / [cacheKindFlat] "F" flat),
+// cfg.Mode, cfg.Tests, cfg.BuildFlags, root, and the patterns (sorted — pattern
+// order never changes the loaded package SET, and callers dedup/sort downstream).
+// cfg.Context (per-call) and cfg.Dir (loader-owned) are deliberately EXCLUDED;
+// because Context is not keyed, a cache hit ignores a canceled ctx (see
+// [WorkspaceCache.loadKeyed]). NUL separates fields; it cannot occur in a
+// filesystem path or go import pattern, so collisions are impossible.
 func cacheKeyFor(kind string, cfg packages.Config, root string, patterns []string) string {
 	tests := "0"
 	if cfg.Tests {

--- a/tools/packagesload/cache.go
+++ b/tools/packagesload/cache.go
@@ -67,8 +67,7 @@ func NewWorkspaceCache() *WorkspaceCache {
 func (c *WorkspaceCache) LoadWorkspace(
 	root string, cfg packages.Config, patterns ...string,
 ) ([]*packages.Package, []packages.Error, error) {
-	key := cacheKeyFor(cacheKindWorkspace, cfg, root, patterns)
-	return c.loadKeyed(key, func() ([]*packages.Package, []packages.Error, error) {
+	return c.loadKeyed(cacheKindWorkspace, root, cfg, patterns, func() ([]*packages.Package, []packages.Error, error) {
 		return LoadWorkspace(root, cfg, patterns...)
 	})
 }
@@ -83,8 +82,7 @@ func (c *WorkspaceCache) LoadWorkspace(
 func (c *WorkspaceCache) LoadFlat(
 	root string, cfg packages.Config, patterns ...string,
 ) ([]*packages.Package, []packages.Error, error) {
-	key := cacheKeyFor(cacheKindFlat, cfg, root, patterns)
-	return c.loadKeyed(key, func() ([]*packages.Package, []packages.Error, error) {
+	return c.loadKeyed(cacheKindFlat, root, cfg, patterns, func() ([]*packages.Package, []packages.Error, error) {
 		return loadFlat(root, cfg, patterns...)
 	})
 }
@@ -109,21 +107,57 @@ func loadFlat(root string, cfg packages.Config, patterns ...string) ([]*packages
 	return pkgs, errs, nil
 }
 
-// loadKeyed returns the cached packages for key, or runs loader once —
-// collapsing concurrent identical loads via singleflight — and caches only a
-// CLEAN result. A Go error or any non-empty packages.Error is NOT persisted:
-// both are fail-closed failures for callers (metricschema / typeseval both treat
-// non-empty errs as a scan failure), so the NEXT independent call re-loads
-// rather than serving a poisoned entry. Concurrent co-flight waiters of a failed
-// load share that one failure result; only persistence is suppressed.
+// validateCacheable fails fast when cfg sets a field that affects the load
+// RESULT but is NOT part of the cache key — otherwise two calls with identical
+// keyed fields (Mode / Tests / BuildFlags / root / patterns) but different
+// Env / Overlay / ParseFile / Fset would alias, and the second would be served a
+// stale package graph (wrong build env, file contents, AST, or positions).
+// Context (per-call) and Dir (loader-owned) are intentionally unkeyed and thus
+// allowed; Logf is diagnostic-only. The uncached package-level [LoadWorkspace] /
+// [Load] impose no such restriction — a caller needing these fields uses them.
+func validateCacheable(cfg packages.Config) error {
+	for _, f := range []struct {
+		name string
+		set  bool
+	}{
+		{"Env", cfg.Env != nil},
+		{"Overlay", cfg.Overlay != nil},
+		{"ParseFile", cfg.ParseFile != nil},
+		{"Fset", cfg.Fset != nil},
+	} {
+		if f.set {
+			return fmt.Errorf("packagesload: cached load cannot key on cfg.%s "+
+				"(it affects the load result but is not in the cache key); "+
+				"leave it nil or use the uncached loader", f.name)
+		}
+	}
+	return nil
+}
+
+// loadKeyed is the single funnel for every cached load: it validates cfg
+// ([validateCacheable]), computes the key ([cacheKeyFor]), then returns the
+// cached packages or runs loader once — collapsing concurrent identical loads
+// via singleflight — and caches only a CLEAN result. Routing both validation and
+// keying through here makes them unavoidable for any cached entrypoint.
+//
+// A Go error or any non-empty packages.Error is NOT persisted: both are
+// fail-closed failures for callers (metricschema / typeseval both treat non-empty
+// errs as a scan failure), so the NEXT independent call re-loads rather than
+// serving a poisoned entry. Concurrent co-flight waiters of a failed load share
+// that one failure result; only persistence is suppressed.
 //
 // On a cache HIT no load runs, so the caller's cfg.Context is irrelevant — a
 // canceled ctx does not interrupt a hit; ctx only governs the first real load.
 // The singleflight "shared" bool is intentionally discarded: a build-time batch
 // tool has no need to distinguish a self-load from a collapsed one.
 func (c *WorkspaceCache) loadKeyed(
-	key string, loader func() ([]*packages.Package, []packages.Error, error),
+	kind, root string, cfg packages.Config, patterns []string,
+	loader func() ([]*packages.Package, []packages.Error, error),
 ) ([]*packages.Package, []packages.Error, error) {
+	if err := validateCacheable(cfg); err != nil {
+		return nil, nil, err
+	}
+	key := cacheKeyFor(kind, cfg, root, patterns)
 	if pkgs, ok := c.get(key); ok {
 		return pkgs, nil, nil
 	}

--- a/tools/packagesload/cache.go
+++ b/tools/packagesload/cache.go
@@ -1,0 +1,176 @@
+package packagesload
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
+	"golang.org/x/tools/go/packages"
+)
+
+// WorkspaceCache memoizes [LoadWorkspace] / [LoadFlat] results across calls
+// within a process: repeated identical loads run packages.Load once and reuse
+// the loaded packages, collapsing concurrent identical loads via singleflight.
+//
+// Single source (#2165): this is the ONLY package-load cache in GoCell tooling.
+// Both the OBS-01 metric scan (tools/metricschema) and the archtest typed façade
+// (tools/archtest/internal/typeseval) route their cached loads here — no package
+// re-implements a parallel singleflight+map cache. The loading itself is already
+// Hard-funneled by PACKAGES-LOAD-FUNNEL-01 (packages.Load reachable only from
+// this package), so a re-introduced parallel cache could not bypass the loader,
+// only fail to reuse this cache (a perf regression, not a correctness gap).
+//
+// Unbounded by design: entries are held for the process lifetime. The consumers
+// are short-lived batch processes (`gocell generate`, the archtest gate) that
+// load a bounded set of (mode, cfg, patterns) once and exit — exactly the
+// in-process warmup pattern this cache exists for. A bounded LRU has no good
+// operating point here: a small cap evicts the large production scans and
+// triggers re-loads (the regression this fixes), a safe-large cap never evicts.
+type WorkspaceCache struct {
+	mu    sync.Mutex
+	items map[string]cacheEntry
+	group singleflight.Group
+}
+
+// cacheEntry is a completed, clean load (len(errs)==0) retained for reuse.
+type cacheEntry struct {
+	pkgs []*packages.Package
+	errs []packages.Error
+}
+
+// NewWorkspaceCache returns an empty cache. Tests construct isolated instances;
+// production routes through the process-wide [LoadWorkspaceCached] /
+// [LoadFlatCached].
+func NewWorkspaceCache() *WorkspaceCache {
+	return &WorkspaceCache{items: map[string]cacheEntry{}}
+}
+
+// LoadWorkspace is the cached form of the package-level [LoadWorkspace] (the
+// satellite-aware loader). Used by metricschema's OBS-01 scan and typeseval's
+// SharedResolver.
+func (c *WorkspaceCache) LoadWorkspace(
+	root string, cfg packages.Config, patterns ...string,
+) ([]*packages.Package, []packages.Error, error) {
+	key := cacheKeyFor("W", cfg, root, patterns)
+	return c.loadKeyed(key, func() ([]*packages.Package, []packages.Error, error) {
+		return LoadWorkspace(root, cfg, patterns...)
+	})
+}
+
+// LoadFlat is the cached form of a flat ModeWorkspace [Load] from root (no
+// satellite parent-prefix expansion) — the cross-module workspace production
+// scan typeseval's LoadProductionPackages performs.
+func (c *WorkspaceCache) LoadFlat(
+	root string, cfg packages.Config, patterns ...string,
+) ([]*packages.Package, []packages.Error, error) {
+	key := cacheKeyFor("F", cfg, root, patterns)
+	return c.loadKeyed(key, func() ([]*packages.Package, []packages.Error, error) {
+		return loadFlat(root, cfg, patterns...)
+	})
+}
+
+// loadFlat performs a flat ModeWorkspace load from root and collects the
+// dir-prefixed packages.Errors, mirroring [LoadWorkspace]'s return shape. cfg is
+// taken by value; Dir is owned here.
+func loadFlat(root string, cfg packages.Config, patterns ...string) ([]*packages.Package, []packages.Error, error) {
+	cfg.Dir = root
+	pkgs, err := Load(ModeWorkspace, &cfg, patterns...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("packages.Load: %w", err)
+	}
+	var errs []packages.Error
+	packages.Visit(pkgs, nil, func(p *packages.Package) {
+		for i := range p.Errors {
+			p.Errors[i].Msg = root + ": " + p.Errors[i].Msg
+		}
+		errs = append(errs, p.Errors...)
+	})
+	return pkgs, errs, nil
+}
+
+// loadKeyed returns the cached result for key, or runs loader once — collapsing
+// concurrent identical loads via singleflight — and caches a CLEAN result. A Go
+// error or any non-empty packages.Error is NOT cached: both are fail-closed
+// failures for callers (metricschema / typeseval both treat non-empty errs as a
+// scan failure), so the next call re-loads rather than serving a poisoned entry.
+func (c *WorkspaceCache) loadKeyed(
+	key string, loader func() ([]*packages.Package, []packages.Error, error),
+) ([]*packages.Package, []packages.Error, error) {
+	if e, ok := c.get(key); ok {
+		return e.pkgs, e.errs, nil
+	}
+	v, err, _ := c.group.Do(key, func() (any, error) {
+		// Re-check: another caller may have filled the cache between our miss
+		// and entering Do.
+		if e, ok := c.get(key); ok {
+			return e, nil
+		}
+		pkgs, errs, err := loader()
+		if err != nil {
+			return nil, err
+		}
+		e := cacheEntry{pkgs: pkgs, errs: errs}
+		if len(errs) == 0 {
+			c.put(key, e)
+		}
+		return e, nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	e := v.(cacheEntry)
+	return e.pkgs, e.errs, nil
+}
+
+func (c *WorkspaceCache) get(key string) (cacheEntry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.items[key]
+	return e, ok
+}
+
+func (c *WorkspaceCache) put(key string, e cacheEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items[key] = e
+}
+
+// cacheKeyFor builds the cache key from the result-determining inputs: kind
+// ("W" satellite-aware / "F" flat), cfg.Mode, cfg.Tests, cfg.BuildFlags, root,
+// and the patterns (sorted — pattern order never changes the loaded package
+// SET, and callers dedup/sort downstream). cfg.Context (per-call) and cfg.Dir
+// (loader-owned) are deliberately EXCLUDED. NUL separates fields; it cannot
+// occur in a filesystem path or go import pattern, so collisions are impossible.
+func cacheKeyFor(kind string, cfg packages.Config, root string, patterns []string) string {
+	tests := "0"
+	if cfg.Tests {
+		tests = "1"
+	}
+	pats := append([]string(nil), patterns...)
+	sort.Strings(pats)
+	return strings.Join([]string{
+		kind,
+		strconv.Itoa(int(cfg.Mode)),
+		tests,
+		strings.Join(cfg.BuildFlags, "\x00"),
+		root,
+		strings.Join(pats, "\x00"),
+	}, "\x00")
+}
+
+// sharedWorkspaceCache is the sanctioned process-wide instance both consumers
+// route through; they hold no cache state of their own.
+var sharedWorkspaceCache = NewWorkspaceCache()
+
+// LoadWorkspaceCached is [WorkspaceCache.LoadWorkspace] on the process-wide cache.
+func LoadWorkspaceCached(root string, cfg packages.Config, patterns ...string) ([]*packages.Package, []packages.Error, error) {
+	return sharedWorkspaceCache.LoadWorkspace(root, cfg, patterns...)
+}
+
+// LoadFlatCached is [WorkspaceCache.LoadFlat] on the process-wide cache.
+func LoadFlatCached(root string, cfg packages.Config, patterns ...string) ([]*packages.Package, []packages.Error, error) {
+	return sharedWorkspaceCache.LoadFlat(root, cfg, patterns...)
+}

--- a/tools/packagesload/cache_test.go
+++ b/tools/packagesload/cache_test.go
@@ -64,7 +64,7 @@ func TestWorkspaceCache_Key(t *testing.T) {
 }
 
 func withMode(cfg packages.Config, m packages.LoadMode) packages.Config { cfg.Mode = m; return cfg }
-func withTests(cfg packages.Config, v bool) packages.Config            { cfg.Tests = v; return cfg }
+func withTests(cfg packages.Config, v bool) packages.Config             { cfg.Tests = v; return cfg }
 func withFlags(cfg packages.Config, f string) packages.Config {
 	cfg.BuildFlags = []string{f}
 	return cfg

--- a/tools/packagesload/cache_test.go
+++ b/tools/packagesload/cache_test.go
@@ -88,7 +88,7 @@ func TestWorkspaceCache_HitReturnsSamePackages(t *testing.T) {
 	if err2 != nil {
 		t.Fatalf("second LoadWorkspace: err=%v", err2)
 	}
-	if &p1[0] != &p2[0] && p1[0] != p2[0] {
+	if p1[0] != p2[0] {
 		t.Fatalf("cache hit must return the same *packages.Package; got %p vs %p", p1[0], p2[0])
 	}
 }

--- a/tools/packagesload/cache_test.go
+++ b/tools/packagesload/cache_test.go
@@ -2,7 +2,9 @@ package packagesload
 
 import (
 	"context"
+	"go/token"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"golang.org/x/tools/go/packages"
@@ -12,11 +14,11 @@ import (
 // temp dir and returns its root. LoadWorkspace takes its ModeModule fallback
 // path for such a tree (GOWORK=off appended), so loads are deterministic and
 // independent of the ambient repo workspace.
-func writeSingleModule(t *testing.T, pkgBody string) string {
+func writeSingleModule(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
 	writeWS(t, root, "go.mod", "module example.com/c\n\ngo 1.25\n")
-	writeWS(t, root, "p/p.go", pkgBody)
+	writeWS(t, root, "p/p.go", "package p\n\nfunc P() int { return 1 }\n")
 	return root
 }
 
@@ -73,7 +75,7 @@ func withFlags(cfg packages.Config, f string) packages.Config {
 // TestWorkspaceCache_HitReturnsSamePackages verifies a cache HIT returns the
 // identical loaded *packages.Package pointers (no second load) for the same key.
 func TestWorkspaceCache_HitReturnsSamePackages(t *testing.T) {
-	root := writeSingleModule(t, "package p\n\nfunc P() int { return 1 }\n")
+	root := writeSingleModule(t)
 	cfg := packages.Config{Mode: packages.NeedName | packages.NeedFiles | packages.NeedImports}
 	c := NewWorkspaceCache()
 
@@ -99,7 +101,7 @@ func TestWorkspaceCache_HitReturnsSamePackages(t *testing.T) {
 // independently → distinct package pointers and a racy map write; this is the
 // regression guard for the singleflight collapse (run under -race).
 func TestWorkspaceCache_ConcurrentSingleflight(t *testing.T) {
-	root := writeSingleModule(t, "package p\n\nfunc P() int { return 1 }\n")
+	root := writeSingleModule(t)
 	cfg := packages.Config{Mode: packages.NeedName | packages.NeedFiles | packages.NeedImports}
 	c := NewWorkspaceCache()
 
@@ -195,7 +197,7 @@ func TestWorkspaceCache_LoadFlatCaches(t *testing.T) {
 // points reuse one process-wide cache: two calls with the same key serve the
 // same loaded packages.
 func TestLoadWorkspaceCached_SharedInstance(t *testing.T) {
-	root := writeSingleModule(t, "package p\n\nfunc P() int { return 1 }\n")
+	root := writeSingleModule(t)
 	cfg := packages.Config{Mode: packages.NeedName | packages.NeedFiles | packages.NeedImports}
 
 	p1, errs1, err1 := LoadWorkspaceCached(root, cfg, "./...")
@@ -211,5 +213,107 @@ func TestLoadWorkspaceCached_SharedInstance(t *testing.T) {
 	}
 	if p1[0] != p2[0] {
 		t.Fatalf("shared cache must reuse loaded packages across calls; got %p vs %p", p1[0], p2[0])
+	}
+}
+
+// TestWorkspaceCache_RejectsUncacheableConfig verifies the cached entrypoints
+// fail fast (both LoadWorkspace and LoadFlat, via the loadKeyed funnel) when cfg
+// sets a result-affecting field that is NOT in the cache key — otherwise the
+// second call could be served a stale package graph.
+func TestWorkspaceCache_RejectsUncacheableConfig(t *testing.T) {
+	root := writeSingleModule(t)
+	c := NewWorkspaceCache()
+	cases := []struct {
+		name string
+		cfg  packages.Config
+	}{
+		{"Env", packages.Config{Mode: packages.NeedName, Env: []string{"FOO=bar"}}},
+		{"Overlay", packages.Config{Mode: packages.NeedName, Overlay: map[string][]byte{"/x.go": {}}}},
+		{"Fset", packages.Config{Mode: packages.NeedName, Fset: token.NewFileSet()}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, err := c.LoadWorkspace(root, tc.cfg, "./..."); err == nil {
+				t.Fatalf("LoadWorkspace must fail-fast when cfg.%s is set (unkeyed, affects load result)", tc.name)
+			}
+			if _, _, err := c.LoadFlat(root, tc.cfg, "./..."); err == nil {
+				t.Fatalf("LoadFlat must fail-fast when cfg.%s is set (same loadKeyed funnel)", tc.name)
+			}
+		})
+	}
+}
+
+// TestWorkspaceCache_loadKeyed_RunsLoaderOnce is the deterministic singleflight
+// proof: N concurrent callers of the same key must collapse to exactly one
+// loader execution (atomic counter == 1) and all receive the same packages. A
+// blocking fake loader holds the single in-flight load open while the others
+// pile in; if singleflight regressed, each cache-miss caller would run its own
+// loader and the counter would exceed 1.
+func TestWorkspaceCache_loadKeyed_RunsLoaderOnce(t *testing.T) {
+	c := NewWorkspaceCache()
+	cfg := packages.Config{Mode: packages.NeedName}
+	const N = 8
+	var calls atomic.Int64
+	entered := make(chan struct{}, N)
+	proceed := make(chan struct{})
+	//nolint:unparam // signature is dictated by loadKeyed's loader param; this fake always succeeds
+	loader := func() ([]*packages.Package, []packages.Error, error) {
+		calls.Add(1)
+		entered <- struct{}{}
+		<-proceed // hold the in-flight load open so concurrent callers join it
+		return []*packages.Package{{PkgPath: "example.com/x"}}, nil, nil
+	}
+
+	results := make([][]*packages.Package, N)
+	var ready, done sync.WaitGroup
+	ready.Add(N)
+	done.Add(N)
+	for i := range N {
+		go func() {
+			defer done.Done()
+			ready.Done()
+			results[i], _, _ = c.loadKeyed(cacheKindWorkspace, "/r", cfg, []string{"./..."}, loader)
+		}()
+	}
+	ready.Wait() // all goroutines launched
+	<-entered    // the single in-flight load has started (blocked on proceed)
+	close(proceed)
+	done.Wait()
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("singleflight must run the loader exactly once per key; ran %d times", got)
+	}
+	for i := 1; i < N; i++ {
+		if results[i][0] != results[0][0] {
+			t.Fatalf("all callers must receive the same loaded packages; goroutine %d differs", i)
+		}
+	}
+}
+
+// TestLoadFlatCached_SharedInstance proves the flat production warm-up path
+// (LoadProductionPackages -> LoadFlatCached) reuses the process-wide cache: a
+// repeated LoadFlatCached of the same (root, patterns) returns the same
+// *packages.Package pointers (the F3 coverage gap for the kind "F" path).
+func TestLoadFlatCached_SharedInstance(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("GOWORK", "off")
+	writeWS(t, root, "go.work", "go 1.25\n\nuse .\n")
+	writeWS(t, root, "go.mod", "module example.com/flatshared\n\ngo 1.25\n")
+	writeWS(t, root, "p/p.go", "package p\n\nfunc P() int { return 1 }\n")
+	cfg := packages.Config{Mode: packages.NeedName | packages.NeedFiles | packages.NeedImports}
+
+	p1, errs1, err1 := LoadFlatCached(root, cfg, "./p/...")
+	if err1 != nil || len(errs1) > 0 {
+		t.Fatalf("first LoadFlatCached: err=%v errs=%v", err1, errs1)
+	}
+	if !containsPkgPath(p1, "example.com/flatshared/p") {
+		t.Fatalf("LoadFlatCached did not load example.com/flatshared/p; got %v", pkgPaths(p1))
+	}
+	p2, _, err2 := LoadFlatCached(root, cfg, "./p/...")
+	if err2 != nil {
+		t.Fatalf("second LoadFlatCached: err=%v", err2)
+	}
+	if p1[0] != p2[0] {
+		t.Fatalf("LoadFlatCached must reuse the process-wide cache (flat production path); got %p vs %p", p1[0], p2[0])
 	}
 }

--- a/tools/packagesload/cache_test.go
+++ b/tools/packagesload/cache_test.go
@@ -1,0 +1,215 @@
+package packagesload
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// writeSingleModule writes a minimal single-module (no go.work) tree at a fresh
+// temp dir and returns its root. LoadWorkspace takes its ModeModule fallback
+// path for such a tree (GOWORK=off appended), so loads are deterministic and
+// independent of the ambient repo workspace.
+func writeSingleModule(t *testing.T, pkgBody string) string {
+	t.Helper()
+	root := t.TempDir()
+	writeWS(t, root, "go.mod", "module example.com/c\n\ngo 1.25\n")
+	writeWS(t, root, "p/p.go", pkgBody)
+	return root
+}
+
+// TestWorkspaceCache_Key pins the cache-key semantics WITHOUT a real load: the
+// key includes kind / cfg.Mode / cfg.Tests / cfg.BuildFlags / root / sorted
+// patterns, and EXCLUDES cfg.Context (per-call) and cfg.Dir (loader-owned).
+// Pattern order is normalized (same set → same key) because order never changes
+// the loaded package SET.
+func TestWorkspaceCache_Key(t *testing.T) {
+	root := "/ws/root"
+	patterns := []string{"./a/...", "./b/..."}
+	base := packages.Config{Mode: packages.NeedName | packages.NeedFiles, Tests: false}
+	k := cacheKeyFor("W", base, root, patterns)
+
+	// Context + Dir excluded → same key.
+	ctxDir := base
+	ctxDir.Context = context.Background()
+	ctxDir.Dir = "/some/other/dir"
+	if got := cacheKeyFor("W", ctxDir, root, patterns); got != k {
+		t.Fatalf("Context/Dir must be excluded from key:\n base=%q\n  got=%q", k, got)
+	}
+
+	// Pattern order normalized → same key.
+	if got := cacheKeyFor("W", base, root, []string{"./b/...", "./a/..."}); got != k {
+		t.Fatalf("pattern order must be normalized in key:\n base=%q\n  got=%q", k, got)
+	}
+
+	// Every keyed dimension must change the key.
+	diffs := []struct {
+		name string
+		key  string
+	}{
+		{"kind W vs F", cacheKeyFor("F", base, root, patterns)},
+		{"Mode", cacheKeyFor("W", withMode(base, base.Mode|packages.NeedDeps), root, patterns)},
+		{"Tests", cacheKeyFor("W", withTests(base, true), root, patterns)},
+		{"BuildFlags", cacheKeyFor("W", withFlags(base, "-tags=x"), root, patterns)},
+		{"root", cacheKeyFor("W", base, "/other/root", patterns)},
+		{"patterns", cacheKeyFor("W", base, root, []string{"./a/..."})},
+	}
+	for _, d := range diffs {
+		if d.key == k {
+			t.Fatalf("%s must change the cache key, but it matched base %q", d.name, k)
+		}
+	}
+}
+
+func withMode(cfg packages.Config, m packages.LoadMode) packages.Config { cfg.Mode = m; return cfg }
+func withTests(cfg packages.Config, v bool) packages.Config            { cfg.Tests = v; return cfg }
+func withFlags(cfg packages.Config, f string) packages.Config {
+	cfg.BuildFlags = []string{f}
+	return cfg
+}
+
+// TestWorkspaceCache_HitReturnsSamePackages verifies a cache HIT returns the
+// identical loaded *packages.Package pointers (no second load) for the same key.
+func TestWorkspaceCache_HitReturnsSamePackages(t *testing.T) {
+	root := writeSingleModule(t, "package p\n\nfunc P() int { return 1 }\n")
+	cfg := packages.Config{Mode: packages.NeedName | packages.NeedFiles | packages.NeedImports}
+	c := NewWorkspaceCache()
+
+	p1, errs1, err1 := c.LoadWorkspace(root, cfg, "./...")
+	if err1 != nil || len(errs1) > 0 {
+		t.Fatalf("first LoadWorkspace: err=%v errs=%v", err1, errs1)
+	}
+	if len(p1) == 0 {
+		t.Fatalf("first LoadWorkspace returned no packages")
+	}
+	p2, _, err2 := c.LoadWorkspace(root, cfg, "./...")
+	if err2 != nil {
+		t.Fatalf("second LoadWorkspace: err=%v", err2)
+	}
+	if &p1[0] != &p2[0] && p1[0] != p2[0] {
+		t.Fatalf("cache hit must return the same *packages.Package; got %p vs %p", p1[0], p2[0])
+	}
+}
+
+// TestWorkspaceCache_ConcurrentSingleflight verifies concurrent cache-miss
+// callers of the same key all receive the same loaded packages and the race
+// detector stays clean. Without singleflight each goroutine would load
+// independently → distinct package pointers and a racy map write; this is the
+// regression guard for the singleflight collapse (run under -race).
+func TestWorkspaceCache_ConcurrentSingleflight(t *testing.T) {
+	root := writeSingleModule(t, "package p\n\nfunc P() int { return 1 }\n")
+	cfg := packages.Config{Mode: packages.NeedName | packages.NeedFiles | packages.NeedImports}
+	c := NewWorkspaceCache()
+
+	const N = 8
+	results := make([][]*packages.Package, N)
+	errsArr := make([]error, N)
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := range N {
+		go func() {
+			defer wg.Done()
+			results[i], _, errsArr[i] = c.LoadWorkspace(root, cfg, "./...")
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errsArr {
+		if err != nil {
+			t.Fatalf("goroutine %d: %v", i, err)
+		}
+		if len(results[i]) == 0 {
+			t.Fatalf("goroutine %d got no packages", i)
+		}
+	}
+	for i := 1; i < N; i++ {
+		if results[i][0] != results[0][0] {
+			t.Fatalf("goroutine %d got a distinct *packages.Package (singleflight regressed): %p vs %p",
+				i, results[i][0], results[0][0])
+		}
+	}
+}
+
+// TestWorkspaceCache_FailureNotCached verifies a load that surfaces
+// packages.Error is NOT cached: a second call re-loads (fresh package pointers)
+// rather than serving a poisoned entry. Both callers see the errors and decide
+// to fail closed.
+func TestWorkspaceCache_FailureNotCached(t *testing.T) {
+	root := t.TempDir()
+	writeWS(t, root, "go.mod", "module example.com/bad\n\ngo 1.25\n")
+	writeWS(t, root, "bad/bad.go", "package bad\n\nfunc F() { undefinedSymbol() }\n")
+	cfg := packages.Config{Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
+		packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports}
+	c := NewWorkspaceCache()
+
+	p1, errs1, err1 := c.LoadWorkspace(root, cfg, "./bad/...")
+	if err1 != nil {
+		t.Fatalf("loader itself should not error: %v", err1)
+	}
+	if len(errs1) == 0 {
+		t.Fatalf("type error must surface as packages.Error")
+	}
+	if len(p1) == 0 {
+		t.Fatalf("bad package should still load (with errors)")
+	}
+
+	p2, errs2, err2 := c.LoadWorkspace(root, cfg, "./bad/...")
+	if err2 != nil || len(errs2) == 0 {
+		t.Fatalf("second call must re-surface errors (not cached): err=%v errs=%v", err2, errs2)
+	}
+	if p1[0] == p2[0] {
+		t.Fatalf("failed load must not be cached — second call must re-load (distinct package pointer)")
+	}
+}
+
+// TestWorkspaceCache_LoadFlatCaches verifies the flat ModeWorkspace path caches
+// and is keyed distinctly from LoadWorkspace (kind "F" vs "W").
+func TestWorkspaceCache_LoadFlatCaches(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("GOWORK", "off")
+	writeWS(t, root, "go.work", "go 1.25\n\nuse .\n")
+	writeWS(t, root, "go.mod", "module example.com/flat\n\ngo 1.25\n")
+	writeWS(t, root, "p/p.go", "package p\n\nfunc P() int { return 1 }\n")
+	cfg := packages.Config{Mode: packages.NeedName | packages.NeedFiles | packages.NeedImports}
+	c := NewWorkspaceCache()
+
+	p1, errs1, err1 := c.LoadFlat(root, cfg, "./p/...")
+	if err1 != nil || len(errs1) > 0 {
+		t.Fatalf("first LoadFlat: err=%v errs=%v", err1, errs1)
+	}
+	if !containsPkgPath(p1, "example.com/flat/p") {
+		t.Fatalf("LoadFlat did not load example.com/flat/p; got %v", pkgPaths(p1))
+	}
+	p2, _, err2 := c.LoadFlat(root, cfg, "./p/...")
+	if err2 != nil {
+		t.Fatalf("second LoadFlat: err=%v", err2)
+	}
+	if p1[0] != p2[0] {
+		t.Fatalf("LoadFlat cache hit must return the same *packages.Package; got %p vs %p", p1[0], p2[0])
+	}
+}
+
+// TestLoadWorkspaceCached_SharedInstance verifies the package-level cached entry
+// points reuse one process-wide cache: two calls with the same key serve the
+// same loaded packages.
+func TestLoadWorkspaceCached_SharedInstance(t *testing.T) {
+	root := writeSingleModule(t, "package p\n\nfunc P() int { return 1 }\n")
+	cfg := packages.Config{Mode: packages.NeedName | packages.NeedFiles | packages.NeedImports}
+
+	p1, errs1, err1 := LoadWorkspaceCached(root, cfg, "./...")
+	if err1 != nil || len(errs1) > 0 {
+		t.Fatalf("first LoadWorkspaceCached: err=%v errs=%v", err1, errs1)
+	}
+	if len(p1) == 0 {
+		t.Fatalf("no packages loaded")
+	}
+	p2, _, err2 := LoadWorkspaceCached(root, cfg, "./...")
+	if err2 != nil {
+		t.Fatalf("second LoadWorkspaceCached: err=%v", err2)
+	}
+	if p1[0] != p2[0] {
+		t.Fatalf("shared cache must reuse loaded packages across calls; got %p vs %p", p1[0], p2[0])
+	}
+}


### PR DESCRIPTION
## Summary

把 archtest `typeseval` 私有的进程内包加载缓存（`sharedCache` map + singleflight）下沉为 `tools/packagesload` 的 `WorkspaceCache`，`metricschema` OBS-01 扫描与 `typeseval` 经同一缓存共用，去除两处平行缓存实现（单源化）。

## Why / 背景

#2147 后 `metricschema.loadPackages` 经 `packagesload.LoadWorkspace` 加载 satellite 展开后的生产代码，**无进程内缓存**；而 archtest 侧 `typeseval.SharedResolver` 早有等价 singleflight 缓存。两处平行缓存是技术债（#2165）。

探索校正了 issue 的设想，并据此定稿（已与提出者对齐）：

- **跨调用方共享收益实际为零**：`metricschema` 用 `NeedCompiledGoFiles`、`typeseval` 不用 → 两者 `cfg.Mode` 不同，按 mode 入 key 永不命中对方条目；OBS-01 生产门每进程只加载一次。故本次真实价值是 **DRY / 单一缓存实现（去平行结构）**，而非跨调用方提速。
- **不上手写 LRU**：LRU 在本场景无好工作点——安全大 cap 永不淘汰（惰性多余代码），小 cap 淘汰大 production 条目触发重载回退。消费方是短命批处理（`gocell generate` / archtest gate，跑完即退）→ **无界 map** 正是 `typeseval` 已验证的 warmup 行为、无泄漏。

实现要点：`WorkspaceCache` 覆盖 satellite-aware `LoadWorkspace` 与 flat `ModeWorkspace`（`LoadFlat`，typeseval `LoadProductionPackages` 路径）两条路径；singleflight 去重；**错误不缓存**（Go error 或非空 `packages.Error` 均 fail-closed，下次重载）；key = `kind(W|F)+cfg.Mode+Tests+BuildFlags+root+sorted(patterns)`，排除 `Context`/`Dir`。`typeseval` 公开签名零变更（funnel meta-archtest 仍匹配），`Resolver` 退为每调用薄 wrapper、命中以共享底层 `[]*packages.Package` 表达。

**AI-HARD**：loader 已由 `PACKAGES-LOAD-FUNNEL-01`（Hard）漏斗化，cache 骑在漏斗内——平行 cache 无法绕过 loader，最多漏命中=性能回退（非安全缺口）；故不新增 enforcement 文件，godoc 写明单源。

| 变更 | contract | generated | cell/slice | tests | docs |
|------|----------|-----------|------------|-------|------|
| WorkspaceCache 单源下沉 | 无（纯 tools/ 内部重构） | 无 | 无 | cache_test.go 新增 + typeseval/metricschema 测试调整 | warmup ADR #2165 amendment |

## Refs

- Closes #2165
- `ref:` 复用仓内 `typeseval.SharedResolver`（singleflight + double-check）范本下沉为 packagesload 单源；go/packages 加载语义不变（沿用 #1499 no-NeedDeps）
- ADR `docs/architecture/202605190000-adr-archtest-in-process-warmup.md`（补 #2165 amendment）

## Risk / 兼容性

- **无 wire / 契约影响**：纯 `tools/` 内部重构，无契约扇出。
- `typeseval` / `packagesload` 公开 API 签名零变更（`LoadPackages`/`SharedResolver`/`LoadProductionPackages`/`Resolver` 保持，funnel meta-archtest 仍匹配）。
- 行为/威胁矩阵不变：仍是同构 singleflight 摊销 + TestMain warmup；warm 命中后 wall/RSS 同前。
- 实际体量 **cx-3**（跨 packagesload / metricschema / typeseval 3 包、7 文件），超 issue 的 cx-2 估计——「单源下沉」的必然结果，非范围蔓延。
- `loadReachablePackages` 不缓存为**文档化非目标**（distinct-per-assembly、零收益），非 deferral。

## Test plan

- [x] `go -C tools build ./...` 本地通过
- [x] `go -C tools test -race ./packagesload/... ./metricschema/... ./archtest/internal/typeseval/...` 本地通过
- [x] archtest 回归：`ProductionLoaderFunnel` / `HandlerDeclCover` / `DeadContract`（real `LoadProductionPackages`→`LoadFlatCached` 路径）+ PassFunnel/MetricsFunnel meta-test 通过
- [x] `golangci-lint run ./packagesload/... ./metricschema/... ./archtest/internal/typeseval/...` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
