### PR TITLE
feat(topology): #2278 PR-2 运行期 role 选择层 — groups/role 子集挂载 [1423-US9]

### DIFF
--- a/cmd/corebundle/run.go
+++ b/cmd/corebundle/run.go
@@ -152,10 +152,15 @@ func runCorebundle(ctx context.Context, assemblyID string, assemblyCellIDs []str
 		return opts, nil
 	}
 
-	// composition.New(assemblyCellIDs...) seals the assembly's cell-id closed set
-	// (M12a #1093): Build fail-fasts if generatedCellModules drifts from the
-	// assembly.yaml cell list (replaces the former hand-written assertModuleIDsMatch).
-	app, err := composition.New(assemblyCellIDs...).With(mods...).Build(ctx, compShared, runtimeOptsFunc)
+	// composition.NewForRole mounts only the cells THIS process hosts for its
+	// deployment role (GOCELL_CELL_ROLE → compShared.DeploymentTopology): the
+	// all-colocated monolith mounts everything (closed set = assemblyCellIDs);
+	// a split role mounts only its colocated subset and reaches the rest as
+	// remote. Build still enforces the M12a closed set (#1093) on whatever is
+	// mounted, and the bootstrap MOUNTED-EQUALS-COLOCATED guard fail-fasts if a
+	// remote cell is ever mounted (#2278).
+	app, err := composition.NewForRole(assemblyCellIDs, compShared.DeploymentTopology, mods...).
+		Build(ctx, compShared, runtimeOptsFunc)
 	if err != nil {
 		return err
 	}

--- a/cmd/corebundle/shared_deps.go
+++ b/cmd/corebundle/shared_deps.go
@@ -127,13 +127,14 @@ func LoadSharedDepsFromEnv(ctx context.Context) (*composition.SharedDeps, *cmdLo
 	// closed when the deployment topology has a non-loopback remote cell but no
 	// TLS material is provisioned (see cellmodules/celltls).
 	// generatedTopologyGroups() is the assembly's complete deployment-partition
-	// graph. PR-1 (#1423) runs the all-colocated monolith only: an empty
-	// GOCELL_CELL_ROLE selects the zero spec (every cell mounted in this one
-	// process). A non-empty role is fail-closed by SpecForRole (per-role subset
-	// mounting lands in PR-2). We read and forward the env so the operator's role
-	// choice is honored-or-rejected at startup, never silently ignored — a set
-	// GOCELL_CELL_ROLE that landed on a PR-1 build (silent monolith) would mask a
-	// split-deployment misconfiguration (12-factor: env is consumed or it errors).
+	// graph. SpecForRole derives THIS process's placement from GOCELL_CELL_ROLE
+	// (#2278): an empty role with 0/1 group selects the all-colocated monolith
+	// (zero spec); a declared role selects its colocated cells + the other groups
+	// as remote; an empty role with ≥2 groups, or an unknown role, is fail-closed
+	// — so a split-deployment misconfiguration is rejected at startup, never
+	// silently run as a monolith (12-factor: env is consumed or it errors). The
+	// spec flows into SharedDeps.DeploymentTopology (consumed by celltransport +
+	// composition.NewForRole's subset mount).
 	deployTopoSpec, err := bootstrap.SpecForRole(generatedTopologyGroups(), os.Getenv("GOCELL_CELL_ROLE"))
 	if err != nil {
 		return nil, nil, err

--- a/cmd/corebundle/shared_deps.go
+++ b/cmd/corebundle/shared_deps.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/ghbvf/gocell/cellmodules/celltls"
@@ -193,11 +194,20 @@ func LoadSharedDepsFromEnv(ctx context.Context) (*composition.SharedDeps, *cmdLo
 	// cells this process hosts (colocated) vs reaches remotely. The colocated set
 	// IS the selected role's footprint; we log the DERIVED spec (validated by
 	// SpecForRole) rather than the raw GOCELL_CELL_ROLE env to avoid log-injection
-	// taint (gosec G706). split=false ∧ empty colocated = the all-colocated monolith.
+	// taint (gosec G706). `split` keys on a real cross-process boundary (≥1 remote
+	// cell) — a single-group role is colocated-only, NOT a split. remote_cell_endpoints
+	// gives the full cellID→endpoint placement (sorted) so operators can audit who
+	// each remote peer is, not just the count (#2278 review F3/F4).
+	remoteCellEndpoints := make([]string, 0, len(deployTopoSpec.Remote))
+	for _, r := range deployTopoSpec.Remote {
+		remoteCellEndpoints = append(remoteCellEndpoints, r.CellID+"="+r.Endpoint)
+	}
+	sort.Strings(remoteCellEndpoints)
 	slog.Info("corebundle: deployment role",
-		slog.Bool("split", len(deployTopoSpec.Colocated) > 0 || len(deployTopoSpec.Remote) > 0),
+		slog.Bool("split", len(deployTopoSpec.Remote) > 0),
 		slog.Any("colocated_cells", deployTopoSpec.Colocated),
-		slog.Int("remote_cells", len(deployTopoSpec.Remote)))
+		slog.Int("remote_cells", len(deployTopoSpec.Remote)),
+		slog.Any("remote_cell_endpoints", remoteCellEndpoints))
 
 	loaded = true
 	return compShared, locals, nil

--- a/cmd/corebundle/shared_deps.go
+++ b/cmd/corebundle/shared_deps.go
@@ -189,6 +189,16 @@ func LoadSharedDepsFromEnv(ctx context.Context) (*composition.SharedDeps, *cmdLo
 		slog.String("requested", adapterMode),
 		slog.String("effective", topo.AdapterInfo()["mode"]))
 
+	// Deployment-role placement: lets an operator confirm, per process, which
+	// cells this process hosts (colocated) vs reaches remotely. The colocated set
+	// IS the selected role's footprint; we log the DERIVED spec (validated by
+	// SpecForRole) rather than the raw GOCELL_CELL_ROLE env to avoid log-injection
+	// taint (gosec G706). split=false ∧ empty colocated = the all-colocated monolith.
+	slog.Info("corebundle: deployment role",
+		slog.Bool("split", len(deployTopoSpec.Colocated) > 0 || len(deployTopoSpec.Remote) > 0),
+		slog.Any("colocated_cells", deployTopoSpec.Colocated),
+		slog.Int("remote_cells", len(deployTopoSpec.Remote)))
+
 	loaded = true
 	return compShared, locals, nil
 }

--- a/docs/guides/deployment-topology.md
+++ b/docs/guides/deployment-topology.md
@@ -41,20 +41,29 @@ correct choice for most assemblies and requires no configuration change.
 - **Split requires a broker**: when an event's publisher and subscriber land in
   different groups, a real event broker is required (TOPO-13).
 
-## Current status: `topology.groups` authoring, monolith runtime (PR-1)
+## Current status: `topology.groups` authoring + runtime role selection (PR-2)
 
 `topology.groups` is the authoring model (#2278 PR-1, replacing the earlier
 single-process `colocated/remote` form). `gocell validate` (TOPO-10/11/13/14),
 `gocell generate` (emits `generatedTopologyGroups()`), and the catalog export all
-operate on groups. The runtime still runs the all-colocated monolith: the
-composition root calls `bootstrap.SpecForRole(generatedTopologyGroups(), "")`,
-which selects the zero (all-colocated) spec. Startup role selection
-(`GOCELL_CELL_ROLE` → per-process subset mounting) lands in PR-2.
+operate on groups.
 
-> **Warning — do NOT set `GOCELL_CELL_ROLE` on a PR-1 build.** Per-role process
-> selection is not yet supported; `SpecForRole` fail-closes (startup
-> `ERR_VALIDATION_FAILED`) on any non-empty role. Leave `GOCELL_CELL_ROLE` unset
-> to run the all-colocated monolith. Role selection arrives in PR-2.
+Runtime role selection landed in #2278 PR-2: the composition root calls
+`bootstrap.SpecForRole(generatedTopologyGroups(), os.Getenv("GOCELL_CELL_ROLE"))`
+and mounts the result via `composition.NewForRole`:
+
+- **empty `GOCELL_CELL_ROLE` + 0/1 group** → all-colocated monolith (zero spec).
+- **empty role + ≥2 groups** → fail-fast: a multi-group topology is a split
+  deployment, so the process MUST select its role (a silent monolith would mask
+  the misconfiguration).
+- **`GOCELL_CELL_ROLE=<role>`** → this process hosts that group's cells
+  (colocated) and reaches every other group's cells as remote.
+- **unknown role** → fail-fast (the server log lists the declared `availableRoles`).
+
+The bootstrap `MOUNTED-EQUALS-COLOCATED-01` phase guard fail-fasts if a process
+ever mounts a cell declared remote for its role (the upstream backstop for
+`NewForRole`). End-to-end dual-topology acceptance (same image, 2 processes +
+broker + PG) is tracked by #1967 (PR-4).
 
 A split topology requires a real event broker (TOPO-13 enforces this). See the
 §Split topology requirements section below for the full infrastructure checklist.

--- a/examples/corebundlestarter/run.go
+++ b/examples/corebundlestarter/run.go
@@ -74,22 +74,20 @@ func runStarter(ctx context.Context) error {
 		return fmt.Errorf("corebundlestarter: build shared deps: %w", err)
 	}
 
-	// composition.New().With(...).Build(...) is the public API under test (#1085).
-	// Module order mirrors corebundle assembly.yaml cell order purely for
-	// convention/determinism — it is NOT runtime-significant. The former
-	// auditcore→accesscore BootstrapLedgerStore handoff was removed in #1423
-	// (bootstrap auth-fail is now event-driven via event.auth.bootstrap-failed.v1),
-	// so module Provide order carries no cross-cell dependency.
-	// composition.New(<cell ids>) seals the assembly's cell-id closed set (M12a
-	// #1093): Build fail-fasts if the composed modules drift from this declared
-	// set. corebundlestarter mirrors the corebundle cell set.
-	app, err := composition.New("auditcore", "accesscore", "configcore").
-		With(
-			cellmodulesauditcore.Module(),
-			cellmodulesaccesscore.Module(),
-			cellmodulesconfigcore.Module(),
-		).
-		Build(ctx, shared, starterRuntimeOptions(shared))
+	// composition.NewForRole(...).Build(...) is the public subset-mount API
+	// (#2278): the demo SharedDeps carries the zero DeploymentTopology, so this
+	// example mounts every cell (all-colocated monolith) — equivalent to the old
+	// composition.New + closed-set guard. Module order mirrors corebundle
+	// assembly.yaml cell order purely for convention/determinism — it is NOT
+	// runtime-significant. corebundlestarter mirrors the corebundle cell set; the
+	// closed set is sealed by Build (M12a #1093).
+	app, err := composition.NewForRole(
+		[]string{"auditcore", "accesscore", "configcore"},
+		shared.DeploymentTopology,
+		cellmodulesauditcore.Module(),
+		cellmodulesaccesscore.Module(),
+		cellmodulesconfigcore.Module(),
+	).Build(ctx, shared, starterRuntimeOptions(shared))
 	if err != nil {
 		return fmt.Errorf("corebundlestarter: Build: %w", err)
 	}

--- a/examples/corebundlestarter/run.go
+++ b/examples/corebundlestarter/run.go
@@ -77,7 +77,10 @@ func runStarter(ctx context.Context) error {
 	// composition.NewForRole(...).Build(...) is the public subset-mount API
 	// (#2278): the demo SharedDeps carries the zero DeploymentTopology, so this
 	// example mounts every cell (all-colocated monolith) — equivalent to the old
-	// composition.New + closed-set guard. Module order mirrors corebundle
+	// composition.New + closed-set guard. This example is always memory-mode and
+	// has no topology.groups, so GOCELL_CELL_ROLE is intentionally NOT read here
+	// (unlike cmd/corebundle, which derives the spec via SpecForRole) — do not copy
+	// this monolith shortcut into a split deployment. Module order mirrors corebundle
 	// assembly.yaml cell order purely for convention/determinism — it is NOT
 	// runtime-significant. corebundlestarter mirrors the corebundle cell set; the
 	// closed set is sealed by Build (M12a #1093).

--- a/framework/runtime/bootstrap/deployment_topology.go
+++ b/framework/runtime/bootstrap/deployment_topology.go
@@ -39,26 +39,70 @@ type TopologyGroup struct {
 	Endpoint string
 }
 
-const errMsgDeployTopoRoleUnsupported = "deployment topology: per-role process selection is not supported in this build; " +
-	"leave GOCELL_CELL_ROLE empty to run the all-colocated monolith"
+// Deployment-role selection error message constants — MESSAGE-CONST-LITERAL-01.
+const (
+	errMsgDeployTopoRoleRequired = "deployment topology: GOCELL_CELL_ROLE must be set when the assembly declares " +
+		"multiple deployment groups; a multi-group topology is a split deployment, so this process must select its role"
+	errMsgDeployTopoUnknownRole = "deployment topology: GOCELL_CELL_ROLE names a role not declared in the assembly topology groups"
+)
 
 // SpecForRole derives the per-process DeploymentTopologySpec from the full
-// topology group graph for the deployment role this process runs as.
+// topology group graph for the deployment role this process runs as (selected at
+// startup by GOCELL_CELL_ROLE, WriteOnce).
 //
-// PR-1 (#1423) implements only the no-role path: an empty role selects the
-// all-colocated monolith — every cell mounted in one process (the single-binary
-// deployment that #1423 preserves), expressed as the zero DeploymentTopologySpec.
-// A non-empty role is fail-closed (errcode) here: role-based subset derivation
-// (colocated = the role's cells, remote = every other group's cells × endpoint)
-// plus the multi-group-without-role startup gate land in PR-2 via GOCELL_CELL_ROLE.
+//   - empty role + 0/1 group → the zero (all-colocated monolith) spec: every
+//     cell mounted in one process, the single-binary zero-migration default #1423
+//     preserves.
+//   - empty role + ≥2 groups → fail-closed: a multi-group topology declares an
+//     intended split, so running it with no role is a misconfiguration that a
+//     silent monolith would mask (12-factor: the env is consumed or it errors).
+//   - role ∈ declared set → Colocated = the role's own cells, Remote = every
+//     other group's cells mapped to that group's endpoint (the form
+//     celltransport.Resolve consumes).
+//   - role ∉ declared set → fail-closed.
+//
+// ref: akka/akka cluster-sharding withRole — one artifact, a static role config
+// selects which cells the node hosts.
 func SpecForRole(groups []TopologyGroup, role string) (DeploymentTopologySpec, error) {
 	if role == "" {
-		return DeploymentTopologySpec{}, nil // all-colocated monolith
+		if len(groups) >= 2 {
+			return DeploymentTopologySpec{}, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+				errMsgDeployTopoRoleRequired,
+				errcode.WithInternal(errcode.InternalAttr("groupCount", len(groups))))
+		}
+		return DeploymentTopologySpec{}, nil // 0/1 group → all-colocated monolith
 	}
-	return DeploymentTopologySpec{}, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-		errMsgDeployTopoRoleUnsupported,
-		errcode.WithInternal(errcode.InternalAttr("role", role), errcode.InternalAttr("groupCount", len(groups))),
-		errcode.WithDetails(errcode.PublicString("role", role)))
+	return deriveRoleSpec(groups, role)
+}
+
+// deriveRoleSpec builds the per-process spec for a named role: Colocated = the
+// role's own cells; Remote = every other group's cells mapped to that group's
+// endpoint. Fails closed if role is not a declared group. Extracted to keep
+// SpecForRole within the cognitive-complexity budget. Output is sorted by cellID
+// for determinism (newDeploymentTopology builds maps, so order is otherwise
+// irrelevant — sorting only aids tests and diagnostics).
+func deriveRoleSpec(groups []TopologyGroup, role string) (DeploymentTopologySpec, error) {
+	var spec DeploymentTopologySpec
+	found := false
+	for _, g := range groups {
+		if g.Role == role {
+			found = true
+			spec.Colocated = append([]string(nil), g.Cells...)
+			continue
+		}
+		for _, c := range g.Cells {
+			spec.Remote = append(spec.Remote, RemoteCellEndpoint{CellID: c, Endpoint: g.Endpoint})
+		}
+	}
+	if !found {
+		return DeploymentTopologySpec{}, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+			errMsgDeployTopoUnknownRole,
+			errcode.WithInternal(errcode.InternalAttr("role", role)),
+			errcode.WithDetails(errcode.PublicString("role", role)))
+	}
+	sort.Strings(spec.Colocated)
+	sort.Slice(spec.Remote, func(i, j int) bool { return spec.Remote[i].CellID < spec.Remote[j].CellID })
+	return spec, nil
 }
 
 // DeploymentTopologySpec is the PLAIN, codegen-produced input describing the

--- a/framework/runtime/bootstrap/deployment_topology.go
+++ b/framework/runtime/bootstrap/deployment_topology.go
@@ -68,11 +68,25 @@ func SpecForRole(groups []TopologyGroup, role string) (DeploymentTopologySpec, e
 		if len(groups) >= 2 {
 			return DeploymentTopologySpec{}, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 				errMsgDeployTopoRoleRequired,
-				errcode.WithInternal(errcode.InternalAttr("groupCount", len(groups))))
+				errcode.WithInternal(
+					errcode.InternalAttr("groupCount", len(groups)),
+					errcode.InternalAttr("availableRoles", topoGroupRoles(groups))))
 		}
 		return DeploymentTopologySpec{}, nil // 0/1 group → all-colocated monolith
 	}
 	return deriveRoleSpec(groups, role)
+}
+
+// topoGroupRoles renders the declared role names (sorted, comma-joined) for
+// diagnostic InternalAttrs — lets an operator see the valid GOCELL_CELL_ROLE
+// values in the server log without consulting assembly.yaml.
+func topoGroupRoles(groups []TopologyGroup) string {
+	roles := make([]string, 0, len(groups))
+	for _, g := range groups {
+		roles = append(roles, g.Role)
+	}
+	sort.Strings(roles)
+	return strings.Join(roles, ",")
 }
 
 // deriveRoleSpec builds the per-process spec for a named role: Colocated = the
@@ -97,7 +111,9 @@ func deriveRoleSpec(groups []TopologyGroup, role string) (DeploymentTopologySpec
 	if !found {
 		return DeploymentTopologySpec{}, errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 			errMsgDeployTopoUnknownRole,
-			errcode.WithInternal(errcode.InternalAttr("role", role)),
+			errcode.WithInternal(
+				errcode.InternalAttr("role", role),
+				errcode.InternalAttr("availableRoles", topoGroupRoles(groups))),
 			errcode.WithDetails(errcode.PublicString("role", role)))
 	}
 	sort.Strings(spec.Colocated)

--- a/framework/runtime/bootstrap/deployment_topology_specforrole_test.go
+++ b/framework/runtime/bootstrap/deployment_topology_specforrole_test.go
@@ -1,7 +1,14 @@
 package bootstrap
 
 // deployment_topology_specforrole_test.go — tests for SpecForRole, the
-// groups-graph → per-process DeploymentTopologySpec bridge (#1423 PR-1).
+// groups-graph → per-process DeploymentTopologySpec bridge.
+//
+// PR-2 (#2278) replaces the PR-1 fail-closed placeholder with real role-based
+// derivation:
+//   - empty role + 0/1 group  → zero spec (all-colocated monolith)
+//   - empty role + ≥2 groups  → fail-fast (declared a split but picked no role)
+//   - role ∈ declared set     → Colocated = role's cells, Remote = other groups' cells × endpoint
+//   - role ∉ declared set     → fail-fast
 
 import (
 	"errors"
@@ -10,21 +17,28 @@ import (
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 )
 
-// TestSpecForRole_EmptyRoleIsColocatedMonolith verifies that an empty role
-// selects the all-colocated monolith (zero spec) regardless of the declared
-// group graph — the single-binary deployment #1423 preserves.
-func TestSpecForRole_EmptyRoleIsColocatedMonolith(t *testing.T) {
+// twoGroupGraph is the canonical split topology used across these tests:
+// role "core" hosts alpha; role "edge" hosts beta + gamma.
+func twoGroupGraph() []TopologyGroup {
+	return []TopologyGroup{
+		{Role: "core", Cells: []string{"alpha"}, Endpoint: "core.svc:9000"},
+		{Role: "edge", Cells: []string{"beta", "gamma"}, Endpoint: "edge.svc:9001"},
+	}
+}
+
+// TestSpecForRole_EmptyRoleColocatedMonolith verifies that an empty role selects
+// the all-colocated monolith (zero spec) when 0 or 1 group is declared — the
+// single-binary zero-migration default #1423 preserves.
+func TestSpecForRole_EmptyRoleColocatedMonolith(t *testing.T) {
 	cases := []struct {
 		name   string
 		groups []TopologyGroup
 	}{
 		{name: "no groups", groups: nil},
+		{name: "empty groups slice", groups: []TopologyGroup{}},
 		{
-			name: "multi-group graph, no role selected",
-			groups: []TopologyGroup{
-				{Role: "core", Cells: []string{"alpha"}, Endpoint: "core.svc:9000"},
-				{Role: "edge", Cells: []string{"beta"}, Endpoint: "edge.svc:9001"},
-			},
+			name:   "single group, no role",
+			groups: []TopologyGroup{{Role: "solo", Cells: []string{"alpha", "beta"}, Endpoint: "solo.svc:9000"}},
 		},
 	}
 	for _, tc := range cases {
@@ -34,7 +48,7 @@ func TestSpecForRole_EmptyRoleIsColocatedMonolith(t *testing.T) {
 				t.Fatalf("SpecForRole(_, \"\") unexpected error: %v", err)
 			}
 			if len(spec.Colocated) != 0 || len(spec.Remote) != 0 {
-				t.Fatalf("empty role must yield the zero (all-colocated) spec, got %+v", spec)
+				t.Fatalf("empty role + 0/1 group must yield the zero (all-colocated) spec, got %+v", spec)
 			}
 			// The zero spec seals to an all-colocated DeploymentTopology.
 			topo, err := NewDeploymentTopology(spec)
@@ -48,20 +62,16 @@ func TestSpecForRole_EmptyRoleIsColocatedMonolith(t *testing.T) {
 	}
 }
 
-// TestSpecForRole_NonEmptyRoleFailsClosed verifies that role-based derivation is
-// fail-closed in PR-1 (it lands in PR-2 with GOCELL_CELL_ROLE) — a non-empty role
-// returns an error rather than silently mounting the monolith.
-func TestSpecForRole_NonEmptyRoleFailsClosed(t *testing.T) {
-	groups := []TopologyGroup{
-		{Role: "core", Cells: []string{"alpha"}, Endpoint: "core.svc:9000"},
-		{Role: "edge", Cells: []string{"beta"}, Endpoint: "edge.svc:9001"},
-	}
-	_, err := SpecForRole(groups, "core")
+// TestSpecForRole_EmptyRoleMultiGroupFailsClosed verifies the PR-2 behavior
+// reversal: a multi-group topology declares an intended split, so running it
+// with no GOCELL_CELL_ROLE is a misconfiguration — fail-fast rather than
+// silently mounting the monolith (which would mask the misconfig). 12-factor:
+// the env is consumed or it errors.
+func TestSpecForRole_EmptyRoleMultiGroupFailsClosed(t *testing.T) {
+	_, err := SpecForRole(twoGroupGraph(), "")
 	if err == nil {
-		t.Fatal("non-empty role must fail closed in PR-1, got nil error")
+		t.Fatal("empty role + ≥2 groups must fail closed, got nil error")
 	}
-	// fail-closed must be a typed errcode (ErrValidationFailed), not a bare error —
-	// the error type/code is the contract callers branch on.
 	var ec *errcode.Error
 	if !errors.As(err, &ec) {
 		t.Fatalf("fail-closed error must be *errcode.Error, got %T", err)
@@ -69,4 +79,94 @@ func TestSpecForRole_NonEmptyRoleFailsClosed(t *testing.T) {
 	if ec.Code != errcode.ErrValidationFailed {
 		t.Fatalf("fail-closed error code = %v, want ErrValidationFailed", ec.Code)
 	}
+}
+
+// TestSpecForRole_RoleDerivesColocatedRemote verifies that a declared role
+// derives Colocated = the role's cells and Remote = every OTHER group's cells
+// mapped to that group's endpoint.
+func TestSpecForRole_RoleDerivesColocatedRemote(t *testing.T) {
+	spec, err := SpecForRole(twoGroupGraph(), "core")
+	if err != nil {
+		t.Fatalf("SpecForRole(_, \"core\") unexpected error: %v", err)
+	}
+
+	// Colocated = core's cells.
+	if got := asSet(spec.Colocated); !got["alpha"] || len(got) != 1 {
+		t.Fatalf("Colocated = %v, want {alpha}", spec.Colocated)
+	}
+
+	// Remote = edge's cells × edge endpoint.
+	remote := map[string]string{}
+	for _, r := range spec.Remote {
+		remote[r.CellID] = r.Endpoint
+	}
+	if len(remote) != 2 || remote["beta"] != "edge.svc:9001" || remote["gamma"] != "edge.svc:9001" {
+		t.Fatalf("Remote = %+v, want beta+gamma → edge.svc:9001", spec.Remote)
+	}
+}
+
+// TestSpecForRole_SplitSpecSealsConsumable closes the derive→consume loop: the
+// derived split spec must seal into a DeploymentTopology whose IsColocated /
+// RemoteEndpoint queries are correct — i.e. the value celltransport.Resolve
+// actually consumes routes the right cells in/out of process.
+func TestSpecForRole_SplitSpecSealsConsumable(t *testing.T) {
+	spec, err := SpecForRole(twoGroupGraph(), "core")
+	if err != nil {
+		t.Fatalf("SpecForRole: %v", err)
+	}
+	dt, err := NewDeploymentTopology(spec)
+	if err != nil {
+		t.Fatalf("NewDeploymentTopology(split spec): %v", err)
+	}
+	if !dt.IsColocated("alpha") {
+		t.Error("IsColocated(alpha) = false, want true (core's own cell)")
+	}
+	if dt.IsColocated("beta") {
+		t.Error("IsColocated(beta) = true, want false (edge cell is remote)")
+	}
+	ep, ok := dt.RemoteEndpoint("beta")
+	if !ok || ep != "edge.svc:9001" {
+		t.Errorf("RemoteEndpoint(beta) = (%q,%v), want (edge.svc:9001,true)", ep, ok)
+	}
+}
+
+// TestSpecForRole_SingleGroupRoleNoRemotes verifies that selecting the only
+// declared role yields its cells colocated and no remote cells.
+func TestSpecForRole_SingleGroupRoleNoRemotes(t *testing.T) {
+	groups := []TopologyGroup{{Role: "solo", Cells: []string{"alpha", "beta"}, Endpoint: "solo.svc:9000"}}
+	spec, err := SpecForRole(groups, "solo")
+	if err != nil {
+		t.Fatalf("SpecForRole(_, \"solo\") unexpected error: %v", err)
+	}
+	if got := asSet(spec.Colocated); !got["alpha"] || !got["beta"] || len(got) != 2 {
+		t.Fatalf("Colocated = %v, want {alpha,beta}", spec.Colocated)
+	}
+	if len(spec.Remote) != 0 {
+		t.Fatalf("Remote = %+v, want empty (no other groups)", spec.Remote)
+	}
+}
+
+// TestSpecForRole_UnknownRoleFailsClosed verifies that a role not present in the
+// declared group set fails fast — never silently degrades to monolith.
+func TestSpecForRole_UnknownRoleFailsClosed(t *testing.T) {
+	_, err := SpecForRole(twoGroupGraph(), "nope")
+	if err == nil {
+		t.Fatal("unknown role must fail closed, got nil error")
+	}
+	var ec *errcode.Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("fail-closed error must be *errcode.Error, got %T", err)
+	}
+	if ec.Code != errcode.ErrValidationFailed {
+		t.Fatalf("fail-closed error code = %v, want ErrValidationFailed", ec.Code)
+	}
+}
+
+// asSet is a tiny test helper to assert membership order-independently.
+func asSet(ss []string) map[string]bool {
+	m := make(map[string]bool, len(ss))
+	for _, s := range ss {
+		m[s] = true
+	}
+	return m
 }

--- a/framework/runtime/bootstrap/deployment_topology_specforrole_test.go
+++ b/framework/runtime/bootstrap/deployment_topology_specforrole_test.go
@@ -66,18 +66,32 @@ func TestSpecForRole_EmptyRoleColocatedMonolith(t *testing.T) {
 // reversal: a multi-group topology declares an intended split, so running it
 // with no GOCELL_CELL_ROLE is a misconfiguration — fail-fast rather than
 // silently mounting the monolith (which would mask the misconfig). 12-factor:
-// the env is consumed or it errors.
+// the env is consumed or it errors. Covers the `len >= 2` boundary (exactly 2)
+// and a >2 case to prove the gate is "≥2", not "exactly 2".
 func TestSpecForRole_EmptyRoleMultiGroupFailsClosed(t *testing.T) {
-	_, err := SpecForRole(twoGroupGraph(), "")
-	if err == nil {
-		t.Fatal("empty role + ≥2 groups must fail closed, got nil error")
+	threeGroupGraph := append(twoGroupGraph(),
+		TopologyGroup{Role: "rim", Cells: []string{"delta"}, Endpoint: "rim.svc:9002"})
+	cases := []struct {
+		name   string
+		groups []TopologyGroup
+	}{
+		{name: "exactly 2 groups (lower boundary)", groups: twoGroupGraph()},
+		{name: "3 groups", groups: threeGroupGraph},
 	}
-	var ec *errcode.Error
-	if !errors.As(err, &ec) {
-		t.Fatalf("fail-closed error must be *errcode.Error, got %T", err)
-	}
-	if ec.Code != errcode.ErrValidationFailed {
-		t.Fatalf("fail-closed error code = %v, want ErrValidationFailed", ec.Code)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := SpecForRole(tc.groups, "")
+			if err == nil {
+				t.Fatal("empty role + ≥2 groups must fail closed, got nil error")
+			}
+			var ec *errcode.Error
+			if !errors.As(err, &ec) {
+				t.Fatalf("fail-closed error must be *errcode.Error, got %T", err)
+			}
+			if ec.Code != errcode.ErrValidationFailed {
+				t.Fatalf("fail-closed error code = %v, want ErrValidationFailed", ec.Code)
+			}
+		})
 	}
 }
 

--- a/framework/runtime/bootstrap/mounted_equals_colocated_test.go
+++ b/framework/runtime/bootstrap/mounted_equals_colocated_test.go
@@ -120,6 +120,26 @@ func TestValidateMountedEqualsColocated(t *testing.T) {
 	}
 }
 
+// TestValidateMountedEqualsColocated_NilAssemblySkips documents the intentional
+// nil-assembly skip: phase0 supports an assembly-less validation mode (the sibling
+// validateAssemblyClockAlignment skips the same way), and the production flow always
+// wires WithAssembly via composition.Builder.Build. So even with an explicit split
+// topology, a nil assemblyCore passes — the guard has no mounted set to compare.
+// (anti-vacuity for the nil short-circuit: deleting it would panic, not silently pass.)
+func TestValidateMountedEqualsColocated_NilAssemblySkips(t *testing.T) {
+	dt, err := newDeploymentTopology(DeploymentTopologySpec{
+		Colocated: []string{"alpha"},
+		Remote:    []RemoteCellEndpoint{{CellID: "beta", Endpoint: "edge.svc:9001"}},
+	})
+	if err != nil {
+		t.Fatalf("newDeploymentTopology: %v", err)
+	}
+	b := &Bootstrap{deploymentTopology: dt} // assemblyCore is nil
+	if err := b.validateMountedEqualsColocated(); err != nil {
+		t.Fatalf("nil assemblyCore must skip the guard, got error: %v", err)
+	}
+}
+
 // TestPhase0_RejectsMountedRemoteCell verifies the guard is wired into phase0
 // end-to-end: a split topology whose mounted assembly includes a remote cell is
 // rejected before any side effects start. The broker-mandatory gate is satisfied

--- a/framework/runtime/bootstrap/mounted_equals_colocated_test.go
+++ b/framework/runtime/bootstrap/mounted_equals_colocated_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 // mountedAssembly builds an un-started CoreAssembly with the given cell IDs
-// registered, modelling the cells THIS process actually mounts.
+// registered, modeling the cells THIS process actually mounts.
 func mountedAssembly(t *testing.T, ids ...string) *assembly.CoreAssembly {
 	t.Helper()
 	asm := assembly.New(clock.Real(), assembly.Config{ID: "mec-test", DurabilityMode: outbox.DurabilityDemo})

--- a/framework/runtime/bootstrap/mounted_equals_colocated_test.go
+++ b/framework/runtime/bootstrap/mounted_equals_colocated_test.go
@@ -1,0 +1,170 @@
+package bootstrap
+
+// mounted_equals_colocated_test.go — red/green + anti-vacuity for the phase0
+// MOUNTED-EQUALS-COLOCATED guard (#2278 PR-2).
+//
+// INVARIANT: MOUNTED-EQUALS-COLOCATED-01
+//
+// The guard is the upstream backstop for role-based subset mounting: even if a
+// composition root bypasses composition.NewForRole and mounts the wrong cell set
+// directly (New(allCells).With(allMods)), phase0 fails fast when the mounted cell
+// set is not exactly the active topology's colocated set, or when any mounted
+// cell is declared remote (the silent double-mount D4 describes). AI-robust
+// grade: Medium (runtime bijection; cellID is a runtime string — same honest
+// ceiling as M12a / the broker-mandatory gate).
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ghbvf/gocell/framework/kernel/assembly"
+	"github.com/ghbvf/gocell/framework/kernel/auth"
+	"github.com/ghbvf/gocell/framework/kernel/cell"
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/metadata"
+	"github.com/ghbvf/gocell/framework/kernel/outbox"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/runtime/eventbus"
+)
+
+// mountedAssembly builds an un-started CoreAssembly with the given cell IDs
+// registered, modelling the cells THIS process actually mounts.
+func mountedAssembly(t *testing.T, ids ...string) *assembly.CoreAssembly {
+	t.Helper()
+	asm := assembly.New(clock.Real(), assembly.Config{ID: "mec-test", DurabilityMode: outbox.DurabilityDemo})
+	for _, id := range ids {
+		if err := asm.Register(cell.MustNewBaseCell(&metadata.CellMeta{ID: id})); err != nil {
+			t.Fatalf("register %q: %v", id, err)
+		}
+	}
+	return asm
+}
+
+// TestValidateMountedEqualsColocated exercises the guard directly (no full Run),
+// mirroring TestValidateSplitTopologyBroker.
+func TestValidateMountedEqualsColocated(t *testing.T) {
+	splitSpec := DeploymentTopologySpec{
+		Colocated: []string{"alpha"},
+		Remote:    []RemoteCellEndpoint{{CellID: "beta", Endpoint: "edge.svc:9001"}},
+	}
+	twoColocatedSpec := DeploymentTopologySpec{
+		Colocated: []string{"alpha", "gamma"},
+		Remote:    []RemoteCellEndpoint{{CellID: "beta", Endpoint: "edge.svc:9001"}},
+	}
+
+	cases := []struct {
+		name    string
+		spec    DeploymentTopologySpec
+		mounted []string
+		wantErr bool
+	}{
+		{
+			name:    "GREEN: mounted == colocated, no remote mounted",
+			spec:    splitSpec,
+			mounted: []string{"alpha"},
+			wantErr: false,
+		},
+		{
+			name:    "GREEN: zero topology (monolith) — guard does not fire",
+			spec:    DeploymentTopologySpec{},
+			mounted: []string{"alpha", "beta", "gamma"},
+			wantErr: false,
+		},
+		{
+			name:    "RED: a mounted cell is declared remote (silent double-mount)",
+			spec:    splitSpec,
+			mounted: []string{"alpha", "beta"},
+			wantErr: true,
+		},
+		{
+			name:    "RED: a colocated cell is not mounted (missing host)",
+			spec:    twoColocatedSpec,
+			mounted: []string{"alpha"},
+			wantErr: true,
+		},
+		{
+			name:    "RED: a mounted cell is neither colocated nor remote",
+			spec:    splitSpec,
+			mounted: []string{"alpha", "zeta"},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dt, err := newDeploymentTopology(tc.spec)
+			if err != nil {
+				t.Fatalf("newDeploymentTopology: %v", err)
+			}
+			b := &Bootstrap{
+				deploymentTopology: dt,
+				assemblyCore:       mountedAssembly(t, tc.mounted...),
+			}
+			err = b.validateMountedEqualsColocated()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("validateMountedEqualsColocated: expected error, got nil")
+				}
+				var ec *errcode.Error
+				if !errors.As(err, &ec) {
+					t.Fatalf("error is not *errcode.Error: %T %v", err, err)
+				}
+				if ec.Code != errcode.ErrValidationFailed {
+					t.Errorf("error code = %s, want %s", ec.Code, errcode.ErrValidationFailed)
+				}
+			} else if err != nil {
+				t.Errorf("validateMountedEqualsColocated: unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestPhase0_RejectsMountedRemoteCell verifies the guard is wired into phase0
+// end-to-end: a split topology whose mounted assembly includes a remote cell is
+// rejected before any side effects start. The broker-mandatory gate is satisfied
+// (real-broker kind + non-nil pub/sub) so the ONLY remaining failure is the
+// MOUNTED-EQUALS-COLOCATED guard — asserted via its distinctive message.
+func TestPhase0_RejectsMountedRemoteCell(t *testing.T) {
+	clk := clock.Real()
+	splitSpec := DeploymentTopologySpec{
+		Colocated: []string{"alpha"},
+		Remote:    []RemoteCellEndpoint{{CellID: "beta", Endpoint: "edge.svc:9001"}},
+	}
+	postgresTopo, err := NewTopology("real", "postgres", false)
+	if err != nil {
+		t.Fatalf("NewTopology: %v", err)
+	}
+	brokerBus := eventbus.New(clk)
+	// beta (a remote cell) is wrongly mounted alongside alpha.
+	asm := assembly.New(clk, assembly.Config{ID: "mec-phase0", DurabilityMode: outbox.DurabilityDemo})
+	for _, id := range []string{"alpha", "beta"} {
+		if regErr := asm.Register(cell.MustNewBaseCell(&metadata.CellMeta{ID: id})); regErr != nil {
+			t.Fatalf("register %q: %v", id, regErr)
+		}
+	}
+
+	b := New(
+		clk,
+		WithDeploymentTopology(splitSpec),
+		WithControlPlaneTopology(postgresTopo),
+		WithPublisher(brokerBus),
+		WithSubscriber(brokerBus),
+		WithEventTransportKind(RealBrokerEventTransport()),
+		WithAssembly(asm),
+		WithListener(cell.PrimaryListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
+		WithListener(cell.HealthListener, "127.0.0.1:0", []auth.ListenerAuth{auth.AuthNone{}}),
+	)
+
+	err = b.phase0ValidateOptions()
+	if err == nil {
+		t.Fatal("phase0ValidateOptions: expected error when a remote cell is mounted, got nil")
+	}
+	var ec *errcode.Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("error is not *errcode.Error: %T %v", err, err)
+	}
+	if !strings.Contains(strings.ToLower(ec.Message), "mounted") {
+		t.Errorf("error message %q should come from the MOUNTED-EQUALS-COLOCATED guard (mention 'mounted')", ec.Message)
+	}
+}

--- a/framework/runtime/bootstrap/phases_assembly.go
+++ b/framework/runtime/bootstrap/phases_assembly.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/ghbvf/gocell/framework/kernel/assembly"
@@ -139,19 +141,26 @@ const (
 	errMsgColocatedCellNotMounted = "deployment topology: a cell in this role's colocated set is not mounted in this process"
 )
 
-// validateMountedEqualsColocated enforces MOUNTED-EQUALS-COLOCATED: in an
+// validateMountedEqualsColocated enforces MOUNTED-EQUALS-COLOCATED-01: in an
 // explicit split topology, the set of cells this process mounts (b.assemblyCore)
 // MUST equal the topology's colocated set, and no mounted cell may be declared
 // remote. This is the upstream backstop for composition.NewForRole — even a root
 // that bypasses NewForRole and mounts the full cell set directly
 // (New(allCells).With(allMods)) fails fast here instead of silently
-// double-mounting a remote cell. A zero (all-colocated) topology, or a process
-// with no assembly, trivially satisfies the invariant.
+// double-mounting a remote cell.
+//
+// A zero (all-colocated) topology trivially satisfies the invariant. A nil
+// assemblyCore is also skipped: phase0 supports an assembly-less validation mode
+// (the sibling validateAssemblyClockAlignment skips the same way), and the
+// production composition flow always wires WithAssembly via
+// composition.Builder.Build, so a split topology always has its mounted set here.
 //
 // AI-robust grade: Medium (runtime bijection over runtime cellID strings — the
 // same honest ceiling as M12a / the broker-mandatory gate; cellID is not a
-// compile-time fact). Called at phase0 after the topology is sealed and the
-// assembly is wired.
+// compile-time fact). Blind spot: the mounted/colocated sets are runtime-derived,
+// so this cannot be Hard; static reachability of consumed providers is the
+// separate gocell-validate TOPO gate. Called at phase0 after the topology is
+// sealed and the assembly is wired.
 func (b *Bootstrap) validateMountedEqualsColocated() error {
 	dt := b.deploymentTopology
 	if !dt.explicit {
@@ -161,19 +170,26 @@ func (b *Bootstrap) validateMountedEqualsColocated() error {
 		return nil // no mounted cells to validate (assembly presence handled elsewhere)
 	}
 	mounted := b.assemblyCore.CellIDs()
+	// Diagnostic context shared by every failure path: the full mounted +
+	// colocated sets let an operator see the whole bijection mismatch, not just
+	// the first offending cell.
+	ctxAttrs := []errcode.InternalDetail{
+		errcode.InternalAttr("mounted", strings.Join(mounted, ",")),
+		errcode.InternalAttr("colocated", deployTopoSortedKeys(dt.colocated)),
+	}
 	mountedSet := make(map[string]struct{}, len(mounted))
 	for _, id := range mounted {
 		mountedSet[id] = struct{}{}
 		if _, isRemote := dt.remote[id]; isRemote {
 			return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 				errMsgMountedCellRemote,
-				errcode.WithInternal(errcode.InternalAttr("cellID", id)),
+				errcode.WithInternal(append(ctxAttrs, errcode.InternalAttr("cellID", id))...),
 				errcode.WithDetails(errcode.PublicString("cellID", id)))
 		}
 		if _, isColoc := dt.colocated[id]; !isColoc {
 			return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 				errMsgMountedCellNotColocated,
-				errcode.WithInternal(errcode.InternalAttr("cellID", id)),
+				errcode.WithInternal(append(ctxAttrs, errcode.InternalAttr("cellID", id))...),
 				errcode.WithDetails(errcode.PublicString("cellID", id)))
 		}
 	}
@@ -181,11 +197,22 @@ func (b *Bootstrap) validateMountedEqualsColocated() error {
 		if _, ok := mountedSet[id]; !ok {
 			return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
 				errMsgColocatedCellNotMounted,
-				errcode.WithInternal(errcode.InternalAttr("cellID", id)),
+				errcode.WithInternal(append(ctxAttrs, errcode.InternalAttr("cellID", id))...),
 				errcode.WithDetails(errcode.PublicString("cellID", id)))
 		}
 	}
 	return nil
+}
+
+// deployTopoSortedKeys returns the map keys joined by "," in sorted order — a
+// deterministic rendering of a cell-ID set for diagnostic InternalAttrs.
+func deployTopoSortedKeys(m map[string]struct{}) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ",")
 }
 
 // validateSplitTopologyBroker rejects the illegal combination of a split

--- a/framework/runtime/bootstrap/phases_assembly.go
+++ b/framework/runtime/bootstrap/phases_assembly.go
@@ -73,6 +73,12 @@ func (b *Bootstrap) phase0ValidateOptions() error {
 	if err := b.validateAssemblyClockAlignment(); err != nil {
 		return err
 	}
+	// MOUNTED-EQUALS-COLOCATED: runs after the assembly is known (mounted cell
+	// set) and the deployment topology is sealed — the upstream backstop for
+	// role-based subset mounting.
+	if err := b.validateMountedEqualsColocated(); err != nil {
+		return err
+	}
 	// Advisory check (non-blocking): warn when the declared K8s grace period
 	// is smaller than the bootstrap shutdown budget plus a 10s safety margin.
 	b.warnTerminationGracePeriodInsufficient()
@@ -122,6 +128,63 @@ func (b *Bootstrap) validateDeploymentTopology() error {
 		return err
 	}
 	b.deploymentTopology = dt
+	return nil
+}
+
+// MOUNTED-EQUALS-COLOCATED error message constants — MESSAGE-CONST-LITERAL-01.
+const (
+	errMsgMountedCellRemote = "deployment topology: a cell mounted in this process is declared remote for this role; " +
+		"a remote cell must not be hosted locally (mount the colocated subset via composition.NewForRole)"
+	errMsgMountedCellNotColocated = "deployment topology: a cell mounted in this process is not in this role's colocated set"
+	errMsgColocatedCellNotMounted = "deployment topology: a cell in this role's colocated set is not mounted in this process"
+)
+
+// validateMountedEqualsColocated enforces MOUNTED-EQUALS-COLOCATED: in an
+// explicit split topology, the set of cells this process mounts (b.assemblyCore)
+// MUST equal the topology's colocated set, and no mounted cell may be declared
+// remote. This is the upstream backstop for composition.NewForRole — even a root
+// that bypasses NewForRole and mounts the full cell set directly
+// (New(allCells).With(allMods)) fails fast here instead of silently
+// double-mounting a remote cell. A zero (all-colocated) topology, or a process
+// with no assembly, trivially satisfies the invariant.
+//
+// AI-robust grade: Medium (runtime bijection over runtime cellID strings — the
+// same honest ceiling as M12a / the broker-mandatory gate; cellID is not a
+// compile-time fact). Called at phase0 after the topology is sealed and the
+// assembly is wired.
+func (b *Bootstrap) validateMountedEqualsColocated() error {
+	dt := b.deploymentTopology
+	if !dt.explicit {
+		return nil // monolith / no explicit topology: all colocated, no remotes
+	}
+	if b.assemblyCore == nil {
+		return nil // no mounted cells to validate (assembly presence handled elsewhere)
+	}
+	mounted := b.assemblyCore.CellIDs()
+	mountedSet := make(map[string]struct{}, len(mounted))
+	for _, id := range mounted {
+		mountedSet[id] = struct{}{}
+		if _, isRemote := dt.remote[id]; isRemote {
+			return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+				errMsgMountedCellRemote,
+				errcode.WithInternal(errcode.InternalAttr("cellID", id)),
+				errcode.WithDetails(errcode.PublicString("cellID", id)))
+		}
+		if _, isColoc := dt.colocated[id]; !isColoc {
+			return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+				errMsgMountedCellNotColocated,
+				errcode.WithInternal(errcode.InternalAttr("cellID", id)),
+				errcode.WithDetails(errcode.PublicString("cellID", id)))
+		}
+	}
+	for id := range dt.colocated {
+		if _, ok := mountedSet[id]; !ok {
+			return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+				errMsgColocatedCellNotMounted,
+				errcode.WithInternal(errcode.InternalAttr("cellID", id)),
+				errcode.WithDetails(errcode.PublicString("cellID", id)))
+		}
+	}
 	return nil
 }
 

--- a/framework/runtime/composition/builder.go
+++ b/framework/runtime/composition/builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -42,6 +43,11 @@ type Builder struct {
 	modules         []CellModule
 	expectedCellIDs []string
 	migrations      []MigrationRegistration
+	// roleSpec is the deployment-topology spec NewForRole filtered modules with,
+	// or nil for a plain New() builder. Build asserts it equals
+	// SharedDeps.DeploymentTopology so the subset-mount source and the sealed
+	// runtime topology share one source (validateRoleSpecMatchesShared, #2278).
+	roleSpec *bootstrap.DeploymentTopologySpec
 }
 
 // New returns a new Builder whose composed cells must form exactly the
@@ -144,6 +150,30 @@ func validateBuildInputs(shared *SharedDeps, runtimeOptsFn RuntimeOptionsFunc) e
 	return nil
 }
 
+// validateRoleSpecMatchesShared enforces a single deployment-topology source: a
+// Builder produced by [NewForRole] filtered its modules with a spec, and Build
+// seals SharedDeps.DeploymentTopology into the runtime topology. If those two
+// diverged, this process could mount one partition's cells while routing
+// cross-cell transport per another — a silent split-topology corruption. They
+// MUST be the same SpecForRole(generatedTopologyGroups(), role) result; Build
+// fail-fasts on any mismatch. A plain New() builder has no role spec (roleSpec
+// nil) and skips the check.
+//
+// ref: kubernetes cmd/kube-controller-manager options.Validate — validate the
+// aggregate config once before startup; uber-go/fx app.go — surface wiring
+// errors before the graph starts.
+func (b *Builder) validateRoleSpecMatchesShared(shared *SharedDeps) error {
+	if b.roleSpec == nil {
+		return nil
+	}
+	if !reflect.DeepEqual(*b.roleSpec, shared.DeploymentTopology) {
+		return fmt.Errorf("composition.Builder.Build: NewForRole was given a deployment-topology spec that " +
+			"differs from SharedDeps.DeploymentTopology; both must be the single SpecForRole(...) result so the " +
+			"mounted subset and the sealed runtime topology cannot diverge")
+	}
+	return nil
+}
+
 // validateClosedSet enforces the M12a build-time closed-set invariant: the set
 // of composed cell IDs must equal the assembly's declared cell-id set
 // (b.expectedCellIDs) — a bijection. It runs before any module Provide so a
@@ -201,6 +231,9 @@ func (b *Builder) Build(
 	runtimeOptsFn RuntimeOptionsFunc,
 ) (*App, error) {
 	if err := validateBuildInputs(shared, runtimeOptsFn); err != nil {
+		return nil, err
+	}
+	if err := b.validateRoleSpecMatchesShared(shared); err != nil {
 		return nil, err
 	}
 	if err := b.validateClosedSet(); err != nil {

--- a/framework/runtime/composition/builder_role.go
+++ b/framework/runtime/composition/builder_role.go
@@ -1,0 +1,59 @@
+package composition
+
+import (
+	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
+)
+
+// NewForRole returns a Builder that mounts only the cells THIS process hosts for
+// its deployment role — the colocated subset of the assembly. It is the
+// sanctioned subset-mount entry for production composition roots (cmd/*,
+// examples/*): COMPOSITION-NEWFORROLE-FUNNEL-01 bans bare composition.New there
+// so a root cannot mount the full cell set in a split topology.
+//
+// spec is the per-process placement derived once at the composition root via
+// bootstrap.SpecForRole(generatedTopologyGroups(), GOCELL_CELL_ROLE) and also
+// carried on SharedDeps.DeploymentTopology (single source — NewForRole consumes
+// it, it does not re-derive). Two branches:
+//
+//   - zero spec (all-colocated monolith): mount EVERY module unfiltered, with the
+//     full assemblyCellIDs as the closed set. Filtering here would silently drop
+//     an out-of-assembly module instead of letting Build's M12a closed-set guard
+//     (validateClosedSet) reject it; the monolith path must stay unfiltered so
+//     drift between generatedCellModules and the assembly cell list still fails.
+//   - explicit spec (split role): the closed set is spec.Colocated and only
+//     modules whose ID is in it are mounted; other groups' cells are remote and
+//     their modules are dropped (a nil module is skipped — Build then reports the
+//     resulting missing colocated cell).
+//
+// assemblyCellIDs is the monolith branch's independent M12a closed-set source;
+// the split branch uses spec.Colocated. Selecting the closed set per mode is the
+// design, not a dead parameter.
+//
+// NewForRole is a convenience funnel, not the enforcement boundary: bijection /
+// missing-module errors surface from Build.validateClosedSet, and the true
+// fail-closed check is the bootstrap MOUNTED-EQUALS-COLOCATED phase guard, which
+// catches any process that mounts a remote cell regardless of how it was built.
+//
+// ref: akka/akka cluster-sharding withRole — one artifact, a static role selects
+// which cells this node hosts; non-hosted cells are reached as remote.
+func NewForRole(assemblyCellIDs []string, spec bootstrap.DeploymentTopologySpec, allModules ...CellModule) *Builder {
+	// Zero spec → monolith: full assembly closed set, all modules unfiltered.
+	if len(spec.Colocated) == 0 && len(spec.Remote) == 0 {
+		return New(assemblyCellIDs...).With(allModules...)
+	}
+	// Explicit spec → split: closed set = colocated subset; filter modules to it.
+	colocated := make(map[string]struct{}, len(spec.Colocated))
+	for _, id := range spec.Colocated {
+		colocated[id] = struct{}{}
+	}
+	mounted := make([]CellModule, 0, len(spec.Colocated))
+	for _, m := range allModules {
+		if m == nil {
+			continue // nil module → its colocated cell surfaces as missing in Build
+		}
+		if _, ok := colocated[m.ID()]; ok {
+			mounted = append(mounted, m)
+		}
+	}
+	return New(spec.Colocated...).With(mounted...)
+}

--- a/framework/runtime/composition/builder_role.go
+++ b/framework/runtime/composition/builder_role.go
@@ -20,19 +20,33 @@ import (
 //     an out-of-assembly module instead of letting Build's M12a closed-set guard
 //     (validateClosedSet) reject it; the monolith path must stay unfiltered so
 //     drift between generatedCellModules and the assembly cell list still fails.
-//   - explicit spec (split role): the closed set is spec.Colocated and only
-//     modules whose ID is in it are mounted; other groups' cells are remote and
-//     their modules are dropped (a nil module is skipped — Build then reports the
-//     resulting missing colocated cell).
+//   - explicit spec (split role): the closed set is spec.Colocated. Modules whose
+//     cell is declared remote for this role are dropped (they are reached via
+//     transport); everything else — colocated modules PLUS any stranger whose cell
+//     is in neither colocated nor remote — is passed to Build, whose closed-set
+//     guard (closed set = spec.Colocated) mounts the colocated bijection and
+//     rejects a stranger ("not in the assembly closed set"). A nil module is
+//     skipped. Dropping only the known-remote set (rather than keeping only the
+//     colocated set) is deliberate: it routes stranger drift — generatedCellModules
+//     out of sync with the topology groups — into Build's fail-fast instead of a
+//     silent drop (#2278 review).
+//
+// A dropped (remote) module's Provide is never called, so a module MUST open its
+// infrastructure in Provide, not in its constructor — a constructor that opened a
+// connection would leak it for a remote cell this process never builds.
 //
 // assemblyCellIDs is the monolith branch's independent M12a closed-set source;
 // the split branch uses spec.Colocated. Selecting the closed set per mode is the
 // design, not a dead parameter.
 //
-// NewForRole is a convenience funnel, not the enforcement boundary: bijection /
-// missing-module errors surface from Build.validateClosedSet, and the true
-// fail-closed check is the bootstrap MOUNTED-EQUALS-COLOCATED phase guard, which
-// catches any process that mounts a remote cell regardless of how it was built.
+// NewForRole is a convenience funnel, not the enforcement boundary. The two-sided
+// grading: the caller-funnel COMPOSITION-NEWFORROLE-FUNNEL-01 (Medium, AST scan)
+// bans bare composition.New in wiring roots, and the bootstrap
+// MOUNTED-EQUALS-COLOCATED-01 phase guard (Medium, runtime bijection) is the true
+// fail-closed backstop — it catches any process that mounts a remote cell
+// regardless of how it was built. Bijection / missing-module / stranger errors
+// surface from Build.validateClosedSet. Both ceilings are Medium (exported
+// cross-package constructor + runtime cellID strings), per ADR §#1967 Amendment.
 //
 // ref: akka/akka cluster-sharding withRole — one artifact, a static role selects
 // which cells this node hosts; non-hosted cells are reached as remote.
@@ -41,19 +55,22 @@ func NewForRole(assemblyCellIDs []string, spec bootstrap.DeploymentTopologySpec,
 	if len(spec.Colocated) == 0 && len(spec.Remote) == 0 {
 		return New(assemblyCellIDs...).With(allModules...)
 	}
-	// Explicit spec → split: closed set = colocated subset; filter modules to it.
-	colocated := make(map[string]struct{}, len(spec.Colocated))
-	for _, id := range spec.Colocated {
-		colocated[id] = struct{}{}
+	// Explicit spec → split: closed set = colocated subset. Drop ONLY the
+	// known-remote modules; pass colocated + any stranger to Build so its
+	// closed-set guard rejects a stranger (drift) instead of silently dropping it.
+	remote := make(map[string]struct{}, len(spec.Remote))
+	for _, r := range spec.Remote {
+		remote[r.CellID] = struct{}{}
 	}
-	mounted := make([]CellModule, 0, len(spec.Colocated))
+	mounted := make([]CellModule, 0, len(allModules))
 	for _, m := range allModules {
 		if m == nil {
 			continue // nil module → its colocated cell surfaces as missing in Build
 		}
-		if _, ok := colocated[m.ID()]; ok {
-			mounted = append(mounted, m)
+		if _, isRemote := remote[m.ID()]; isRemote {
+			continue // remote cell: hosted by another role, reached via transport
 		}
+		mounted = append(mounted, m)
 	}
 	return New(spec.Colocated...).With(mounted...)
 }

--- a/framework/runtime/composition/builder_role.go
+++ b/framework/runtime/composition/builder_role.go
@@ -26,10 +26,15 @@ import (
 //     is in neither colocated nor remote — is passed to Build, whose closed-set
 //     guard (closed set = spec.Colocated) mounts the colocated bijection and
 //     rejects a stranger ("not in the assembly closed set"). A nil module is
-//     skipped. Dropping only the known-remote set (rather than keeping only the
-//     colocated set) is deliberate: it routes stranger drift — generatedCellModules
-//     out of sync with the topology groups — into Build's fail-fast instead of a
-//     silent drop (#2278 review).
+//     passed through unchanged so Build's nil-guard fail-fasts on it (never
+//     silently dropped). Dropping only the known-remote set (rather than keeping
+//     only the colocated set) is deliberate: it routes stranger drift —
+//     generatedCellModules out of sync with the topology groups — into Build's
+//     fail-fast instead of a silent drop (#2278 review).
+//
+// The spec is recorded on the Builder (roleSpec); Build asserts it equals
+// SharedDeps.DeploymentTopology so the subset-mount source and the sealed runtime
+// topology cannot diverge (single deployment-topology source).
 //
 // A dropped (remote) module's Provide is never called, so a module MUST open its
 // infrastructure in Provide, not in its constructor — a constructor that opened a
@@ -53,7 +58,9 @@ import (
 func NewForRole(assemblyCellIDs []string, spec bootstrap.DeploymentTopologySpec, allModules ...CellModule) *Builder {
 	// Zero spec → monolith: full assembly closed set, all modules unfiltered.
 	if len(spec.Colocated) == 0 && len(spec.Remote) == 0 {
-		return New(assemblyCellIDs...).With(allModules...)
+		b := New(assemblyCellIDs...).With(allModules...)
+		b.roleSpec = &spec
+		return b
 	}
 	// Explicit spec → split: closed set = colocated subset. Drop ONLY the
 	// known-remote modules; pass colocated + any stranger to Build so its
@@ -65,12 +72,19 @@ func NewForRole(assemblyCellIDs []string, spec bootstrap.DeploymentTopologySpec,
 	mounted := make([]CellModule, 0, len(allModules))
 	for _, m := range allModules {
 		if m == nil {
-			continue // nil module → its colocated cell surfaces as missing in Build
+			// Pass nil through to Build, whose resolveModuleResult fail-fasts on a
+			// nil module ("module list contains nil"). NewForRole must not silently
+			// drop a wiring bug — keep the same non-nil contract the monolith branch
+			// (and plain New) rely on (#2278 review F1).
+			mounted = append(mounted, m)
+			continue
 		}
 		if _, isRemote := remote[m.ID()]; isRemote {
 			continue // remote cell: hosted by another role, reached via transport
 		}
 		mounted = append(mounted, m)
 	}
-	return New(spec.Colocated...).With(mounted...)
+	b := New(spec.Colocated...).With(mounted...)
+	b.roleSpec = &spec
+	return b
 }

--- a/framework/runtime/composition/builder_role_test.go
+++ b/framework/runtime/composition/builder_role_test.go
@@ -119,6 +119,45 @@ func TestNewForRole_SplitStrangerModuleRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "closed set")
 }
 
+// TestNewForRole_SplitNilModuleFails verifies that a nil module in the split
+// branch is NOT silently dropped: NewForRole passes it through to Build, whose
+// nil-guard fail-fasts (#2278 review F1) — preserving the same non-nil contract
+// plain New() relies on.
+func TestNewForRole_SplitNilModuleFails(t *testing.T) {
+	ctx := context.Background()
+	spec := bootstrap.DeploymentTopologySpec{
+		Colocated: []string{"mod1"},
+		Remote:    []bootstrap.RemoteCellEndpoint{{CellID: "mod2", Endpoint: "mod2.svc:9090"}},
+	}
+	shared := minimalSharedDeps(t)
+	shared.DeploymentTopology = spec
+	m1 := &fakeCellModule{id: "mod1", cell: stubCell("mod1")}
+
+	_, err := NewForRole([]string{"mod1", "mod2"}, spec, m1, nil).Build(ctx, shared, noopRuntimeOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "module list contains nil")
+}
+
+// TestNewForRole_SpecMismatchSharedFails verifies the single deployment-topology
+// source guard (#2278 review F2): if the spec NewForRole filtered with differs
+// from SharedDeps.DeploymentTopology that Build seals, Build fail-fasts — the
+// mounted subset and the sealed runtime topology must not diverge.
+func TestNewForRole_SpecMismatchSharedFails(t *testing.T) {
+	ctx := context.Background()
+	roleSpec := bootstrap.DeploymentTopologySpec{
+		Colocated: []string{"mod1"},
+		Remote:    []bootstrap.RemoteCellEndpoint{{CellID: "mod2", Endpoint: "mod2.svc:9090"}},
+	}
+	shared := minimalSharedDeps(t)
+	// shared carries a DIFFERENT topology than the spec NewForRole filtered with.
+	shared.DeploymentTopology = bootstrap.DeploymentTopologySpec{Colocated: []string{"mod1", "mod2"}}
+	m1 := &fakeCellModule{id: "mod1", cell: stubCell("mod1")}
+
+	_, err := NewForRole([]string{"mod1", "mod2"}, roleSpec, m1).Build(ctx, shared, noopRuntimeOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DeploymentTopology")
+}
+
 // TestNewForRole_MonolithDoesNotFilter_M12aDriftDetected is the regression guard
 // for the M12a trap: the monolith branch must pass ALL modules to Build
 // unfiltered, so an out-of-assembly module is caught by the closed-set guard

--- a/framework/runtime/composition/builder_role_test.go
+++ b/framework/runtime/composition/builder_role_test.go
@@ -1,0 +1,110 @@
+package composition
+
+// builder_role_test.go — tests for NewForRole, the role-based subset-mount
+// constructor (#2278 PR-2). Two branches:
+//   - zero spec (monolith): mount ALL modules unfiltered (so M12a still detects
+//     an out-of-assembly module — filtering here would silently drop it).
+//   - explicit spec (split): mount only the colocated subset; other groups' cells
+//     are remote and their modules are dropped.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/framework/kernel/cell"
+	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
+)
+
+// TestNewForRole_MonolithMountsAll verifies that a zero (all-colocated) spec
+// mounts every module — equivalent to New(assemblyCellIDs...).With(allModules...).
+func TestNewForRole_MonolithMountsAll(t *testing.T) {
+	ctx := context.Background()
+	m1 := &fakeCellModule{id: "mod1", cell: stubCell("mod1")}
+	m2 := &fakeCellModule{id: "mod2", cell: stubCell("mod2")}
+
+	var runtimeCells []cell.Cell
+	rtFn := func(cells []cell.Cell) ([]bootstrap.Option, error) {
+		runtimeCells = cells
+		return nil, nil
+	}
+
+	app, err := NewForRole([]string{"mod1", "mod2"}, bootstrap.DeploymentTopologySpec{}, m1, m2).
+		Build(ctx, minimalSharedDeps(t), rtFn)
+	require.NoError(t, err)
+	require.NotNil(t, app)
+
+	assert.True(t, m1.called && m2.called, "monolith must mount every module")
+	require.Len(t, runtimeCells, 2)
+}
+
+// TestNewForRole_SplitMountsColocatedSubset verifies that an explicit spec mounts
+// only this role's colocated cells; modules for remote cells are filtered out
+// (their Provide is never called).
+func TestNewForRole_SplitMountsColocatedSubset(t *testing.T) {
+	ctx := context.Background()
+	spec := bootstrap.DeploymentTopologySpec{
+		Colocated: []string{"mod1"},
+		Remote:    []bootstrap.RemoteCellEndpoint{{CellID: "mod2", Endpoint: "mod2.svc:9090"}},
+	}
+	shared := minimalSharedDeps(t)
+	shared.DeploymentTopology = spec
+
+	m1 := &fakeCellModule{id: "mod1", cell: stubCell("mod1")}
+	m2 := &fakeCellModule{id: "mod2", cell: stubCell("mod2")}
+
+	var runtimeCells []cell.Cell
+	rtFn := func(cells []cell.Cell) ([]bootstrap.Option, error) {
+		runtimeCells = cells
+		return nil, nil
+	}
+
+	app, err := NewForRole([]string{"mod1", "mod2"}, spec, m1, m2).Build(ctx, shared, rtFn)
+	require.NoError(t, err)
+	require.NotNil(t, app)
+
+	assert.True(t, m1.called, "colocated module mod1 must be mounted")
+	assert.False(t, m2.called, "remote module mod2 must NOT be mounted (its cell is remote)")
+	require.Len(t, runtimeCells, 1)
+	assert.Equal(t, "mod1", runtimeCells[0].ID())
+}
+
+// TestNewForRole_SplitMissingColocatedModuleFails verifies that a colocated cell
+// with no providing module is rejected by Build's closed-set guard (the filtered
+// module set must be a bijection onto the colocated cell IDs).
+func TestNewForRole_SplitMissingColocatedModuleFails(t *testing.T) {
+	ctx := context.Background()
+	spec := bootstrap.DeploymentTopologySpec{
+		Colocated: []string{"mod1", "mod3"},
+		Remote:    []bootstrap.RemoteCellEndpoint{{CellID: "mod2", Endpoint: "mod2.svc:9090"}},
+	}
+	shared := minimalSharedDeps(t)
+	shared.DeploymentTopology = spec
+
+	m1 := &fakeCellModule{id: "mod1", cell: stubCell("mod1")}
+	m2 := &fakeCellModule{id: "mod2", cell: stubCell("mod2")}
+
+	_, err := NewForRole([]string{"mod1", "mod2", "mod3"}, spec, m1, m2).Build(ctx, shared, noopRuntimeOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mod3")
+	assert.Contains(t, err.Error(), "no module provides it")
+}
+
+// TestNewForRole_MonolithDoesNotFilter_M12aDriftDetected is the regression guard
+// for the M12a trap: the monolith branch must pass ALL modules to Build
+// unfiltered, so an out-of-assembly module is caught by the closed-set guard
+// rather than silently dropped. If NewForRole filtered in the monolith branch,
+// mOutsider would vanish and the drift would go undetected.
+func TestNewForRole_MonolithDoesNotFilter_M12aDriftDetected(t *testing.T) {
+	ctx := context.Background()
+	m1 := &fakeCellModule{id: "mod1", cell: stubCell("mod1")}
+	mOutsider := &fakeCellModule{id: "outsider", cell: stubCell("outsider")}
+
+	_, err := NewForRole([]string{"mod1"}, bootstrap.DeploymentTopologySpec{}, m1, mOutsider).
+		Build(ctx, minimalSharedDeps(t), noopRuntimeOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outsider")
+	assert.Contains(t, err.Error(), "closed set")
+}

--- a/framework/runtime/composition/builder_role_test.go
+++ b/framework/runtime/composition/builder_role_test.go
@@ -49,6 +49,9 @@ func TestNewForRole_SplitMountsColocatedSubset(t *testing.T) {
 		Colocated: []string{"mod1"},
 		Remote:    []bootstrap.RemoteCellEndpoint{{CellID: "mod2", Endpoint: "mod2.svc:9090"}},
 	}
+	// In production shared.DeploymentTopology and the spec passed to NewForRole are
+	// the SAME value (both = SpecForRole(generatedTopologyGroups(), role)); the test
+	// aligns them explicitly to mirror that single-source contract.
 	shared := minimalSharedDeps(t)
 	shared.DeploymentTopology = spec
 
@@ -90,6 +93,30 @@ func TestNewForRole_SplitMissingColocatedModuleFails(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mod3")
 	assert.Contains(t, err.Error(), "no module provides it")
+}
+
+// TestNewForRole_SplitStrangerModuleRejected verifies that a module whose cell is
+// in NEITHER the colocated set nor the remote set (a "stranger" — generatedCellModules
+// drifted from the topology groups) is NOT silently dropped: NewForRole drops only
+// known-remote modules, so the stranger reaches Build and is rejected by the
+// closed-set guard "not in the assembly closed set" (#2278 review).
+func TestNewForRole_SplitStrangerModuleRejected(t *testing.T) {
+	ctx := context.Background()
+	spec := bootstrap.DeploymentTopologySpec{
+		Colocated: []string{"mod1"},
+		Remote:    []bootstrap.RemoteCellEndpoint{{CellID: "mod2", Endpoint: "mod2.svc:9090"}},
+	}
+	shared := minimalSharedDeps(t)
+	shared.DeploymentTopology = spec
+
+	m1 := &fakeCellModule{id: "mod1", cell: stubCell("mod1")}
+	m2 := &fakeCellModule{id: "mod2", cell: stubCell("mod2")} // remote → dropped
+	mStranger := &fakeCellModule{id: "zzz", cell: stubCell("zzz")}
+
+	_, err := NewForRole([]string{"mod1", "mod2"}, spec, m1, m2, mStranger).Build(ctx, shared, noopRuntimeOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "zzz")
+	assert.Contains(t, err.Error(), "closed set")
 }
 
 // TestNewForRole_MonolithDoesNotFilter_M12aDriftDetected is the regression guard

--- a/tools/archtest/composition_newforrole_funnel.go
+++ b/tools/archtest/composition_newforrole_funnel.go
@@ -1,0 +1,90 @@
+package archtest
+
+// composition_newforrole_funnel.go — importable COMPOSITION-NEWFORROLE-FUNNEL-01
+// rule logic (#2278 PR-2). Non-test home so the detector core is shared by the
+// production scan, the synthetic RED fixture, and the dot-import blind-spot
+// guard — single source, no parallel rule body.
+
+// # COMPOSITION-NEWFORROLE-FUNNEL-01
+//
+// composition.NewForRole is the sole sanctioned entry by which a production
+// composition root (cmd/*, examples/*) mounts cells: it derives the per-process
+// colocated subset from the deployment topology spec and filters the module set
+// to it (the all-colocated monolith mounts everything; a split role mounts only
+// its own cells). Wiring-layer packages MUST NOT call composition.New directly:
+// New takes the full assembly cell-id set and mounts whatever modules it is
+// given, so a root that calls New(allCells).With(allMods) in a split topology
+// silently double-mounts a remote cell (the failure mode D4 describes).
+//
+// The funnel bans the bare composition.New selector in the wiring roots. The
+// composition package itself (where NewForRole legitimately calls New) is the
+// framework, not under a scanned root, so its New call is naturally out of
+// scope. composition.NewForRole and composition.NewSharedDeps are distinct
+// selectors and are not matched. Test files (*_test.go) are excluded by the
+// scanner: integration tests legitimately exercise the lower-level New API.
+//
+// # AI-robust grade: Medium (AST callsite scan)
+//
+// NewForRole is an exported cross-package constructor; Go visibility cannot
+// express "only the composition root may call it", so this is a CI-time AST
+// scan — the same family as CELLTRANSPORT-SELECT-FUNNEL-01 and
+// CROSSCELLOBS-MINTER-FUNNEL-01. The true fail-closed enforcement is the
+// runtime MOUNTED-EQUALS-COLOCATED phase guard (upstream backstop), which
+// catches any bypass regardless of how the build was assembled.
+//
+// # Blind spots
+//
+//   - Dot-import of runtime/composition: `import . ".../composition"; New(...)`
+//     would make New a bare ident the SelectorExpr scan misses. Closed by the
+//     reverse self-test TestCOMPOSITION_NEWFORROLE_FUNNEL_01_NoDotImportBlindSpot.
+//   - Reflection-based construction: out of scope, treated as theoretical.
+
+import (
+	"testing"
+
+	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
+)
+
+// runtimeCompositionModule is the import path of the composition package whose
+// bare New constructor the funnel bans in wiring-layer roots.
+const runtimeCompositionModule = PlatformFrameworkModulePath + "/runtime/composition"
+
+// compositionNewForRoleWiringRoots are the module-relative wiring-layer prefixes
+// the funnel scans. These are the production composition roots that must mount
+// cells via composition.NewForRole, never bare composition.New. cellmodules/ and
+// corecells/ are NOT scanned: they provide modules, they do not assemble the app.
+var compositionNewForRoleWiringRoots = []string{"cmd", "examples"}
+
+// CheckCompositionNewForRoleFunnel01 scans the wiring-layer roots for direct
+// calls to composition.New and returns one Diagnostic per offending callsite. It
+// is the single rule body — the Test* dogfoods it via Report — so the exact scan
+// is the one enforced.
+func CheckCompositionNewForRoleFunnel01(t *testing.T, _ ConfigForExternalCell) []Diagnostic {
+	t.Helper()
+
+	root := findModuleRoot(t)
+	files, err := scanner.DirsScope(root, compositionNewForRoleWiringRoots).Files()
+	if err != nil {
+		t.Fatalf("COMPOSITION-NEWFORROLE-FUNNEL-01: scanner.DirsScope: %v", err)
+	}
+
+	var diags []Diagnostic
+	for _, path := range files {
+		rel := funnelRelSlash(root, path)
+
+		line, ok, perr := firstQualifiedSelectorLine(path, runtimeCompositionModule, "composition", "New")
+		if perr != nil {
+			t.Fatalf("COMPOSITION-NEWFORROLE-FUNNEL-01: parse %s: %v", rel, perr)
+		}
+		if ok {
+			diags = append(diags, Diagnostic{
+				Rel:  rel,
+				Line: line,
+				Message: "composition.New in a wiring-layer package; mount cells via " +
+					"composition.NewForRole so the deployment role's colocated subset is selected " +
+					"(COMPOSITION-NEWFORROLE-FUNNEL-01)",
+			})
+		}
+	}
+	return diags
+}

--- a/tools/archtest/composition_newforrole_funnel_test.go
+++ b/tools/archtest/composition_newforrole_funnel_test.go
@@ -1,0 +1,104 @@
+//go:build archtest
+
+// INVARIANT: COMPOSITION-NEWFORROLE-FUNNEL-01
+package archtest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/tools/archtest/internal/scanner"
+)
+
+// TestCOMPOSITION_NEWFORROLE_FUNNEL_01 dogfoods CheckCompositionNewForRoleFunnel01:
+// production wiring-layer packages (cmd/*, examples/*) must mount cells via
+// composition.NewForRole — no direct composition.New call (#2278 PR-2).
+func TestCOMPOSITION_NEWFORROLE_FUNNEL_01(t *testing.T) {
+	t.Parallel()
+	Report(t, "COMPOSITION-NEWFORROLE-FUNNEL-01", CheckCompositionNewForRoleFunnel01(t, ConfigForExternalCell{}))
+}
+
+// TestCOMPOSITION_NEWFORROLE_FUNNEL_01_RedFixture asserts the detector fires on a
+// known-positive composition.New call. The source is written to a temp file and
+// parsed (never compiled), so the fixture cannot pollute the production scan.
+// Without this, a broken detector would silently pass (anti-vacuity).
+func TestCOMPOSITION_NEWFORROLE_FUNNEL_01_RedFixture(t *testing.T) {
+	t.Parallel()
+	src := "package redfixture\n\n" +
+		"import \"" + runtimeCompositionModule + "\"\n\n" +
+		"var _ = composition.New\n"
+	path := filepath.Join(t.TempDir(), "compose_red.go")
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o600))
+
+	line, ok, err := firstQualifiedSelectorLine(path, runtimeCompositionModule, "composition", "New")
+	require.NoError(t, err, "parse composition.New RED fixture")
+	if !ok {
+		t.Error("COMPOSITION-NEWFORROLE-FUNNEL-01 RED fixture: detector found no " +
+			"composition.New; firstQualifiedSelectorLine may be broken")
+		return
+	}
+	t.Logf("composition.New RED fixture hit at line %d", line)
+}
+
+// TestCOMPOSITION_NEWFORROLE_FUNNEL_01_DoesNotMatchSiblingConstructors asserts the
+// scan keys on the exact "New" selector and does NOT flag composition.NewForRole
+// (the sanctioned entry) or composition.NewSharedDeps (a different constructor) —
+// otherwise the funnel would forbid its own replacement.
+func TestCOMPOSITION_NEWFORROLE_FUNNEL_01_DoesNotMatchSiblingConstructors(t *testing.T) {
+	t.Parallel()
+	src := "package siblingfixture\n\n" +
+		"import \"" + runtimeCompositionModule + "\"\n\n" +
+		"var _ = composition.NewForRole\n" +
+		"var _ = composition.NewSharedDeps\n"
+	path := filepath.Join(t.TempDir(), "sibling.go")
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o600))
+
+	line, ok, err := firstQualifiedSelectorLine(path, runtimeCompositionModule, "composition", "New")
+	require.NoError(t, err, "parse sibling-constructor fixture")
+	if ok {
+		t.Errorf("COMPOSITION-NEWFORROLE-FUNNEL-01: selector scan must not match "+
+			"NewForRole/NewSharedDeps, but matched at line %d", line)
+	}
+}
+
+// TestCOMPOSITION_NEWFORROLE_FUNNEL_01_AntiVacuity asserts the scanned file set is
+// non-empty, so a broken scanner that returns an empty set cannot silently appear
+// GREEN.
+func TestCOMPOSITION_NEWFORROLE_FUNNEL_01_AntiVacuity(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	files, err := scanner.DirsScope(root, compositionNewForRoleWiringRoots).Files()
+	require.NoError(t, err, "DirsScope must succeed")
+	require.NotEmpty(t, files,
+		"COMPOSITION-NEWFORROLE-FUNNEL-01: scanned file set is empty — "+
+			"the scanner is broken or compositionNewForRoleWiringRoots point at non-existent dirs")
+}
+
+// TestCOMPOSITION_NEWFORROLE_FUNNEL_01_NoDotImportBlindSpot closes the dot-import
+// blind spot: a dot-import of runtime/composition would make New a bare ident the
+// SelectorExpr scan misses. Asserts no production file in the wiring roots
+// dot-imports runtime/composition.
+func TestCOMPOSITION_NEWFORROLE_FUNNEL_01_NoDotImportBlindSpot(t *testing.T) {
+	t.Parallel()
+	root := findModuleRoot(t)
+	files, err := scanner.DirsScope(root, compositionNewForRoleWiringRoots).Files()
+	require.NoError(t, err)
+
+	var findings []string
+	for _, path := range files {
+		rel := funnelRelSlash(root, path)
+		dot, perr := fileDotImportsModule(path, runtimeCompositionModule)
+		require.NoError(t, perr)
+		if dot {
+			findings = append(findings, fmt.Sprintf("%s: dot-import of %s evades COMPOSITION-NEWFORROLE-FUNNEL-01", rel, runtimeCompositionModule))
+		}
+	}
+	assert.Empty(t, findings,
+		"dot-importing runtime/composition in a wiring root would make New a bare ident "+
+			"and evade the funnel scan; forbidden")
+}


### PR DESCRIPTION
## Summary

运行期 role 选择层：`GOCELL_CELL_ROLE` 经 `bootstrap.SpecForRole` 由 assembly `topology.groups` 派生本进程 placement，`composition.NewForRole` 按 role 只挂 colocated 子集、其余当 remote，`MOUNTED-EQUALS-COLOCATED` phase guard 兜底——同一份 cell 代码 / 同一 image 即可单进程跑子集（#1423「彻底拆分」能力的 PR-2）。

## Why / 背景

PR-1（#2337）已落 `topology.groups` authoring schema + codegen golden，但运行期最小桥 `SpecForRole(groups, "")` 只支持全 colocated monolith，非空 role fail-closed；`composition.New(allCells).With(allMods)` 无条件挂载全部 cell——即使声明了多 group 拓扑，进程仍把对端 cell 本地双挂（静默破坏拆分）。PR-2 接上「assembly 声明拓扑 → 进程按 role 只挂 colocated 子集 → 其余当 remote」这条端到端桥接，使 SC-001 验收信号 (b) 任意子集 / (c) 多进程 生产可达。

核心对标 = Akka 节点角色模型（一份制品 + 静态 role 配置选 role，WriteOnce）/ Service Weaver `component.local` / controller-runtime「枚举全部、实例化 enabled 子集」。裁定见 ADR §#1967 Amendment（D1/D4）。

### 行为变更（不向后兼容，pre-GA 原地改）

`SpecForRole` 语义：

| 输入 | 行为 |
|------|------|
| empty role + 0/1 group | 零 spec（全 colocated monolith，零迁移默认） |
| empty role + ≥2 group | **fail-fast**（声明拆分却没选 role → 12-factor：env 被消费或报错；PR-1 此情形返回 monolith，本 PR 反转） |
| role ∈ 声明集 | Colocated = 本组 cells；Remote = 其余组 cells × 各自 endpoint |
| role ∉ 声明集 | **fail-fast** |

### 双层 enforcement

- `composition.NewForRole`（收口构造器，Medium caller-funnel `COMPOSITION-NEWFORROLE-FUNNEL-01`）：monolith 分支**不过滤**全部 module 喂 Build（保 M12a 越界检测不退化）、split 分支按 colocated 过滤。
- `MOUNTED-EQUALS-COLOCATED` bootstrap phase guard（Medium 运行期 backstop）：mounted==colocated ∧ remote∉mounted，即便绕过 NewForRole 直挂也 fail-fast。

AI-robust 评级：两机制均 Medium（运行期 cellID/role 数据 + exported 跨包构造器 = Go 可见性天花板）；Hard 底座 = PR-1 的 groups codegen golden（PR-2 是其上的确定性纯函数）。审过的 Hard 化路径（per-role golden module list）因引入平行结构、违反优雅简洁而拒，无低成本 Hard 路径 → 不另开 Issue。

## Refs

- Refs #2278（1423-US9，PR-2 of 3；**不 close**——PR-3 缺失依赖启动期闸 + `gocell validate` 静态 arm 仍待）
- ADR `docs/architecture/202606131142-1423-adr-cell-deployment-topology.md` §#1967 Amendment（D1/D4）
- ref: akka/akka cluster-sharding withRole
- ref: ServiceWeaver/weaver internal/weaver/remoteweavelet.go
- ref: kubernetes cmd/kube-controller-manager ControllerDescriptor

## Risk / 兼容性

- **wire/contract 影响：无**——codegen / metadata / schema 零改动（`generatedTopologyGroups()` 仍返回全图，filtering 在运行期）。
- **行为变更**：`SpecForRole(groups, "")` 在 ≥2 group 时由「返回 monolith」变为「fail-fast」。当前 `corebundle` assembly.yaml 无 `topology.groups`（`generatedTopologyGroups()` 返回 nil），故**默认部署不受影响**；待 PR-4 给 corebundle 加 groups 后，多 group 部署须显式设 `GOCELL_CELL_ROLE`（Akka 模型）。
- 两个生产 composition root（corebundle + corebundlestarter）迁移到 `NewForRole`；in-repo 调用方随本 PR 原子更新。
- 端到端双拓扑（同 image 2 进程 + broker + PG）验收是 PR-4 / #1967，不在本 PR。

## Test plan

- [x] `go build ./...` 本地通过（framework + cmd/corebundle + examples/corebundlestarter）
- [x] `go test ./...` 本地通过（bootstrap + composition 全量；两 root 模块；archtest funnel + topology + inventory gates）
- [x] `golangci-lint run ./...` 0 issues（framework / cmd/corebundle / examples/corebundlestarter / tools）
- [x] TDD：RED commit（`8efad216d`）先于 GREEN（`355b8c79c`）
- [ ] 注：full archtest 套件有 5 个**预存失败**（`registrycore` / `kernel/governance` / `audit`，commit `e5d71bf53` clean develop 上已红），与本 PR 无关、不在范围
