### PR TITLE
feat(eventtransport): #2152 per-cell AMQP 凭据/vhost 隔离安全模型 + AMQP-URL-REDACTION-FUNNEL-01 [1423-US6 PR-3]

### DIFF
--- a/.claude/rules/gocell/eventbus.md
+++ b/.claude/rules/gocell/eventbus.md
@@ -16,7 +16,7 @@ in-memory bus **仅** demo 拓扑可达：**composition root**（`cmd/corebundle
 broker（mqtt）在 `eventtransport` 的 `brokerKind` switch 加分支 + 暴露选择 env，不在本约束外另开旁路。
 权威语义见 `cellmodules/eventtransport/doc.go` 与 ADR `202606131500-1940`。
 
-## per-cell AMQP vhost/credential 隔离（#2152 PR-3）
+## per-cell AMQP vhost/credential 隔离
 
 per-cell URL 携带 per-cell 凭据（user:pass）和 vhost。split 拓扑下 operator 为每个 cell
 provision 独立的 vhost 和 AMQP user，使每个进程只持有访问自身 broker 资源所需凭据——

--- a/.claude/rules/gocell/eventbus.md
+++ b/.claude/rules/gocell/eventbus.md
@@ -18,17 +18,16 @@ broker（mqtt）在 `eventtransport` 的 `brokerKind` switch 加分支 + 暴露�
 
 ## per-cell AMQP vhost/credential 隔离
 
-per-cell URL 携带 per-cell 凭据（user:pass）和 vhost。split 拓扑下 operator 为每个 cell
-provision 独立的 vhost 和 AMQP user，使每个进程只持有访问自身 broker 资源所需凭据——
-cell 进程无法跨 cell 发布或消费事件。凭据由 broker operator 外部配置（非 framework 派生，
-无 HKDF/派生层，原因：AMQP broker 用户是外部对象，不存在 framework 可控的 master key）。
+per-cell URL（`GOCELL_<CELLID>_AMQP_URL`，CELLID 大写，缺省回退 `GOCELL_AMQP_URL`）携带 per-cell
+凭据（user:pass）和 vhost，是 per-cell 凭据/vhost 隔离的 **seam**。**目标安全模型**（split 拓扑）：operator
+为每个 cell provision 独立 vhost/AMQP user，使每个进程只持有访问自身 broker 资源所需凭据、无法跨 cell
+发布或消费事件。凭据由 broker operator 外部配置（非 framework 派生，无 HKDF/派生层，原因：AMQP broker
+用户是外部对象，不存在 framework 可控的 master key）。
 
-composition root 按 cell 读 `GOCELL_<CELLID>_AMQP_URL`（CELLID 大写），缺省回退
-`GOCELL_AMQP_URL`；完整接线示例见 `cellmodules/eventtransport/doc.go` §Composition-root usage。
-
-distinct per-cell URL 今 egress-only fail-closed（运行期隔离须 #2366/#2341 完成）；凭据
-non-leak 由 `AMQP-URL-REDACTION-FUNNEL-01`（Medium，typed AST funnel）守，权威语义见
-`cellmodules/eventtransport/doc.go` 与 ADR `202606131500-1940`。
+**当前可运行边界（非目标态）**：distinct per-cell URL 尚不可启用——egress-only fail-closed（运行期 per-cell
+隔离 blocked-by #2366/#2341），故当前唯一可运行配置是所有 cell 用同一 URL（共享同一 AMQP 凭据）。当前**已生效**
+的控制 = distinct-URL fail-closed + 凭据 non-leak（由 `AMQP-URL-REDACTION-FUNNEL-01` Medium typed AST funnel 守），
+**非** live per-cell 凭据隔离。权威语义见 `cellmodules/eventtransport/doc.go` 与 ADR `202606131500-1940`。
 
 ## 复用层选型（claimer / nonce，topology-gated）
 

--- a/.claude/rules/gocell/eventbus.md
+++ b/.claude/rules/gocell/eventbus.md
@@ -23,6 +23,9 @@ provision 独立的 vhost 和 AMQP user，使每个进程只持有访问自身 b
 cell 进程无法跨 cell 发布或消费事件。凭据由 broker operator 外部配置（非 framework 派生，
 无 HKDF/派生层，原因：AMQP broker 用户是外部对象，不存在 framework 可控的 master key）。
 
+composition root 按 cell 读 `GOCELL_<CELLID>_AMQP_URL`（CELLID 大写），缺省回退
+`GOCELL_AMQP_URL`；完整接线示例见 `cellmodules/eventtransport/doc.go` §Composition-root usage。
+
 distinct per-cell URL 今 egress-only fail-closed（运行期隔离须 #2366/#2341 完成）；凭据
 non-leak 由 `AMQP-URL-REDACTION-FUNNEL-01`（Medium，typed AST funnel）守，权威语义见
 `cellmodules/eventtransport/doc.go` 与 ADR `202606131500-1940`。

--- a/.claude/rules/gocell/eventbus.md
+++ b/.claude/rules/gocell/eventbus.md
@@ -6,15 +6,26 @@ composition root 的 `outbox.Publisher`/`outbox.Subscriber` 经
 `cellmodules/eventtransport.Resolve(clk, topo, cfg)` 按 `Topology` 单源选型：
 
 - demo / memory 拓扑 → 进程内 `runtime/eventbus`（Publisher == Subscriber 同实例）。
-- postgres 拓扑 → 真实 broker（RabbitMQ，从 `GOCELL_AMQP_URL`）；缺 broker URL 启动期
-  fail-closed，**不静默降级回 in-memory**（relay 必须把已持久化的 outbox entry 发到 broker，
-  而非进程内 bus，否则跨进程/重启丢事件）。
+- postgres 拓扑 → 真实 broker（RabbitMQ，从 `GOCELL_<CELLID>_AMQP_URL`，缺省回退
+  `GOCELL_AMQP_URL`）；缺 broker URL 启动期 fail-closed，**不静默降级回 in-memory**（relay
+  必须把已持久化的 outbox entry 发到 broker，而非进程内 bus，否则跨进程/重启丢事件）。
 
 in-memory bus **仅** demo 拓扑可达：**composition root**（`cmd/corebundle` + `examples/ssobff`）
 生产代码禁止直接 import `runtime/eventbus`，由 depguard `corebundle-no-direct-eventbus` /
 `ssobff-no-direct-eventbus` 守卫（`COREBUNDLE-EVENTBUS-FUNNEL-01`，路径级 import ban）。扩展新
 broker（mqtt）在 `eventtransport` 的 `brokerKind` switch 加分支 + 暴露选择 env，不在本约束外另开旁路。
 权威语义见 `cellmodules/eventtransport/doc.go` 与 ADR `202606131500-1940`。
+
+## per-cell AMQP vhost/credential 隔离（#2152 PR-3）
+
+per-cell URL 携带 per-cell 凭据（user:pass）和 vhost。split 拓扑下 operator 为每个 cell
+provision 独立的 vhost 和 AMQP user，使每个进程只持有访问自身 broker 资源所需凭据——
+cell 进程无法跨 cell 发布或消费事件。凭据由 broker operator 外部配置（非 framework 派生，
+无 HKDF/派生层，原因：AMQP broker 用户是外部对象，不存在 framework 可控的 master key）。
+
+distinct per-cell URL 今 egress-only fail-closed（运行期隔离须 #2366/#2341 完成）；凭据
+non-leak 由 `AMQP-URL-REDACTION-FUNNEL-01`（Medium，typed AST funnel）守，权威语义见
+`cellmodules/eventtransport/doc.go` 与 ADR `202606131500-1940`。
 
 ## 复用层选型（claimer / nonce，topology-gated）
 

--- a/cellmodules/celltransport/resolve.go
+++ b/cellmodules/celltransport/resolve.go
@@ -37,13 +37,24 @@ const remoteReadinessDialTimeout = 3 * time.Second
 
 // Error messages — MESSAGE-CONST-LITERAL-01.
 const (
-	msgNilInProc = "celltransport.Resolve: InProcessTransport must be set" +
-		" for a co-located cell (composition.Builder.Build mints it)"
-	// msgUnclassifiedCell is the error message for a cellID that is neither
-	// co-located nor remote in an explicit topology (TOPO-11 normally prevents
-	// this at static-analysis time; this is defense-in-depth).
-	msgUnclassifiedCell = "celltransport.Resolve: cellID not classified in deployment topology" +
-		" (neither co-located nor remote); gocell validate TOPO-11 prevents this at build time"
+	// msgNilInProc names the failure class "local dependency missing": the
+	// consumed provider is declared co-located (runs in this process) but its
+	// in-process transport was never minted, i.e. the local provider cell is not
+	// actually mounted/wired here. Distinct from msgUnclassifiedCell, where the
+	// provider has no place in the topology at all.
+	msgNilInProc = "celltransport.Resolve: local dependency missing —" +
+		" the co-located provider's in-process transport was not minted" +
+		" (composition.Builder.Build mints it for a mounted co-located cell)"
+	// msgUnclassifiedCell names the failure class "topology under-declared": the
+	// consumed provider cellID is neither co-located nor remote in this explicit
+	// deployment topology, so it has no route. gocell validate TOPO-11 rejects
+	// this statically; this eager seam (called at module-wiring/startup time) is
+	// the sync-dimension missing-dependency runtime fail-fast — there is no
+	// separate phase0 gate (ADR 202606131142-1423 §#1967).
+	msgUnclassifiedCell = "celltransport.Resolve: topology under-declared —" +
+		" cellID is neither co-located nor remote in this deployment topology" +
+		" (the consumed provider has no route); declare it in an assembly topology.groups group." +
+		" gocell validate TOPO-11 prevents this at build time"
 	// msgPlaintextNonLoopback rejects a non-loopback peer reached over plaintext
 	// (#2263): mTLS is mandatory across a real network boundary. The gocell
 	// validate TOPO gate also rejects this at build time; this is the runtime

--- a/cellmodules/celltransport/resolve_test.go
+++ b/cellmodules/celltransport/resolve_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,6 +44,24 @@ func assertKindInternal(t *testing.T, err error) {
 	}
 	if ec.Kind != errcode.KindInternal {
 		t.Errorf("Kind = %v, want KindInternal", ec.Kind)
+	}
+}
+
+// assertMessageContains asserts the errcode message names the expected failure
+// class. The diagnostic naming is the #2278 PR-3 contribution: the eager
+// celltransport.Resolve seam IS the sync-dimension missing-dependency runtime
+// fail-fast (ADR 202606131142-1423 §#1967), so its two failure paths must name
+// their class ("topology under-declared" / "local dependency missing") rather
+// than a generic "not classified" string. Asserts on ec.Message (not err.Error,
+// which renders the internal cellID attr when present).
+func assertMessageContains(t *testing.T, err error, want string) {
+	t.Helper()
+	var ec *errcode.Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected *errcode.Error, got %T: %v", err, err)
+	}
+	if !strings.Contains(ec.Message, want) {
+		t.Errorf("error message %q does not name failure class %q", ec.Message, want)
 	}
 }
 
@@ -144,6 +163,9 @@ func TestResolve_UnclassifiedCellReturnsKindInternal(t *testing.T) {
 		t.Fatal("expected error for unclassified cell, got nil")
 	}
 	assertKindInternal(t, resolveErr)
+	// Failure class: the consumed provider is absent from the topology partition
+	// (neither co-located nor remote) — "topology under-declared".
+	assertMessageContains(t, resolveErr, "topology under-declared")
 }
 
 // TestResolve_ColocatedNilInProcReturnsError verifies that a nil inProc
@@ -163,6 +185,10 @@ func TestResolve_ColocatedNilInProcReturnsError(t *testing.T) {
 		t.Fatal("expected error for nil inProc, got nil")
 	}
 	assertKindInternal(t, resolveErr)
+	// Failure class: the provider is declared co-located but its in-process
+	// transport was not minted — the local provider is not mounted here ("local
+	// dependency missing").
+	assertMessageContains(t, resolveErr, "local dependency missing")
 }
 
 // TestResolve_ZeroTopoIsColocated verifies that a zero topology (all-colocated
@@ -183,6 +209,28 @@ func TestResolve_ZeroTopoIsColocated(t *testing.T) {
 	if got != inProc {
 		t.Errorf("Resolve returned %v, want inProc for zero topo", got)
 	}
+}
+
+// TestResolve_ZeroTopoNilInProcIsLocalDependencyMissing covers the "local
+// dependency missing" failure class via the zero-topology (all-colocated)
+// IsColocated path: a zero topo treats any cellID as co-located, so a nil inProc
+// is the same local-provider-not-mounted failure as the explicit-colocated case
+// (TestResolve_ColocatedNilInProcReturnsError) but reached through the !explicit
+// branch — guards both entry conditions for the renamed diagnostic (#2278 PR-3).
+func TestResolve_ZeroTopoNilInProcIsLocalDependencyMissing(t *testing.T) {
+	t.Parallel()
+
+	topo, err := bootstrap.NewDeploymentTopology(bootstrap.DeploymentTopologySpec{})
+	if err != nil {
+		t.Fatalf("NewDeploymentTopology: %v", err)
+	}
+
+	_, _, resolveErr := celltransport.Resolve(topo, "configcore", nil, clock.Real(), transport.CrossCellObs{}, tlsutil.ClientIdentity{})
+	if resolveErr == nil {
+		t.Fatal("expected error for nil inProc under zero topo, got nil")
+	}
+	assertKindInternal(t, resolveErr)
+	assertMessageContains(t, resolveErr, "local dependency missing")
 }
 
 // --- #2251 P1.3: tracer propagation through the sealed bundle ---

--- a/cellmodules/eventtransport/doc.go
+++ b/cellmodules/eventtransport/doc.go
@@ -109,7 +109,14 @@
 // typed field-selection AST scan with go/types identity for rabbitmq.Config.URL
 // and brokerSpec.url). Blind spot: local-variable laundering and map-value reads
 // (cells[id]) are not field selections and fall outside the scan; these paths are
-// covered by TestDedupBrokerURL_CredentialNonLeak (behavior test).
+// covered by TestDedupBrokerURL_CredentialNonLeak (behavior test). Second blind
+// spot: resolveRabbitMQ wraps the rabbitmq.NewConnection error with
+// fmt.Errorf("...: %w", err); that err is not a .URL/.url selection, so the scan
+// does not inspect it. Non-leak there rests on an adapter precondition — the dial
+// path pre-sanitizes via sanitizeDialError before the error escapes NewConnection
+// (a Soft caller-side contract in adapters/rabbitmq, not a Medium guard here);
+// tightening it would require NewConnection to return an already-redacted sealed
+// error type.
 //
 // # Per-cell AMQP credential/vhost isolation (#2152 PR-3)
 //
@@ -130,6 +137,12 @@
 // requires:
 //   - ingress fan-out (#2366, subscriber single → N + phase6 N-router);
 //   - per-cell relay fan-out (#2341, per-cell PGProvider → N pools → N relays).
+//
+// Ops note: until #2366/#2341 land, an operator MUST configure an identical
+// GOCELL_<CELLID>_AMQP_URL for every broker cell in an assembly (or rely on the
+// shared GOCELL_AMQP_URL fallback). A distinct value fails closed at Resolve with
+// distinct_url_count in the internal attrs — that is the expected egress-only
+// boundary, not a misconfiguration to "fix" by other means.
 //
 // Credentials are never written to error strings or logs; the sanitize funnel in
 // adapters/rabbitmq (sanitizeURL / sanitizeErrorURL / sanitizeDialError) is the

--- a/cellmodules/eventtransport/doc.go
+++ b/cellmodules/eventtransport/doc.go
@@ -121,10 +121,19 @@
 // # Per-cell AMQP credential/vhost isolation (#2152 PR-3)
 //
 // Each cell's AMQP URL (GOCELL_<CELLID>_AMQP_URL, falling back to
-// GOCELL_AMQP_URL) carries per-cell credentials and a vhost. In a split
-// topology the operator provisions a distinct user and vhost per cell so each
-// process holds only the credentials it needs — a cell cannot publish to or
-// consume from a broker it has no access to.
+// GOCELL_AMQP_URL) is the SEAM for per-cell credential/vhost isolation: the URL
+// carries per-cell credentials and a vhost. The TARGET model (split topology) is
+// for the operator to provision a distinct user + vhost per cell so each process
+// holds only the credentials it needs and cannot publish to or consume from a
+// broker it has no access to.
+//
+// This is NOT a runtime reality today. Distinct per-cell URLs are fail-closed
+// (see "current boundary" below and dedupBrokerURL), so the only runnable
+// configuration is a shared/identical URL across cells — under which all cells
+// share one AMQP credential. True per-cell runtime isolation is blocked-by
+// #2366/#2341; until they land, the enforced controls are the distinct-URL
+// fail-closed gate plus URL credential non-leak (below), NOT live per-cell
+// credential separation.
 //
 // This credential/vhost isolation is operator-provisioned via the AMQP DSN
 // itself. Framework does NOT derive per-cell keys (no HKDF / key derivation

--- a/cellmodules/eventtransport/doc.go
+++ b/cellmodules/eventtransport/doc.go
@@ -98,4 +98,44 @@
 // ref: kernel/outbox.ResolveEmitter — the symmetric durability-gated funnel.
 // ref: cellmodules/percellpg.Resolve — the per-cell DSN dedup twin.
 // ref: github.com/ThreeDotsLabs/watermill message/router.go — disabledPublisher pattern.
+//
+// # INVARIANT: AMQP-URL-REDACTION-FUNNEL-01
+//
+// AMQP connection URLs carry embedded credentials in the DSN form
+// amqp://user:pass@host/vhost. The adapter layer (adapters/rabbitmq) provides a
+// sanitize funnel — sanitizeURL / sanitizeErrorURL / sanitizeDialError — that
+// redacts user:pass before any URL string reaches a slog / fmt / errcode sink.
+// This invariant is enforced by archtest AMQP-URL-REDACTION-FUNNEL-01 (Medium:
+// typed field-selection AST scan with go/types identity for rabbitmq.Config.URL
+// and brokerSpec.url). Blind spot: local-variable laundering and map-value reads
+// (cells[id]) are not field selections and fall outside the scan; these paths are
+// covered by TestDedupBrokerURL_CredentialNonLeak (behavior test).
+//
+// # Per-cell AMQP credential/vhost isolation (#2152 PR-3)
+//
+// Each cell's AMQP URL (GOCELL_<CELLID>_AMQP_URL, falling back to
+// GOCELL_AMQP_URL) carries per-cell credentials and a vhost. In a split
+// topology the operator provisions a distinct user and vhost per cell so each
+// process holds only the credentials it needs — a cell cannot publish to or
+// consume from a broker it has no access to.
+//
+// This credential/vhost isolation is operator-provisioned via the AMQP DSN
+// itself. Framework does NOT derive per-cell keys (no HKDF / key derivation
+// layer): AMQP broker users are external to the framework and are managed by the
+// broker operator, unlike the #2153 HMAC keyring which has a framework-level
+// master key to derive from.
+//
+// The current boundary is egress-only: distinct per-cell broker URLs are
+// fail-closed (see dedupBrokerURL). Running per-cell isolation end-to-end
+// requires:
+//   - ingress fan-out (#2366, subscriber single → N + phase6 N-router);
+//   - per-cell relay fan-out (#2341, per-cell PGProvider → N pools → N relays).
+//
+// Credentials are never written to error strings or logs; the sanitize funnel in
+// adapters/rabbitmq (sanitizeURL / sanitizeErrorURL / sanitizeDialError) is the
+// canonical redaction path. Archtest AMQP-URL-REDACTION-FUNNEL-01 (above) guards
+// non-leak.
+//
+// ref: adapters/rabbitmq/connection.go — sanitizeURL / sanitizeErrorURL.
+// ref: ADR docs/architecture/202606131500-1940-adr-topology-gated-event-transport.md.
 package eventtransport

--- a/cellmodules/eventtransport/transport.go
+++ b/cellmodules/eventtransport/transport.go
@@ -162,7 +162,10 @@ func dedupBrokerURL(cells map[string]string) (string, error) {
 			"eventtransport: per-cell distinct broker URLs require split-topology ingress "+
 				"fan-out (phase6 N-router, #2366) plus per-cell relay fan-out (#2341), not yet "+
 				"wired (egress-only, #2152 PR-2); colocated assemblies must configure an "+
-				"identical GOCELL_<CELLID>_AMQP_URL for every broker cell",
+				"identical GOCELL_<CELLID>_AMQP_URL for every broker cell. "+
+				"Per-cell credential/vhost isolation (distinct vhost/user per cell) is "+
+				"the intended security model; this egress-only gate lifts together with "+
+				"#2366/#2341",
 			errcode.WithInternal(errcode.InternalAttr("distinct_url_count", len(seen))),
 			errcode.WithInternal(errcode.InternalAttr("cell_ids", strings.Join(cellIDs, ","))),
 		)

--- a/cellmodules/eventtransport/transport_test.go
+++ b/cellmodules/eventtransport/transport_test.go
@@ -341,6 +341,51 @@ func TestDLXExchange_StableName(t *testing.T) {
 	assert.NotEmpty(t, dlxExchange, "DLXExchange must be non-empty or rabbitmq Setup fail-fasts")
 }
 
+// TestResolve_Postgres_DistinctURLs_FailClosed_CredIsolationMessage asserts that
+// the distinct-URL fail-closed error message mentions credential/vhost isolation
+// semantics, documenting that per-cell AMQP URL = per-cell credential+vhost seam
+// (operator-provisioned, not framework-derived). This test drives change #5.
+func TestResolve_Postgres_DistinctURLs_FailClosed_CredIsolationMessage(t *testing.T) {
+	t.Parallel()
+
+	_, err := Resolve(clock.Real(), mkTopo(t, "postgres"), Config{
+		Cells: map[string]string{
+			"accesscore": "amqp://a:5672/",
+			"configcore": "amqp://b:5672/",
+		},
+	})
+	require.Error(t, err)
+	// The message must state that per-cell credential/vhost isolation is the
+	// blocking concern — not just the ingress fan-out wiring. This is the PR-3
+	// documentation gate for the security model closure (#2152 PR-3).
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Contains(t, ec.Message, "credential/vhost isolation",
+		"distinct-URL fail-closed message must document that per-cell URL = "+
+			"per-cell credential/vhost seam; isolation is gated by #2366/#2341")
+}
+
+// TestDedupBrokerURL_CredentialNonLeak asserts that dedupBrokerURL never leaks
+// embedded URL credentials into the error string. This closes the archtest
+// AMQP-URL-REDACTION-FUNNEL-01 blind spot for the cells[id] local-var path
+// (map-value reads are not field selections and therefore outside the AST scan).
+func TestDedupBrokerURL_CredentialNonLeak(t *testing.T) {
+	t.Parallel()
+
+	const secret = "SECRETPW"
+	// Inject a password into the per-cell URLs. Distinct hosts trigger the
+	// fail-closed distinct-URL path — the most likely place credentials could
+	// appear in an error string.
+	cells := map[string]string{
+		"accesscore": "amqp://u:" + secret + "@a:5672/vh",
+		"configcore": "amqp://u:" + secret + "@b:5672/vh",
+	}
+	_, err := dedupBrokerURL(cells)
+	require.Error(t, err, "distinct per-cell URLs must fail-closed")
+	assert.NotContains(t, err.Error(), secret,
+		"dedupBrokerURL must not leak embedded AMQP credentials into the error string")
+}
+
 func TestDispatchTransport_UnhandledBrokerKind_FailClosed(t *testing.T) {
 	t.Parallel()
 	// White-box: resolveBrokerSpec can only emit the two valid kinds, so the

--- a/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
+++ b/docs/architecture/202606131142-1423-adr-cell-deployment-topology.md
@@ -256,6 +256,7 @@ amendment 落地时必须同步重评安全模型」，此处显式列出威胁�
 | **业务 principal 跨进程传播伪造** | caller 伪造他人 actor/subject/session → 越权 | **现有栈不足，是真缺口**：service token MAC（`runtime/auth/servicetoken.go`）只覆盖 method/path/query/timestamp/nonce/`callerCell`/`X-Tenant-ID`，且 `authenticator.go` 只构造 `PrincipalService{CallerCellID}`——**只认证调用方 cell 身份，不传播也不还原原始业务 principal（actor/subject/session）**。故 split 下传播业务 principal **MUST 用 tamper-evident 的 signed/sealed envelope**（或把 actor/subject/session/tenant 全纳入 MAC material）+ 专用 callee middleware 重建——不能靠「现有 auth middleware 已足够」。| US5 #1966 → **已闭合**（折进 MAC + sealed funnel，见 §#1966 Amendment；残留 keyring 隔离归 #2153）|
 | **共享 HMAC keyring（无 per-cell 身份颁发）** | 单 cell 进程泄露 keyring → 可签发任意 `callerCell` | **#1964 评估并登记此缺口**：`runtime/auth/servicetoken.go` 的 4 段 MAC（`ts:nonce:callerCell:mac`）确实覆盖了 `callerCell` 字段，但所有 cell 使用**同一** `ring.Current()` 密钥签名——这只能证明「某个 keyring 持有者」发出了请求，无法证明「哪个 cell」发出。任何持有 keyring 的 cell 进程均可伪造任意 `callerCell`。推荐方向：**通过以 cellID 为 HKDF 派生上下文的 per-cell 子密钥**（`HKDF(masterKey, cellID)` → per-cell signing key），使单 cell 泄露无法伪造其它 cell 的 `callerCell`。当前补偿控制 = 服务端 `RequireCallerCell` allowlist（防止跳入预期以外的 internal endpoint）+ 可信网络/同进程假设——对 monolith/同址部署足够，**跨信任边界拆分不足**。**per-cell keyring 子密钥派生在本 PR（#1964）中不实现**，追踪在 **#2153**。 | US6 #1964（登记）→ **#2153 已实现**：per-cell provisioning（cell 持子密钥、**master 缺席**）+ HKDF 子密钥，**split 下 CLOSED**；monolith 不变（单信任域，非 per-cell-Hard，可接受）。见 §#2153 Amendment（含对上文「per-cell HKDF」措辞的修正）|
 | **无 mTLS 对等认证** | 中间人 / 端点伪造 | ~~service token MAC 提供消息完整性，但无传输层对等认证——此缺口已登记，**#1964/#2153 均不实现 mTLS**~~ → **#2263 RESOLVED**：非 loopback split 强制 mTLS（TLS 1.3 + SPIFFE-ID cross-bind），fail-closed 双闸移除「private network 补偿」soft 约束，见 §#2263 Amendment | **#2263 CLOSED**（2026-06-17） |
+| **共享 AMQP broker 凭据** | 单 cell 进程持有共享 AMQP 凭据 → 可跨 cell 发布 / 消费事件（突破隔离） | **PR-2 per-cell `GOCELL_<CELLID>_AMQP_URL` seam**：AMQP DSN 格式 `amqp://user:pass@host/vhost` 携带 broker 凭据+vhost；operator 可为每个 cell provision 独立 vhost/user（**operator-provisioned**，非 framework 派生——外部 broker 用户，无 master key，不适用 HKDF，对比 #2153）。**凭据 non-leak**：adapter sanitize funnel（`sanitizeURL` / `sanitizeErrorURL` / `sanitizeDialError`）防止凭据写入 log/error；archtest `AMQP-URL-REDACTION-FUNNEL-01`（Medium，typed AST scan）守。**当前限制**：distinct per-cell URL 今 egress-only fail-closed（运行期每 cell 独立连接须 #2366/#2341）。| **#2152 PR-3 文档化 + Medium 守卫**（2026-06-18）；运行期隔离待 #2366/#2341 |
 | **token replay（多实例）** | 重放已签 token | `RequiresDistributedReplay()` 多实例强制分布式 NonceStore（**已有，US5 复用**）| 已覆盖 |
 | **`upstream-cell-unavailable` 错误语义** | 远端不可达与本地依赖缺失混淆 → 误诊 | 新增的是 **`errcode.Code`（`ERR_UPSTREAM_CELL_UNAVAILABLE`），用既有 `KindUnavailable` 构造**（`pkg/errcode/status.go` 已有该 Kind，**非新增 Kind**），Code 经 `ERRCODE-PREFIX-OWNERSHIP-01` 注册 + golden。**wire 可见性警示**：`KindUnavailable.PublicCode()` 现折叠为 `ERR_SERVICE_UNAVAILABLE` 且 5xx details 强制 strip——故该专属码默认只作**服务端**诊断（log/trace/internal）；若要客户端 wire 可区分，须 US5 **有意重评 5xx public-code 投影策略** + redaction（非默认）。| US5 #1966 → **已落地**（见 §#1966 Amendment）|
 
@@ -495,17 +496,33 @@ kubernetes `cmd/kube-controller-manager` ControllerDescriptor；spring-projects/
   入口的直挂——upstream backstop）。`MOUNTED-EQUALS-COLOCATED` **AI-robust 评级 Medium**（运行期 bijection 守卫；
   cellID 运行期字符串，Hard 不可达——同 M12a / broker-mandatory闸 诚实天花板）+ red/green fixture + anti-vacuity。
 
-**缺失依赖启动期闸（SC-002 sync 维补全）**：消费 contract 的 provider cell ∉ colocated ∪ remote map → fail-fast
-（区分「本地依赖缺失」vs「拓扑漏声明」）+ `gocell validate` 静态 arm。**注**：该静态检查原属 US2 T011（计划但未落地）
-+ US3 T030（event 维，已由 #1965 broker 闸覆盖）；本 amendment 把 sync 维补全并加运行期闸。对标 Spring Modulith
-`ApplicationModules.verify()` 的 allowed-dependencies。sync 维（本闸）+ event 维（#1965）合起来 = 无静默死路由。
+**缺失依赖 fail-fast（SC-002 sync 维）—— 已由既有双层兑现，PR-3 不建平行闸（2026-06-18 PR-3 收口）**：
+消费 contract 的 provider cell ∉ colocated ∪ remote → fail-fast，sync 维由**两层**覆盖：
+① **静态** `gocell validate` arm = `validateTOPO11`（**PR-1 #2337 已落地**，遍历 contractUsages 消费方，provider
+∉ `assembly.cells` → 报错；配 TOPO-10 穷尽分区 ⟹ provider ∉ colocated∪remote）——该检查原属 US2 T011（本 amendment
+原记「计划但未落地」，实由 PR-1 over-deliver 兑现）；② **运行期** fail-fast = `celltransport.Resolve` 的 **eager**
+（module-wiring / 启动期）fail-closed（US5 #1966）：sync client wiring 拨真实 server cell，provider 既非 colocated 也非
+remote → `KindInternal` fail-fast、错误冒泡 → 进程起不来（FR-004「bootstrap MUST fail-fast」满足），该 seam 由
+`CELLTRANSPORT-SELECT-FUNNEL-01` 锁为 sync 跨 cell 调用唯一出口。event 维由 US3 #1965 broker 闸覆盖。
+对标 Spring Modulith `ApplicationModules.verify()` 的 allowed-dependencies；sync 维（双层）+ event 维（#1965）= 无静默死路由。
+
+**PR-3 不新增 phase0 平行闸（三层自审结论）**：本 amendment 原写「补全 sync 维并**加运行期闸**」，前提是「静态 arm 空缺
++ 无运行期兜底」。PR-1 over-deliver TOPO-11 + US5 已有 eager fail-closed seam 使该前提消失。新增一个 bootstrap phase0 闸
+经实测判为**冗余平行结构**：它须以运行期 `ConsumedContracts().OwnerCell()` 重派生可达性，弱于 TOPO-11 的权威
+`ProviderEndpoint()`、引入 owner≠server 盲区（两条 truth）；`MOUNTED-EQUALS-COLOCATED` 先保证 colocated==mounted 后其
+「本地依赖缺失」分支为死代码；funnel 已禁绕过 seam 的裸 http 兄弟调用 → 闸在 sanctioned 路径零触发。按「抽象前提消失第一
+选择是删除」，PR-3 收敛为本收口注（载体重评）+ `celltransport.Resolve` 两类失败诊断命名（`topology under-declared` /
+`local dependency missing`，单源于该 seam）。**本收口是部署配置正确性（deployment config correctness）控制的载体重评，
+不改变任何安全边界、不触及上文 §威胁矩阵的安全模型**（MAC 完整性 / per-cell 身份 #2153 / mTLS #2263 不变）。
 
 **威胁矩阵重评（AI-robust 章程：amendment 必须同步重评）**：本 amendment 使 split **真实端到端可发生**（此前
 seam 齐全但无接线）。关键前置已落地——「共享 HMAC keyring」缺口经 **#2153（per-cell HKDF 子密钥 + master 缺席）
-在 split 下 CLOSED**（见 §#2153 Amendment）；「无 mTLS」defer **#2263**（与 token 层身份正交）；remote 操作约束
-（私网部署 + 共享 `GOCELL_SERVICE_SECRET` + `RequireCallerCell` allowlist）见 §#1966 review Amendment，groups 多
-进程部署沿用之。本 amendment **不新增**安全缺口——它把既已可达的 remote 路径从「单进程内不触发」变为「双拓扑验收
-触发」，威胁画像不变（MAC 完整性 Hard + per-cell 身份 #2153 + 私网/mTLS-#2263）。
+在 split 下 CLOSED**（见 §#2153 Amendment）；「无 mTLS」缺口经 **#2263 CLOSED**（非 loopback split 强制 mTLS：
+TLS 1.3 + SPIFFE-ID cross-bind，2026-06-17，见 §#2263 Amendment——该 amendment 已取代本段早先「defer #2263 / 私网
+补偿」措辞）；remote 操作约束（共享 `GOCELL_SERVICE_SECRET` + `RequireCallerCell` allowlist + 私网部署作纵深防御，
+非技术闸替代）见 §#1966 review Amendment + §#2263 Amendment，groups 多进程部署沿用之。本 amendment **不新增**安全缺口
+——它把既已可达的 remote 路径从「单进程内不触发」变为「双拓扑验收触发」，威胁画像不变（MAC 完整性 Hard + per-cell
+身份 #2153 CLOSED + mTLS #2263 CLOSED）。
 
 **PR 分解（mini-epic 收口，逐个独立 review，TDD RED→GREEN 在各 feature PR 内；能力 = US9 #2278，验收 = US7 #1967）**：
 - **PR-0（本 PR）**：本 amendment + `specs/069 tasks.md` US7 细化 + sibling issues。**docs-only、全绿**（不携 RED stub——
@@ -516,12 +533,16 @@ seam 齐全但无接线）。关键前置已落地——「共享 HMAC keyring�
   `generatedTopologyGroups()` + 字节 golden（Hard golden + Medium validate）。运行期最小桥 `bootstrap.SpecForRole(groups, "")`
   = 全 colocated monolith（role 选择留 PR-2）。
 - **PR-2**：role 选择器 + `NewForRole` 子集挂载 + `MOUNTED-EQUALS-COLOCATED` 守卫（Medium）。
-- **PR-3**：缺失依赖启动期闸 + `gocell validate` 静态 arm + archtest red/green（Medium）。
+- **PR-3（✅ 收口 #2278）**：缺失依赖 sync 维**已由 PR-1 TOPO-11（静态）+ US5 #1966 `celltransport.Resolve` eager
+  fail-closed seam（运行期，`CELLTRANSPORT-SELECT-FUNNEL-01` 锁）双层兑现**；三层自审判新增 phase0 闸为冗余平行结构 →
+  **不建闸**。PR-3 = ADR/tasks 重评收口 + `celltransport.Resolve` 两类失败诊断命名（in-place，无新机制）。
 - **PR-4（= #1967 验收）**：`corebundle` assembly.yaml `topology.groups`（accesstier/configtier）+ `tests/e2e/` split
   compose（同 image 2 进程 + broker + PG）+ 双拓扑参数化 journey 一致性断言 + CI 接入（对标 weavertest Local/Multi）。
 
 AI-robust 新机制评级：groups codegen golden = **Hard**；groups 校验 / role fail-fast / `MOUNTED-EQUALS-COLOCATED`
-/ 缺失依赖闸 = **Medium**（拓扑/role/cellID 均运行期数据，Hard 不可达，诚实天花板，无 Soft）。
+= **Medium**（拓扑/role/cellID 均运行期数据，Hard 不可达，诚实天花板，无 Soft）。**缺失依赖 sync 维不新增机制**——
+覆盖 = `validateTOPO11`（Medium governance rule）+ sealed `DeploymentTopology`（Hard）+ `CELLTRANSPORT-SELECT-FUNNEL-01`
+（Medium caller funnel，下游 `Resolve` fail-closed Hard）。
 
 **范围切割（显式 backlog，不静默）**：外部 cell（ssobff 等）双拓扑覆盖（epic 验收第二条）→ 新 backlog issue；
 per-cell relay 扇出 → 已 #2152；mTLS → 已 #2263（见下 §#2263 Amendment，已 CLOSED，非 defer）。
@@ -565,6 +586,37 @@ mTLS 对等认证行此刻 CLOSED，私网不再是 peer-auth 的替代补偿（
   形态类型级不可表达。
 - `INSECURE-SKIP-VERIFY-LITERAL-01`（Medium）：`InsecureSkipVerify:true` 字面量限 tlsutil 包内。
 - 完整评级分层见 ADR `202606171200-2263` §AI-robust 档位表。
+
+### #2152 PR-3 Amendment — per-cell AMQP 凭据/vhost 隔离安全模型（2026-06-18）
+
+本 amendment 补全上表「共享 AMQP broker 凭据」缺口行，对该行做 AI-robust 评级显式分层，并与
+§#2153 HMAC keyring 凭据隔离族对齐。
+
+#### 凭据隔离 seam 性质
+
+AMQP DSN 格式 `amqp://user:pass@host/vhost` 携带 broker 凭据+vhost。per-cell
+`GOCELL_<CELLID>_AMQP_URL` 是凭据/vhost 隔离的 seam，operator 可为每个 cell 配置独立
+vhost/user。**非 framework 派生**：broker 用户在 RabbitMQ 管理面单独 provision，不存在
+framework 可控的 master key，故不做 HKDF 派生（对比 #2153 HMAC keyring 有 master key 可派生）。
+
+#### AI-robust 评级显式分层
+
+① **per-cell 运行期隔离（每 cell 独立连接不同 broker）**：Hard 今天**不可得**（blocked-by
+#2366 ingress N-router + #2341 per-cell relay fan-out）；声称 Hard 即 overclaim。
+
+② **凭据 non-leak**（URL 不写入 log/error）：Soft（`connection.go` 注释约定）→ **Medium**
+（archtest `AMQP-URL-REDACTION-FUNNEL-01`，typed AST field-selection scan，go/types 身份解析）。
+
+③ **Hard-via-sealed-URL-type**：封装 redacted-Stringer URL 类型需改 adapter 全部调用方，成本高、
+无低成本路径，不立 issue（按章程「无低成本 Hard 路径不立 issue」）。
+
+#### 威胁矩阵重评（对照上表「共享 AMQP broker 凭据」行）
+
+当前补偿：PR-2 per-cell URL seam + sanitize funnel（Medium）；残留：运行期隔离 blocked-by
+#2366/#2341。该行是 broker 侧对 §#1964/§#2153 凭据隔离族的补全。
+
+**权威语义**：`cellmodules/eventtransport/doc.go`（§INVARIANT AMQP-URL-REDACTION-FUNNEL-01 +
+§Per-cell credential/vhost isolation）+ ADR `202606131500-1940` §Amendment 2026-06-18。
 
 ## Rejected alternatives
 

--- a/docs/architecture/202606131500-1940-adr-topology-gated-event-transport.md
+++ b/docs/architecture/202606131500-1940-adr-topology-gated-event-transport.md
@@ -184,8 +184,9 @@ local-var laundering + map-value 读，由 `TestDedupBrokerURL_CredentialNonLeak
 ### 威胁矩阵补全
 
 本 amendment 补全 ADR 1423 §"安全模型与已知缺口"中「共享 AMQP broker 凭据」行（详见 ADR 1423
-的对应 amendment）。PR-2 的 fail-closed 是隔离的充分前提——distinct URL 被拒绝即意味着今天
-colocated 模式下所有 cell 共享同一 AMQP 凭据（预期行为），而 split 运行期隔离须等 #2366/#2341。
+的对应 amendment）。PR-2 的 distinct-URL fail-closed 是当前的安全边界守门：它**拒绝** distinct
+per-cell URL，故今天 colocated 模式下所有 cell 共享同一 AMQP 凭据（预期行为）；真正的 split
+运行期隔离（每 cell 独立凭据/连接）须等 distinct-URL 被允许，即 #2366/#2341 lift egress-only 之后。
 
 **权威语义**：`cellmodules/eventtransport/doc.go`（§INVARIANT AMQP-URL-REDACTION-FUNNEL-01
 + §Per-cell credential/vhost isolation）。

--- a/docs/architecture/202606131500-1940-adr-topology-gated-event-transport.md
+++ b/docs/architecture/202606131500-1940-adr-topology-gated-event-transport.md
@@ -151,6 +151,45 @@ sealed `IsRealBroker()`（«non-nil ≠ real broker» 收口，见 ADR 1423 的 
   `GOCELL_<CELLID>_AMQP_URL`）。
 - **权威语义**：`cellmodules/eventtransport/doc.go`（§"Per-cell broker URL dedup (egress-only, #2152 PR-2)"）。
 
+## Amendment 2026-06-18（#2152 PR-3）：per-cell AMQP vhost/credential 隔离安全模型
+
+### 凭据隔离 seam
+
+per-cell AMQP URL（`GOCELL_<CELLID>_AMQP_URL`）本质上是凭据+vhost 隔离的入口点。AMQP DSN 格式
+`amqp://user:pass@host/vhost` 携带 broker 用户名、密码与 vhost，operator 可为每个 cell 配置独立
+的 user 和 vhost，使每个进程只持有访问自身 broker 资源所需凭据。
+
+**为何不做 HKDF/派生层**：AMQP broker 用户是外部对象，由 broker operator 在 RabbitMQ 管理面
+单独 provision，不存在 framework 可控的 master key（对比 #2153 HMAC keyring：token 签名 key 由
+framework 持有并可派生）。per-cell 凭据是 operator 通过 `GOCELL_<CELLID>_AMQP_URL` 外部注入，
+framework 不建新包、不做派生。
+
+### 当前边界与运行期隔离
+
+- distinct per-cell URL = egress-only fail-closed（同 PR-2，`dedupBrokerURL`）。
+- 运行期 per-cell 隔离（每个 cell 连接独立 broker）blocked-by #2366（ingress 订阅者 N-router）
+  + #2341（per-cell relay/pool fan-out），与 PR-2 fail-closed 一起 lift。
+
+### AI-robust 评级显式分层
+
+① **per-cell 运行期隔离**：Hard 今天不可得（运行期 blocked-by #2366/#2341，声称 Hard 即 overclaim）。
+
+② **凭据 non-leak**：Soft（`connection.go` sanitize 函数注释约定）→ **Medium**（archtest
+`AMQP-URL-REDACTION-FUNNEL-01`，typed AST field-selection scan，go/types 解析；blind spot =
+local-var laundering + map-value 读，由 `TestDedupBrokerURL_CredentialNonLeak` 行为测试补）。
+
+③ **Hard-via-sealed-URL-type**：封装 redacted-Stringer URL 类型并改 adapter 全调用方，成本高、
+无低成本路径，不立 issue（章程「无低成本 Hard 路径不立 issue」）。
+
+### 威胁矩阵补全
+
+本 amendment 补全 ADR 1423 §"安全模型与已知缺口"中「共享 AMQP broker 凭据」行（详见 ADR 1423
+的对应 amendment）。PR-2 的 fail-closed 是隔离的充分前提——distinct URL 被拒绝即意味着今天
+colocated 模式下所有 cell 共享同一 AMQP 凭据（预期行为），而 split 运行期隔离须等 #2366/#2341。
+
+**权威语义**：`cellmodules/eventtransport/doc.go`（§INVARIANT AMQP-URL-REDACTION-FUNNEL-01
++ §Per-cell credential/vhost isolation）。
+
 ## 参考
 
 - 对称 funnel：`kernel/outbox/mode_resolver.go`（`ResolveEmitter`）、`cellmodules/replaydeps`（#825/#2017）

--- a/docs/guides/deployment-topology.md
+++ b/docs/guides/deployment-topology.md
@@ -97,6 +97,40 @@ broker gate for split topologies: it fires when a split topology uses an
 in-memory EventBus for a cross-process (different-group) event contract.
 Correctness is proven by synthetic RED/GREEN unit tests.
 
+### Missing-dependency fail-fast (sync dimension)
+
+A consumed `http` (sync) contract whose provider cell is not reachable in the
+deployment topology is rejected at **two** layers, so a missing sync dependency
+never surfaces only at request time:
+
+- **Static** (`gocell validate` **TOPO-11**, above): the provider must be a member
+  of the assembly — with TOPO-10's exhaustive partition that means it is placed in
+  some group (co-located here, or remote elsewhere).
+- **Runtime** (`celltransport.Resolve`, eager at module-wiring / startup): the
+  composition root resolves each consumed sync client's transport against the
+  sealed topology. A provider that is neither co-located nor remote fails closed
+  with `KindInternal`; the error bubbles up and the process does not start
+  (FR-004). `CELLTRANSPORT-SELECT-FUNNEL-01` makes this seam the sole construction
+  site for cross-cell sync transports, so no sync call can bypass it. The diagnostic
+  names two failure classes: `topology under-declared` (the provider has no place in
+  the topology) and `local dependency missing` (the provider is co-located but not
+  mounted in this process).
+
+The offending `cellID` is on the `KindInternal` error in the **server log**
+(`InternalAttr`, never on the wire). Operator action by class:
+
+- `topology under-declared` → the provider is not in any group: add it to the right
+  `topology.groups` group (co-located here, or another group whose endpoint this
+  process reaches as remote).
+- `local dependency missing` → the provider is declared co-located for this role but
+  its module was not wired: confirm the composition root mounts that cell (e.g. it is
+  in the role's group and `composition.NewForRole` selected it).
+
+The event dimension is covered separately by the broker gate (TOPO-13 + bootstrap
+phase0, US3 #1965). There is **no** separate phase0 missing-dependency gate — the
+eager `celltransport.Resolve` seam already provides the runtime fail-fast (see ADR
+`202606131142-1423` §#1967 Amendment).
+
 ## Example YAML
 
 ```yaml

--- a/specs/069-cell-deploy-topology/tasks.md
+++ b/specs/069-cell-deploy-topology/tasks.md
@@ -24,10 +24,12 @@
 
 ### US2 — 拓扑声明作为一等 wiring（P1）→ #1962（blocked-by #1960）
 
-- [ ] T010 [US2] assembly schema 扩展（`kernel/assembly/assembly.go` 模型 + `tools/codegen/` 派生）：`topology.colocated` 组 + `topology.remote[{cellID,endpoint}]`；colocated/remote 互斥校验；空拓扑 = 现状全 co-located
-- [ ] T011 [US2] `gocell validate` 拓扑校验：cell 归属判定（本地/远程/缺失）静态导出；contractUsages 消费方的提供方 ∉ 本地∪远程 → 报错
-- [ ] T012 [US2] `runtime/bootstrap/topology.go` 扩展：启动期 WriteOnce 拓扑判定 API（`IsColocated(cellID)` / `RemoteEndpoint(cellID)`），phase0 注入（`WithControlPlaneTopology` 先例）
-- [ ] T013 [US2] codegen golden + synthetic red case（非法拓扑 fixture）
+> **重评收口（2026-06-18 PR-3）**：T010-T013 原以单进程 `colocated/remote` authoring 描述，该形态已由 US9 PR-1
+> （T090 #2337）**取代为 `topology.groups`**；下列「✅」指其**能力**已随 groups 模型落地（authoring 形态以 T090-T092 为准）。
+- [x] T010 [US2] （✅ 能力随 PR-1 #2337，authoring 改 `topology.groups`）assembly schema 扩展（`kernel/metadata/assembly_topology.go` 模型 + codegen 派生）：穷尽+互斥分区校验（`ValidateTopologyStructure`）；空拓扑 = 现状全 co-located
+- [x] T011 [US2] （✅ = `validateTOPO11`，PR-1 #2337）`gocell validate` 拓扑校验：cell 归属判定（`CellGroup`/`SameGroup` 静态导出）；contractUsages 消费方的提供方 ∉ 本地∪远程 → 报错（即 T093 引用的 sync 维静态检查）
+- [x] T012 [US2] （✅ = `runtime/bootstrap/deployment_topology.go`，PR-1/PR-2）启动期 WriteOnce 拓扑判定 API（`IsColocated(cellID)` / `RemoteEndpoint(cellID)`），phase0 注入
+- [x] T013 [US2] （✅ PR-1 #2337）codegen golden（`generatedTopologyGroups()`）+ synthetic red case（非法 groups fixture）
 
 ### US4 — CellTransport seam + 进程内短路（P1）→ #1963（blocked-by #1960，可与 US2 并行）
 
@@ -71,20 +73,24 @@
 
 > 拆为 3 个独立 review 的 PR（PR-1/2/3）。
 
-- [ ] T090 [US9·PR-1] `topology.groups` schema（`kernel/metadata/assembly_topology.go` + `schemas/assembly.schema.json`）
+- [x] T090 [US9·PR-1] （✅ PR-1 #2337）`topology.groups` schema（`kernel/metadata/assembly_topology.go` + `schemas/assembly.schema.json`）
   **取代** 单进程 `colocated/remote` authoring：重写 `ValidateTopologyStructure`（穷尽+互斥分区 / role 唯一 /
   endpoint 合法）；删 `ClassifyCell` 单视图分支（生产零使用，pre-GA 原地删，无双 schema）。codegen
   `generatedDeploymentTopology()` → `generatedTopologyGroups()` + golden（Hard）。synthetic red case（非法 groups）。
-- [ ] T091 [US9·PR-2] 启动期 role 选择器 `GOCELL_CELL_ROLE`（WriteOnce）由 groups 派生 `DeploymentTopologySpec`
+- [x] T091 [US9·PR-2] （✅ PR-2 #2363）启动期 role 选择器 `GOCELL_CELL_ROLE`（WriteOnce）由 groups 派生 `DeploymentTopologySpec`
   （未设+多 group→fail-fast / 未设+单/无 group→全 colocated / role∉声明集→fail-fast）；`composition.NewForRole(topo,
   role, allModules...)` **exported 收口入口**（filter+New+With+封 spec；exported 跨包构造器 → caller-funnel 仅
   **Medium** archtest，**非** Hard 包内 sealed，同 `CELLTRANSPORT-SELECT-FUNNEL-01` 族）；`cmd/corebundle/{run,shared_deps}.go`
   改走之。**真正 fail-closed enforcement = T092 的 `MOUNTED-EQUALS-COLOCATED` phase guard**（不依赖调用方走 funnel）。
-- [ ] T092 [US9·PR-2] **新增** bootstrap-phase 守卫 `MOUNTED-EQUALS-COLOCATED`（mounted==colocated ∧ remote∉mounted，
+- [x] T092 [US9·PR-2] （✅ PR-2 #2363）**新增** bootstrap-phase 守卫 `MOUNTED-EQUALS-COLOCATED`（mounted==colocated ∧ remote∉mounted，
   违反 fail-fast，Medium）；M12a（New==With，#1093）代码不动、语义精化为「本进程 host 的 cell」（ADR D4 amendment）。
   双子集 boot 集成测试（accesscore+auditcore host、configcore remote 调通）+ 守卫 red/green fixture + anti-vacuity。
-- [ ] T093 [US9·PR-3] 缺失依赖启动期闸：消费 contract provider ∉ colocated ∪ remote → fail-fast（**补全 US2 T011 未落地
-  的 sync 维静态检查** + 加运行期闸；event 维已由 US3 #1965 覆盖）+ `gocell validate` arm + archtest red/green（Medium）。
+- [x] T093 [US9·PR-3] （✅ 收口 #2278）缺失依赖 sync 维 fail-fast **已由既有双层兑现，不建平行 phase0 闸**（三层自审）：
+  ① 静态 = `validateTOPO11`（PR-1 #2337，provider ∉ colocated∪remote → 报错，**补全 US2 T011 的 sync 维静态检查**）；
+  ② 运行期 = `celltransport.Resolve` eager fail-closed seam（US5 #1966，启动期拨真实 server cell，`CELLTRANSPORT-SELECT-FUNNEL-01`
+  锁为 sync 调用唯一出口，FR-004 满足）；event 维已由 US3 #1965 覆盖。新增 phase0 闸经实测判为冗余平行结构（弱派生 +
+  sanctioned 路径零触发，详见 ADR §#1967 Amendment「PR-3 不新增 phase0 平行闸」）→ **不建闸**。本 PR = ADR/tasks 重评收口 +
+  `celltransport.Resolve` 两类失败诊断命名（`topology under-declared` / `local dependency missing`，in-place，无新机制）。
 
 ### US7 — 双拓扑 journey 验收（P2）→ #1967（blocked-by US9）
 
@@ -127,4 +133,4 @@ US1(ADR) ─┬─ US2 ─┬─ US3 ←─ #1940 │             │
 - 每 story 一个 issue、一个（或一簇）PR，各自走 `/ship`（worktree + TDD + 内置 review）。
 - event broker funnel 不建新单：由 #1940 承载（US3 blocked-by）。
 - 运行时动态 placement / sidecar out of scope（归 #303）；mTLS 对等认证 → **#2263**（与 token 层 per-cell 身份正交，#2153 已落 token 层隔离）。
-- **US9（新）拆 3 个独立 review PR**（PR-1 schema/codegen、PR-2 role 选择器+子集挂载+`MOUNTED-EQUALS-COLOCATED`、PR-3 缺失依赖闸）；US7 #1967 = PR-4 验收，blocked-by US9。PR-0（ADR + 本 tasks + sibling issues）docs-only、先行。各 feature PR 内 TDD RED→GREEN（PR-0 不携 RED stub）。
+- **US9（新）拆 3 个独立 review PR**（PR-1 schema/codegen、PR-2 role 选择器+子集挂载+`MOUNTED-EQUALS-COLOCATED`、PR-3 缺失依赖 sync 维收口：双层已兑现（TOPO-11 静态 + celltransport Resolve 运行期），不建 phase0 平行闸 + Resolve 诊断命名）；US7 #1967 = PR-4 验收，blocked-by US9。PR-0（ADR + 本 tasks + sibling issues）docs-only、先行。各 feature PR 内 TDD RED→GREEN（PR-0 不携 RED stub）。

--- a/tools/archtest/amqp_url_redaction_test.go
+++ b/tools/archtest/amqp_url_redaction_test.go
@@ -236,7 +236,8 @@ func collectAMQPURLLeakDiagsFile(
 				Message: "AMQP-URL-REDACTION-FUNNEL-01: AMQP URL field selection " +
 					"flows into a slog/fmt/errcode sink without sanitizer protection — " +
 					"AMQP URLs carry user:pass credentials; wrap with sanitizeURL / " +
-					"sanitizeErrorURL / sanitizeDialError before passing to any sink",
+					"sanitizeErrorURL / sanitizeDialError (defined in " +
+					"adapters/rabbitmq/connection.go) before passing to any sink",
 			})
 		}
 	})
@@ -331,4 +332,38 @@ func TestAMQPURLRedaction_ScannerNonVacuous(t *testing.T) {
 			"anywhere in the scanned packages — "+
 			"the go/types resolution path may be silently broken; "+
 			"verify that rabbitmq.Config.URL and brokerSpec.url are correctly matched")
+}
+
+// TestAMQPURLRedaction_SanitizerBoundarySuppresses proves the sanitizer stopAt
+// boundary itself is non-vacuous: it must suppress at least one real
+// URL-into-sink violation in production code. Counting diagnostics with the
+// boundary enabled (FunnelOnly mode) vs disabled (DetectsWithoutFunnel mode), the
+// enabled count must be strictly lower — i.e. ≥1 inline sanitizer(.URL) call in a
+// sink arg is actually being recognized as a boundary. Without this, a renamed or
+// mistyped sanitizer in amqpSanitizerNames could leave the funnel detecting
+// nothing while FunnelOnly still (vacuously) reports zero.
+func TestAMQPURLRedaction_SanitizerBoundarySuppresses(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	count := func(treatSanitizerSafe bool) int {
+		var diags []Diagnostic
+		pkgs := []string{amqpRabbitmqPkgPath, amqpEventTransportPkgPath}
+		_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, pkgs),
+			func(p *Pass) []Diagnostic {
+				collectAMQPURLLeakDiags(p, &diags, treatSanitizerSafe)
+				return nil
+			})
+		return len(diags)
+	}
+
+	suppressed := count(false) - count(true)
+	assert.GreaterOrEqual(t, suppressed, 1,
+		"AMQP-URL-REDACTION-FUNNEL-01: the sanitizer stopAt boundary suppressed 0 "+
+			"violations (enabled count not lower than disabled count) — "+
+			"a sanitizer name in amqpSanitizerNames may be stale/mistyped, or the "+
+			"production sanitizer-wrapped URL-in-sink callsites were removed; the "+
+			"funnel is no longer proven to redact anything")
 }

--- a/tools/archtest/amqp_url_redaction_test.go
+++ b/tools/archtest/amqp_url_redaction_test.go
@@ -17,13 +17,27 @@
 // disabling the sanitizer-stopAt boundary and confirming at least one sink-arg
 // traversal crosses a .URL/.url selector on the way down.
 //
-// AI-robust grading: Medium. The funnel is a typed-field callsite scan resolved
-// with go/types (*types.Named identity for Config / brokerSpec), not a bare string
-// anchor. It is not Hard because the URL field is a plain string: a local variable
+// AI-robust grading: Medium. BOTH ends of the funnel are go/types-resolved, not
+// string anchors: the field source by *types.Named identity (rabbitmq.Config.URL
+// / eventtransport.brokerSpec.url) AND the sanitizer boundary by package identity
+// (ResolvePackageRef, callee must resolve to an adapters/rabbitmq sanitize* func)
+// — so a same-named impostor sanitizer in another package cannot exempt a raw URL.
+// It is not Hard because the URL field is a plain string: a local variable
 // (url := c.config.URL; slog.Info("...", slog.String("u", url))) would launder
 // the field access into a non-SelectorExpr reference that this scan cannot see.
 // The callee-resolved + type-identity field check is the Go-reachable ceiling for
 // this shape.
+//
+// No synthetic red fixture (and why): the scanner is type-identity-bound to the
+// two production types — isAMQPURLFieldSel only fires on rabbitmq.Config.URL /
+// eventtransport.brokerSpec.url by their *types.Named identity. A fixture package
+// declares its own types with different identity, so it cannot trigger the field
+// detection at all; a generic red fixture would be vacuous. Anti-vacuity is
+// therefore proven against real code: DetectsWithoutFunnel (raw URL into a sink IS
+// detected when the boundary is disabled) + SanitizerBoundarySuppresses (the
+// boundary recognizes the canonical adapters/rabbitmq sanitizers and suppresses
+// ≥1 real violation). The impostor-rejection is closed structurally by the
+// package-identity check above, not by a fixture.
 //
 // Blind spots: local-variable laundering (url := cells[id]; slog.Info(..., url))
 // and map-value reads (cells[id]) are not field selections and are therefore
@@ -130,23 +144,22 @@ func amqpNamedTypeIs(p *Pass, expr ast.Expr, pkgPath, typeName string) bool {
 	return obj.Pkg() != nil && obj.Pkg().Path() == pkgPath && obj.Name() == typeName
 }
 
-// amqpIsSanitizerCall reports whether call is a sanitizer boundary. Matches
-// calls whose callee name (final segment) is in amqpSanitizerNames.
-func amqpIsSanitizerCall(call *ast.CallExpr) bool {
-	name := amqpCallName(call)
-	_, ok := amqpSanitizerNames[name]
-	return ok
-}
-
-// amqpCallName extracts the base function/method name from a call expression.
-func amqpCallName(call *ast.CallExpr) string {
-	switch fn := call.Fun.(type) {
-	case *ast.Ident:
-		return fn.Name
-	case *ast.SelectorExpr:
-		return fn.Sel.Name
+// amqpIsSanitizerCall reports whether call is a sanitizer boundary — a call to
+// one of the canonical adapters/rabbitmq sanitize* funcs. The callee is resolved
+// by go/types package identity (ResolvePackageRef, same as amqpIsSinkCall), NOT
+// by bare function name, so a same-named impostor defined in another package
+// (e.g. a no-op sanitizeURL in eventtransport) cannot masquerade as the boundary
+// and wrongly exempt a raw URL flowing into a sink.
+func amqpIsSanitizerCall(p *Pass, call *ast.CallExpr) bool {
+	if p.TypesInfo == nil {
+		return false
 	}
-	return ""
+	pkgPath, name, ok := ResolvePackageRef(p.TypesInfo, call.Fun)
+	if !ok || pkgPath != amqpRabbitmqPkgPath {
+		return false
+	}
+	_, isSanitizer := amqpSanitizerNames[name]
+	return isSanitizer
 }
 
 // amqpIsSinkCall reports whether call is a sink call (slog / fmt / errcode
@@ -186,7 +199,7 @@ func collectAMQPURLLeakDiags(p *Pass, diags *[]Diagnostic, treatSanitizerSafe bo
 			return false
 		}
 		call, ok := n.(*ast.CallExpr)
-		return ok && amqpIsSanitizerCall(call)
+		return ok && amqpIsSanitizerCall(p, call)
 	}
 	predicate := func(sel *ast.SelectorExpr) bool {
 		return isAMQPURLFieldSel(p, sel)

--- a/tools/archtest/amqp_url_redaction_test.go
+++ b/tools/archtest/amqp_url_redaction_test.go
@@ -1,0 +1,334 @@
+//go:build archtest
+
+// INVARIANT: AMQP-URL-REDACTION-FUNNEL-01
+//
+// AMQP connection URLs carry embedded credentials in the DSN form
+// amqp://user:pass@host/vhost. Any path that leaks a raw AMQP URL into a
+// slog/fmt/errcode sink exposes those credentials — in structured logs, error
+// messages, or wire responses. The sanitize* funnel in adapters/rabbitmq
+// (sanitizeURL / sanitizeErrorURL / sanitizeDialError) redacts user:pass before
+// any URL string reaches a sink.
+//
+// This invariant scans adapters/rabbitmq and cellmodules/eventtransport for
+// AMQP-URL field selections (rabbitmq.Config.URL and eventtransport.brokerSpec.url)
+// that flow into a log/slog, fmt, or errcode sink call WITHOUT being enclosed by
+// a sanitizer call. The current production code is entirely clean (zero violations
+// in FunnelOnly); DetectsWithoutFunnel proves the detector is non-vacuous by
+// disabling the sanitizer-stopAt boundary and confirming at least one sink-arg
+// traversal crosses a .URL/.url selector on the way down.
+//
+// AI-robust grading: Medium. The funnel is a typed-field callsite scan resolved
+// with go/types (*types.Named identity for Config / brokerSpec), not a bare string
+// anchor. It is not Hard because the URL field is a plain string: a local variable
+// (url := c.config.URL; slog.Info("...", slog.String("u", url))) would launder
+// the field access into a non-SelectorExpr reference that this scan cannot see.
+// The callee-resolved + type-identity field check is the Go-reachable ceiling for
+// this shape.
+//
+// Blind spots: local-variable laundering (url := cells[id]; slog.Info(..., url))
+// and map-value reads (cells[id]) are not field selections and are therefore
+// outside this scan's coverage. The map-value path is exercised by the behavior
+// test in transport_test.go (TestDedupBrokerURL_CredentialNonLeak), closing the
+// gap without a Hard-form sealed URL type. Hard-via-sealed-redacted-Stringer URL
+// type across all adapter call sites would require a large-surface API change;
+// cost is not justified given the current threat model and the behavior-test
+// coverage.
+//
+// Scanner logic lives in this file (single-file rule, dogfood-only: scans
+// adapters/rabbitmq + cellmodules/eventtransport, neither of which exists in an
+// external Cell repo). Platform-symbol paths derived from [PlatformModulePath]
+// and [PlatformFrameworkModulePath].
+
+package archtest
+
+import (
+	"go/ast"
+	"go/types"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	// amqpRabbitmqPkgPath is the canonical import path of the rabbitmq adapter.
+	amqpRabbitmqPkgPath = PlatformModulePath + "/adapters/rabbitmq"
+	// amqpEventTransportPkgPath is the canonical import path of eventtransport.
+	amqpEventTransportPkgPath = PlatformModulePath + "/cellmodules/eventtransport"
+
+	// amqpRabbitmqConfigTypeName is the type whose URL field is tracked in rabbitmq.
+	amqpRabbitmqConfigTypeName = "Config"
+	// amqpRabbitmqURLFieldName is the exported URL field on rabbitmq.Config.
+	amqpRabbitmqURLFieldName = "URL"
+
+	// amqpBrokerSpecTypeName is the type whose url field is tracked in eventtransport.
+	amqpBrokerSpecTypeName = "brokerSpec"
+	// amqpBrokerSpecURLFieldName is the unexported url field on eventtransport.brokerSpec.
+	amqpBrokerSpecURLFieldName = "url"
+)
+
+// amqpSanitizerNames is the set of sanitizer function names in adapters/rabbitmq.
+// A call whose callee name (last segment) is in this set is treated as a sanitizer
+// boundary — FindFirstInSubtreeStopAt will not descend into it.
+var amqpSanitizerNames = map[string]struct{}{
+	"sanitizeURL":       {},
+	"sanitizeErrorURL":  {},
+	"sanitizeDialError": {},
+}
+
+// amqpSinkPkgPaths is the set of package paths whose calls are considered sinks.
+var amqpSinkPkgPaths = map[string]struct{}{
+	"log/slog": {},
+	"fmt":      {},
+	PlatformFrameworkModulePath + "/pkg/errcode": {},
+}
+
+// isAMQPURLFieldSel reports whether sel is a rabbitmq.Config.URL or
+// eventtransport.brokerSpec.url field selection, resolved via go/types.
+func isAMQPURLFieldSel(p *Pass, sel *ast.SelectorExpr) bool {
+	return isRabbitmqConfigURL(p, sel) || isBrokerSpecURL(p, sel)
+}
+
+// isRabbitmqConfigURL reports whether sel is a SelectorExpr whose selector is
+// "URL" and whose receiver type is rabbitmq.Config (or *rabbitmq.Config).
+func isRabbitmqConfigURL(p *Pass, sel *ast.SelectorExpr) bool {
+	if sel.Sel.Name != amqpRabbitmqURLFieldName {
+		return false
+	}
+	return amqpNamedTypeIs(p, sel.X, amqpRabbitmqPkgPath, amqpRabbitmqConfigTypeName)
+}
+
+// isBrokerSpecURL reports whether sel is a SelectorExpr whose selector is "url"
+// and whose receiver type is eventtransport.brokerSpec (or *brokerSpec).
+func isBrokerSpecURL(p *Pass, sel *ast.SelectorExpr) bool {
+	if sel.Sel.Name != amqpBrokerSpecURLFieldName {
+		return false
+	}
+	return amqpNamedTypeIs(p, sel.X, amqpEventTransportPkgPath, amqpBrokerSpecTypeName)
+}
+
+// amqpNamedTypeIs reports whether expr's go/types type (dereferenced one level
+// for pointer receivers, unaliased) is a *types.Named whose package path is
+// pkgPath and whose name is typeName.
+func amqpNamedTypeIs(p *Pass, expr ast.Expr, pkgPath, typeName string) bool {
+	if p.TypesInfo == nil {
+		return false
+	}
+	t := p.TypesInfo.TypeOf(expr)
+	if t == nil {
+		return false
+	}
+	// Dereference one level for pointer receivers (e.g. *rabbitmq.Config).
+	if ptr, ok := t.Underlying().(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	named, ok := types.Unalias(t).(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj.Pkg() != nil && obj.Pkg().Path() == pkgPath && obj.Name() == typeName
+}
+
+// amqpIsSanitizerCall reports whether call is a sanitizer boundary. Matches
+// calls whose callee name (final segment) is in amqpSanitizerNames.
+func amqpIsSanitizerCall(call *ast.CallExpr) bool {
+	name := amqpCallName(call)
+	_, ok := amqpSanitizerNames[name]
+	return ok
+}
+
+// amqpCallName extracts the base function/method name from a call expression.
+func amqpCallName(call *ast.CallExpr) string {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return fn.Name
+	case *ast.SelectorExpr:
+		return fn.Sel.Name
+	}
+	return ""
+}
+
+// amqpIsSinkCall reports whether call is a sink call (slog / fmt / errcode
+// package, any function).
+func amqpIsSinkCall(p *Pass, call *ast.CallExpr) bool {
+	if p.TypesInfo == nil {
+		return false
+	}
+	pkgPath, _, ok := ResolvePackageRef(p.TypesInfo, call.Fun)
+	if !ok {
+		return false
+	}
+	_, isSink := amqpSinkPkgPaths[pkgPath]
+	return isSink
+}
+
+// collectAMQPURLLeakDiags collects diagnostics for AMQP URL field selections that
+// flow into sink calls without sanitizer protection. It is the per-Pass body for
+// the AMQP-URL-REDACTION-FUNNEL-01 scan.
+//
+// When treatSanitizerSafe=true, a sanitizer call acts as a stopAt boundary so
+// field selections inside sanitizer arguments are not considered leaks (FunnelOnly
+// mode). When treatSanitizerSafe=false, the stopAt is a no-op and every sink-arg
+// traversal that reaches a .URL/.url selector reports a violation (DetectsWithoutFunnel
+// mode — proves the detection path is non-vacuous).
+func collectAMQPURLLeakDiags(p *Pass, diags *[]Diagnostic, treatSanitizerSafe bool) {
+	if p.Pkg == nil || p.TypesInfo == nil {
+		return
+	}
+	pkgPath := p.Pkg.Path()
+	if pkgPath != amqpRabbitmqPkgPath && pkgPath != amqpEventTransportPkgPath {
+		return
+	}
+
+	stopAt := func(n ast.Node) bool {
+		if !treatSanitizerSafe {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		return ok && amqpIsSanitizerCall(call)
+	}
+	predicate := func(sel *ast.SelectorExpr) bool {
+		return isAMQPURLFieldSel(p, sel)
+	}
+
+	for _, f := range p.Files {
+		rel := p.Rel(f)
+		if strings.HasSuffix(rel, "_test.go") {
+			continue
+		}
+		collectAMQPURLLeakDiagsFile(p, f, rel, diags, stopAt, predicate)
+	}
+}
+
+// collectAMQPURLLeakDiagsFile collects diagnostics for a single file.
+// Extracted to keep collectAMQPURLLeakDiags within cognitive complexity ≤ 15.
+func collectAMQPURLLeakDiagsFile(
+	p *Pass,
+	f ast.Node,
+	rel string,
+	diags *[]Diagnostic,
+	stopAt func(ast.Node) bool,
+	predicate func(*ast.SelectorExpr) bool,
+) {
+	EachInSubtree[ast.CallExpr](f, func(sinkCall *ast.CallExpr) {
+		if !amqpIsSinkCall(p, sinkCall) {
+			return
+		}
+		// Search each argument subtree for an AMQP URL field selection not
+		// protected by a sanitizer boundary.
+		for _, arg := range sinkCall.Args {
+			// When treatSanitizerSafe=true: if the top-level arg is itself a
+			// sanitizer call, it is safe by definition — skip entirely.
+			// (FindFirstInSubtreeStopAt always enters the root before consulting
+			// stopAt, so we must guard this case explicitly.)
+			if stopAt != nil && stopAt(arg) {
+				continue
+			}
+			sel, found := FindFirstInSubtreeStopAt[ast.SelectorExpr](arg, stopAt, predicate)
+			if !found {
+				continue
+			}
+			pos := p.Fset.Position(sel.Pos())
+			*diags = append(*diags, Diagnostic{
+				Rel:  rel,
+				Line: pos.Line,
+				Message: "AMQP-URL-REDACTION-FUNNEL-01: AMQP URL field selection " +
+					"flows into a slog/fmt/errcode sink without sanitizer protection — " +
+					"AMQP URLs carry user:pass credentials; wrap with sanitizeURL / " +
+					"sanitizeErrorURL / sanitizeDialError before passing to any sink",
+			})
+		}
+	})
+}
+
+// TestAMQPURLRedaction_FunnelOnly enforces AMQP-URL-REDACTION-FUNNEL-01:
+// every AMQP URL field selection (rabbitmq.Config.URL, eventtransport.brokerSpec.url)
+// that appears as an argument to a slog/fmt/errcode sink call must be enclosed
+// by a sanitizer call (sanitizeURL / sanitizeErrorURL / sanitizeDialError).
+// Expects zero violations because the current production code routes every
+// URL-to-sink path through the sanitize funnel.
+func TestAMQPURLRedaction_FunnelOnly(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var diags []Diagnostic
+	pkgs := []string{amqpRabbitmqPkgPath, amqpEventTransportPkgPath}
+	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, pkgs),
+		func(p *Pass) []Diagnostic {
+			collectAMQPURLLeakDiags(p, &diags, true)
+			return nil
+		})
+
+	Report(t, "AMQP-URL-REDACTION-FUNNEL-01", diags)
+}
+
+// TestAMQPURLRedaction_DetectsWithoutFunnel proves that the scanner's detection
+// path is non-vacuous: when sanitizer calls are NOT treated as safe boundaries
+// (treatSanitizerSafe=false), the scanner must find at least one AMQP URL field
+// selection inside a sink-call argument tree. If this test reports 0 detections,
+// the go/types resolution path may be silently broken (wrong package paths, failed
+// type resolution, or an API change in rabbitmq.Config / brokerSpec).
+func TestAMQPURLRedaction_DetectsWithoutFunnel(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var diags []Diagnostic
+	pkgs := []string{amqpRabbitmqPkgPath, amqpEventTransportPkgPath}
+	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, pkgs),
+		func(p *Pass) []Diagnostic {
+			collectAMQPURLLeakDiags(p, &diags, false)
+			return nil
+		})
+
+	assert.GreaterOrEqual(t, len(diags), 1,
+		"AMQP-URL-REDACTION-FUNNEL-01: scanner found 0 AMQP URL field selections inside "+
+			"sink-call args when sanitizer stopAt is disabled — "+
+			"the go/types resolution path may be silently broken (check package paths, "+
+			"type names rabbitmq.Config.URL / brokerSpec.url, or build tags)")
+}
+
+// TestAMQPURLRedaction_ScannerNonVacuous proves the field-selection recognizer
+// fires on at least one AMQP URL selector anywhere in the scanned packages
+// (not just inside sink args), guarding against a silent go/types failure that
+// would make both FunnelOnly and DetectsWithoutFunnel vacuously pass.
+func TestAMQPURLRedaction_ScannerNonVacuous(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	var found int
+	pkgs := []string{amqpRabbitmqPkgPath, amqpEventTransportPkgPath}
+	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, pkgs),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil || p.TypesInfo == nil {
+				return nil
+			}
+			pkgPath := p.Pkg.Path()
+			if pkgPath != amqpRabbitmqPkgPath && pkgPath != amqpEventTransportPkgPath {
+				return nil
+			}
+			for _, f := range p.Files {
+				if strings.HasSuffix(p.Rel(f), "_test.go") {
+					continue
+				}
+				EachInSubtree[ast.SelectorExpr](f, func(sel *ast.SelectorExpr) {
+					if isAMQPURLFieldSel(p, sel) {
+						found++
+					}
+				})
+			}
+			return nil
+		})
+
+	assert.GreaterOrEqual(t, found, 1,
+		"AMQP-URL-REDACTION-FUNNEL-01: scanner found 0 AMQP URL field selections "+
+			"anywhere in the scanned packages — "+
+			"the go/types resolution path may be silently broken; "+
+			"verify that rabbitmq.Config.URL and brokerSpec.url are correctly matched")
+}


### PR DESCRIPTION
## Summary

per-cell AMQP vhost/credential 隔离的**安全模型闭合**（#2152 PR-3，1423-US6）：在威胁矩阵登记「共享 AMQP broker 凭据」缺口（闭合 review F-B2），并把凭据 non-leak 从 Soft 注释约定升级为 Medium archtest `AMQP-URL-REDACTION-FUNNEL-01`。

## Why / 背景

#2152 按终态架构切三个串行 PR：PR-1（fan-out seam #2338）、PR-2（per-cell broker URL dedup，egress-only #2364）已合并。**PR-3 收口安全模型**——review F-B2 指出「split 下 per-cell AMQP vhost/credential 隔离**未登记威胁矩阵**」。

激进自审认定本 PR 形态：
- **凭据/vhost 隔离 seam 已由 PR-2 提供**：AMQP DSN `amqp://user:pass@host/vhost` 即 per-cell 凭据+vhost 注入入口（`GOCELL_<CELLID>_AMQP_URL`，回退 `GOCELL_AMQP_URL`）。
- **凭据 non-leak 已牢固但缺机器守卫**：`adapters/rabbitmq` 有 `sanitizeURL`/`sanitizeErrorURL`/`sanitizeDialError`，但仅靠注释约定（Soft）。本 PR 加 archtest 升 Medium。
- **AMQP 凭据是外部 broker operator-provisioned 用户**，无 framework master key → **不**对标 #2153 HKDF 派生、**不**建新包（概念错配会造平行结构）。

**AI HARD 诚实边界（不 overclaim）**：per-cell 运行期隔离今天**不可能做 Hard**——distinct per-cell URL 被 egress-only fail-closed，运行期每 cell 独立连接 blocked-by #2366（ingress N-router）+ #2341（per-cell relay fan-out）。本 PR 显式写明该边界，不声称隔离 Hard。

## 改动

| 改动 | 文件 |
|------|------|
| 威胁矩阵新增「共享 AMQP broker 凭据」行 + `### #2152 PR-3 Amendment`（AI-robust 评级分层） | `docs/architecture/202606131142-1423-...md` |
| `## Amendment 2026-06-18（#2152 PR-3）` 安全模型 | `docs/architecture/202606131500-1940-...md` |
| per-cell URL 措辞修正（PR-2 遗留 stale 单数 `GOCELL_AMQP_URL`）+ per-cell 凭据/vhost 隔离条款 | `.claude/rules/gocell/eventbus.md` |
| `§INVARIANT AMQP-URL-REDACTION-FUNNEL-01` + `§Per-cell credential/vhost isolation` | `cellmodules/eventtransport/doc.go` |
| distinct-URL fail-closed 文案补「凭据/vhost 隔离同受 egress-only 门控」 | `cellmodules/eventtransport/transport.go` |
| TDD 文案断言 + 凭据 non-leak 行为守卫（补 archtest 盲区） | `cellmodules/eventtransport/transport_test.go` |
| **新增 Medium 守卫** `AMQP-URL-REDACTION-FUNNEL-01`（typed AST funnel，3 测：FunnelOnly=0 / DetectsWithoutFunnel≥1 / ScannerNonVacuous） | `tools/archtest/amqp_url_redaction_test.go` |

## Refs

- Closes #2152（三 PR 终态子集全部完成；运行期 per-cell 隔离 = 显式 defer，下见 Risk）
- 残留运行期 fan-out：#2366（ingress N-router）+ #2341（per-cell relay/pool）
- ADR：`202606131500-1940`（§Amendment 2026-06-18 #2152 PR-3）、`202606131142-1423`（§#2152 PR-3 Amendment）
- ref: cellmodules/percellpg.Resolve（per-cell DSN dedup 孪生）、tools/archtest/mqtt_reason_redaction.go（redaction archtest 先例）

## Risk / 兼容性

- **无破坏性 wire / API 变更**；contract-fanout 闭环 N/A（无 contract schema/generated/event topic/command key/HTTP path/auth 语义变更）。
- **运行期 per-cell 凭据隔离 = 显式 defer**（非本 PR 缺失）：distinct per-cell URL 今 egress-only fail-closed，运行期隔离 blocked-by #2366/#2341，已在威胁矩阵 + ADR 写明非 silent。
- `Closes #2152`：本 issue 的三 PR scope 完成；若维护者认为应保留至运行期 fan-out（#2366/#2341）落地，可 reopen。

## Test plan

- [x] `go build ./...`（cellmodules + tools/archtest 模块）+ `go vet` 通过
- [x] `go test ./cellmodules/eventtransport/...` 通过（含文案 TDD + 凭据 non-leak 守卫）
- [x] `go test -tags archtest ./tools/archtest/ -run TestAMQPURLRedaction` 通过（FunnelOnly=0、DetectsWithoutFunnel≥1、ScannerNonVacuous≥1）
- [x] PR-time archtest-invariants gate（`hack/verify-archtest-invariants.sh`）通过（新 `INVARIANT:` anchor 合规）
- [x] `golangci-lint run`（cellmodules + tools/archtest `--build-tags archtest`）**0 issues**
- [x] celltransport 回归测试通过（确认未触及 #2278 邻近代码）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
