### PR TITLE
feat(auth): #2303 enrollment-credential issuer（非 bootstrap token, FR-012）[MDM-G4]

### DIFF
--- a/docs/architecture/202606121500-1895-adr-device-cert-framework-pivot.md
+++ b/docs/architecture/202606121500-1895-adr-device-cert-framework-pivot.md
@@ -97,7 +97,8 @@ lifecycle、EST 前端、生产 device 主体。
 | 吊销与续期竞态（吊销正在续期的证书） | epoch 单调 CAS（fencing）保证终态一致；`certlifecycle` 状态机 revoke 转换串行化 | Hard（复用 fencing）/ Medium（状态机测试） |
 | 多租户证书 reconcile 串租户 | reconcile system identity 清空 tenant（#1821）；scan + 命令 key + 签发请求自带 tenant 维度 | Medium |
 | 跨租户吊销（凭裸 serial 吊销他租户证书） | `Revoke`/`RevocationList`/`Tidy` 带 `CertScope`（tenant+issuer+device）typed 位置参，与签发同源；漏传编译错（`CERT-REVOKE-SCOPED-01`）；跨租户/issuer fail-closed | 上游 Hard（typed scope 漏传编译错）/ 下游 Medium（fail-closed 测试） |
-| EST 注册鉴权绕过 | `EST-ENROLL-AUTH-BOUNDARY-01`（enroll=专用 enrollment-credential/device-token，**不复用** setup `auth.bootstrap:true`；reenroll=现证书 mTLS；EST 挂版本化 cell 路径，缺则 fail-closed） | Medium |
+| EST 注册鉴权绕过（路由声明半） | `EST-ENROLL-AUTH-BOUNDARY-01`（EST `auth.Route` 显式声明 enroll=专用 enrollment-credential、reenroll=现证书 mTLS scheme，**不复用** setup `auth.bootstrap:true`；EST 挂版本化 cell 路径，缺则 fail-closed）——**路由声明半归 G2/PR-8b**（`runtime/http/est`） | Medium |
+| enrollment-credential 旁路 wrapper / 越权签发（凭据层半，#2303 G4） | `ENROLLMENT-CREDENTIAL-MINT-CALLER-01`：`EnrollmentCredentialIssuer.Issue` 是唯一 `(*JWTIssuer).Issue(TokenIntentEnrollment,…)` 出口（强制 device + 短 TTL + jti + 非空 tenant/subject）；`EnrollmentCredentialVerifier` fail-closed（intent 隔离 + device 断言 + 构造器拒空）；sealed `EnrollmentIdentity`（unexported 字段，包外不可伪造可用身份） | 下游 Hard（sealed identity 包外不可构造 + TokenIntent 隔离 = 类型/密码学事实）/ 上游 Medium（archtest 扫单一 enrollment Issue callsite，Go 天花板，同族 `COMMAND-ASYNC-EMIT-CALLER-01`） |
 | 续期惊群 | jitter 续期窗口（k8s 70-90% 寿命模型） | —（工程） |
 | device PII（serial/subject/device_id 入日志/wire） | 复用 `pkg/redaction`（#1695）；审计前 hash/redact | Medium |
 
@@ -129,6 +130,31 @@ lifecycle、EST 前端、生产 device 主体。
 > 排到 Stage 1 / 2027 Q1，本身不自洽）。本 ADR **替换**该 P0 为「框架证书底座（`runtime/certsigning` +
 > `adapters/softca` + EST）」——这是真正属于 core v1.0 的能力；winmdm 的 WSTEP/SCEP 协议前端归 2027
 > Stage 2，不塞进 core v1.0 P0。一并消解 #995「不在框架」与原 P0 callout 的张力。
+
+## Amendment 2026-06-18 — #2303（epic #2299 G4）enrollment-credential scheme
+
+落地 FR-012 的**凭据层**：device 首次 EST enroll 的专用鉴权凭据签发器 + 验证器
+（`framework/runtime/auth`），让示例 PR-2 与 EST 前端（G2/PR-8b）有真正的框架原语可依赖，
+不再用「最简 enrollment token 占位」。
+
+- **机制**：enrollment-credential = 带专用 `TokenIntentEnrollment`（typ `enroll+jwt` +
+  `token_use=enrollment`）的短期（`EnrollmentCredentialTTL`=5min）device-scoped 签名 JWT，
+  复用既有 RS256 `JWTIssuer`/`JWTVerifier`。**FR-012「不复用」是类型/密码学事实**：双通道
+  token-confusion 防御（typ 头 + token_use claim 交叉校验）使 enrollment 凭据不能当 access
+  token 用、反之亦然——无需运行时策略。**不复用** setup `auth.bootstrap:true`（FMT-28 正交，
+  本改动不碰）。
+- **概念澄清（防混淆）**：enrollment-credential 与 device **access** token **都是
+  `principal_kind=device` 的 JWT**，唯一区别是 `token_use`（enrollment vs access）。前者证明
+  「被授权以设备 X 身份注册」（注册期、无证书），后者证明「已注册设备 X」（业务期）。
+  两者经 `token_use` 隔离，互不可用。
+- **sealing**：`EnrollmentIdentity`（验证产物）全 unexported 字段 + 唯一构造器拒空 tenant/subject
+  → 包外不可构造可用身份（下游 Hard）。mint funnel `ENROLLMENT-CREDENTIAL-MINT-CALLER-01`
+  钉单一 `Issue(TokenIntentEnrollment,…)` 出口（上游 Medium，Go 天花板）。见上「威胁矩阵」新增行。
+- **归 G2/PR-8b（本 issue OUT）**：EST 端点（`runtime/http/est`）+ `auth.Route` scheme 声明
+  （`EST-ENROLL-AUTH-BOUNDARY-01` 路由声明半）；`EnrollmentIdentity → certsigning.EnrollmentClaim`
+  适配器（避免 auth↔certsigning 互 import 的分层陷阱）；**一次性/replay**（jti 账本/nonce 消费——
+  本 issue 已把随机 `jti` 写入凭据并经 `EnrollmentIdentity.JTI()` 暴露作前向 hook，消费需 enroll
+  请求上下文，归 EST 前端）。本 issue 无契约扇出（无 contract.yaml/generated/event/command）。
 
 ## 参考
 

--- a/framework/kernel/auth/auth_plan_test.go
+++ b/framework/kernel/auth/auth_plan_test.go
@@ -288,7 +288,9 @@ func TestTokenIntent_IsValid(t *testing.T) {
 		valid  bool
 	}{
 		{auth.TokenIntentAccess, true},
+		{auth.TokenIntentEnrollment, true},
 		{auth.TokenIntent("refresh"), false},
+		{auth.TokenIntent("bootstrap"), false},
 		{auth.TokenIntent(""), false},
 	}
 	for _, tc := range tests {

--- a/framework/kernel/auth/auth_types.go
+++ b/framework/kernel/auth/auth_types.go
@@ -26,11 +26,27 @@ const (
 	// TokenIntentAccess marks a short-lived credential for calling business
 	// endpoints. Verifier rejects any access token replayed at /auth/refresh.
 	TokenIntentAccess TokenIntent = "access"
+	// TokenIntentEnrollment marks a short-lived credential a device presents to
+	// authenticate the FIRST EST enrollment (/simpleenroll), before it holds any
+	// certificate. It is a dedicated scheme, NOT reused from the setup bootstrap
+	// token (FR-012): a credential minted for enrollment can never be replayed at
+	// a business endpoint (which require TokenIntentAccess) and vice-versa — the
+	// two-channel token-confusion defense (typ header + token_use claim) makes the
+	// non-reuse a type/crypto fact, not a runtime policy. Subsequent EST re-enroll
+	// uses the device's existing certificate (mTLS), not this credential.
+	//
+	// ref: RFC 7030 §3.2.3 (EST first-enroll bearer credential); RFC 8725 §3.11
+	// (token-confusion isolation). #2303 / epic #2299 G4.
+	TokenIntentEnrollment TokenIntent = "enrollment"
 )
 
 // IsValid reports whether the intent is one of the known enum values.
 func (t TokenIntent) IsValid() bool {
-	return t == TokenIntentAccess
+	switch t {
+	case TokenIntentAccess, TokenIntentEnrollment:
+		return true
+	}
+	return false
 }
 
 // PrincipalKindClaim is the wire value of the "principal_kind" JWT claim — the

--- a/framework/runtime/auth/auth.go
+++ b/framework/runtime/auth/auth.go
@@ -76,6 +76,10 @@ const (
 	// TokenIntentAccess marks a short-lived credential for calling business
 	// endpoints. Verifier rejects any access token replayed at /auth/refresh.
 	TokenIntentAccess = kauth.TokenIntentAccess
+	// TokenIntentEnrollment marks the dedicated device first-enrollment credential
+	// (EST /simpleenroll); see kauth.TokenIntentEnrollment. Issued by
+	// EnrollmentCredentialIssuer, verified by EnrollmentCredentialVerifier.
+	TokenIntentEnrollment = kauth.TokenIntentEnrollment
 )
 
 // PrincipalKindClaim is a type alias of kauth.PrincipalKindClaim so runtime/auth

--- a/framework/runtime/auth/config/registry.go
+++ b/framework/runtime/auth/config/registry.go
@@ -223,6 +223,40 @@ func NewJWTIssuerFromRegistry(reg *Registry, ttl time.Duration, opts ...auth.JWT
 	return auth.NewJWTIssuer(reg.keyProv, reg.issuer, ttl, reg.Clock(), append(baseOpts, opts...)...)
 }
 
+// NewEnrollmentCredentialIssuerFromRegistry constructs a
+// *auth.EnrollmentCredentialIssuer whose signing key, issuer, audience and clock
+// are all sourced from reg. This is the single authorized production entry point
+// for an enrollment-credential issuer; the raw auth.NewEnrollmentCredentialIssuer
+// is retained only for test helpers. The TTL is fixed at
+// auth.EnrollmentCredentialTTL (not a parameter — enrollment credentials are
+// deliberately short-lived).
+//
+// Unlike the raw constructor, this factory FAILS CLOSED on an empty audience: an
+// enrollment credential with no aud claim is rejected by every audience-requiring
+// verifier (NewJWTVerifierFromRegistry), so an unconfigured audience would mint
+// credentials that silently fail every verification (a runtime 401 footgun).
+// Requiring a non-empty audience at construction turns that into a startup error
+// (mirrors NewJWTVerifierFromRegistry).
+//
+// ref: Hydra internal/driver/config.DefaultProvider — configuration through registry
+func NewEnrollmentCredentialIssuerFromRegistry(reg *Registry, opts ...auth.JWTIssuerOption) (*auth.EnrollmentCredentialIssuer, error) {
+	if reg == nil {
+		return nil, errcode.New(errcode.KindInternal, errcode.ErrAuthVerifierConfig, "JWT registry must not be nil")
+	}
+	if validation.IsNilInterface(reg.keyProv) {
+		return nil, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthKeyInvalid, "JWT registry: SigningKeyProvider is nil")
+	}
+	auds := reg.Audiences()
+	if len(auds) == 0 {
+		return nil, errcode.New(errcode.KindInternal, errcode.ErrAuthVerifierConfig,
+			"JWT registry: Audiences must not be empty for enrollment credential issuer construction")
+	}
+	baseOpts := []auth.JWTIssuerOption{
+		auth.WithIssuerAudiencesFromSlice(auds),
+	}
+	return auth.NewEnrollmentCredentialIssuer(reg.keyProv, reg.issuer, reg.Clock(), append(baseOpts, opts...)...)
+}
+
 // NewJWTVerifierFromRegistry constructs a *auth.JWTVerifier whose expected
 // audiences, expected issuer, verification key store, and clock are all
 // sourced from reg.

--- a/framework/runtime/auth/config/registry_test.go
+++ b/framework/runtime/auth/config/registry_test.go
@@ -271,6 +271,69 @@ func TestNewJWTIssuerFromRegistry_NilRegistry(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestNewEnrollmentCredentialIssuerFromRegistry_Success(t *testing.T) {
+	ks, _, _ := keystest.MustNewKeySet(clock.Real())
+	reg, err := config.New(clock.Real(), config.Config{
+		Issuer:    "gocell",
+		Audiences: []string{"gocell-est"},
+		KeyProv:   ks,
+		KeyStore:  ks,
+		RealMode:  true,
+	})
+	require.NoError(t, err)
+
+	iss, err := config.NewEnrollmentCredentialIssuerFromRegistry(reg)
+	require.NoError(t, err)
+	require.NotNil(t, iss)
+
+	tok, err := iss.Issue("11111111-1111-1111-1111-111111111111", "device-1")
+	require.NoError(t, err)
+
+	// End-to-end: the registry-baked audience lets a registry verifier accept it.
+	jwtVer, err := config.NewJWTVerifierFromRegistry(reg)
+	require.NoError(t, err)
+	ver, err := auth.NewEnrollmentCredentialVerifier(jwtVer)
+	require.NoError(t, err)
+	id, err := ver.Verify(context.Background(), tok)
+	require.NoError(t, err)
+	assert.Equal(t, "device-1", id.Subject())
+}
+
+func TestNewEnrollmentCredentialIssuerFromRegistry_NilRegistry(t *testing.T) {
+	_, err := config.NewEnrollmentCredentialIssuerFromRegistry(nil)
+	require.Error(t, err)
+}
+
+func TestNewEnrollmentCredentialIssuerFromRegistry_NilKeyProv(t *testing.T) {
+	reg, err := config.New(clock.Real(), config.Config{
+		Issuer:    "gocell",
+		Audiences: []string{"gocell-est"},
+		KeyProv:   nil,
+		RealMode:  false,
+	})
+	require.NoError(t, err)
+	_, err = config.NewEnrollmentCredentialIssuerFromRegistry(reg)
+	require.Error(t, err, "nil KeyProv must return error")
+}
+
+// TestNewEnrollmentCredentialIssuerFromRegistry_EmptyAudienceFailsClosed is the
+// core F2 fix: an enrollment issuer constructed with no audience would mint
+// credentials every audience-requiring verifier rejects — the factory turns that
+// runtime 401 footgun into a startup error.
+func TestNewEnrollmentCredentialIssuerFromRegistry_EmptyAudienceFailsClosed(t *testing.T) {
+	ks, _, _ := keystest.MustNewKeySet(clock.Real())
+	reg, err := config.New(clock.Real(), config.Config{
+		Issuer:    "gocell",
+		Audiences: nil, // non-real mode allows empty audience at New; the factory must still reject
+		KeyProv:   ks,
+		RealMode:  false,
+	})
+	require.NoError(t, err)
+	_, err = config.NewEnrollmentCredentialIssuerFromRegistry(reg)
+	require.Error(t, err, "empty audience must fail-closed at enrollment issuer construction")
+	assert.Contains(t, err.Error(), "ERR_AUTH_VERIFIER_CONFIG")
+}
+
 // TestNewJWTIssuerFromRegistry_NilKeyProv returns an error when KeyProv is nil.
 func TestNewJWTIssuerFromRegistry_NilKeyProv(t *testing.T) {
 	reg, err := config.New(clock.Real(), config.Config{

--- a/framework/runtime/auth/enrollment_credential.go
+++ b/framework/runtime/auth/enrollment_credential.go
@@ -61,6 +61,7 @@ import (
 
 	"github.com/ghbvf/gocell/framework/kernel/clock"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/tenant"
 	"github.com/ghbvf/gocell/framework/pkg/validation"
 )
 
@@ -72,7 +73,8 @@ const EnrollmentCredentialTTL = 5 * time.Minute
 
 const (
 	msgEnrollmentSubjectMissing = "enrollment credential subject missing"
-	msgEnrollmentTenantMissing  = "enrollment credential tenant missing"
+	msgEnrollmentTenantInvalid  = "enrollment credential tenant must be a canonical tenant id"
+	msgEnrollmentJTIMissing     = "enrollment credential jti missing"
 	msgEnrollmentKindForbidden  = "enrollment credential is not device-scoped"
 	msgEnrollmentVerifierNil    = "enrollment credential verifier requires a token verifier"
 	msgEnrollmentJTIFailed      = "enrollment credential id generation failed"
@@ -85,34 +87,50 @@ const (
 // identity proves it came through EnrollmentCredentialVerifier.Verify. The EST
 // front-end (G2/PR-8b) maps it into a certsigning.EnrollmentClaim.
 type EnrollmentIdentity struct {
-	tenant  string
+	tenant  tenant.TenantID
 	subject string
 	jti     string
 }
 
-// Tenant returns the tenant isolation boundary the credential was minted for.
-func (e EnrollmentIdentity) Tenant() string { return e.tenant }
+// Tenant returns the typed tenant isolation boundary the credential was minted
+// for. It is a canonical tenant.TenantID (validated at construction), so the EST
+// front-end (G2/PR-8b) can pass it straight into certsigning without re-parsing a
+// naked string (tenancy.md: service APIs use typed tenant params, not raw string).
+func (e EnrollmentIdentity) Tenant() tenant.TenantID { return e.tenant }
 
 // Subject returns the device subject (device id) the credential was minted for.
 func (e EnrollmentIdentity) Subject() string { return e.subject }
 
-// JTI returns the credential's JWT ID — the forward hook for the EST front-end's
-// one-time / replay ledger (G2/PR-8b). Empty if the credential carried no jti.
+// JTI returns the credential's JWT ID — never empty for a verified identity (the
+// constructor fails closed on a missing jti). It is the forward hook for the EST
+// front-end's one-time / replay ledger: the consumer (G2/PR-8b) MUST consume this
+// jti at /simpleenroll to reject replay within the TTL window; G4 only guarantees
+// the jti is present, not consumed. Tracked: enrollment one-time/replay backlog
+// (see ADR 202606121500-1895 Amendment 2026-06-18).
 func (e EnrollmentIdentity) JTI() string { return e.jti }
 
-// newEnrollmentIdentity is the SOLE constructor of a usable EnrollmentIdentity.
-// It fails closed on empty tenant or subject so a verified enrollment identity is
-// always tenant-scoped and device-identified (mirrors certsigning.NewEnrollmentClaim
-// and mintDevicePrincipal). It exists only in this file; the archtest funnel
-// ENROLLMENT-CREDENTIAL-MINT-CALLER-01 rejects any other in-package construction.
-func newEnrollmentIdentity(tenant, subject, jti string) (EnrollmentIdentity, error) {
-	if tenant == "" {
-		return EnrollmentIdentity{}, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, msgEnrollmentTenantMissing)
+// newEnrollmentIdentity is the SOLE constructor of a usable EnrollmentIdentity. It
+// fails closed on a non-canonical/empty tenant (via tenant.ParseTenantID), an
+// empty subject, or an empty jti, so a verified enrollment identity is always
+// tenant-scoped (typed + canonical), device-identified, and replay-keyable
+// (mirrors certsigning.NewEnrollmentClaim and mintDevicePrincipal). It exists only
+// in this file; the archtest funnel ENROLLMENT-CREDENTIAL-MINT-CALLER-01 rejects
+// any other in-package construction. rawTenant is the verified token's tenant
+// claim (already canonical from VerifyIntent); it is re-parsed here as
+// defense-in-depth and to produce the typed value.
+func newEnrollmentIdentity(rawTenant, subject, jti string) (EnrollmentIdentity, error) {
+	canonicalTenant, err := tenant.ParseTenantID(rawTenant)
+	if err != nil {
+		return EnrollmentIdentity{}, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, msgEnrollmentTenantInvalid,
+			errcode.WithInternal(errcode.InternalAttr("_", err.Error())))
 	}
 	if subject == "" {
 		return EnrollmentIdentity{}, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, msgEnrollmentSubjectMissing)
 	}
-	return EnrollmentIdentity{tenant: tenant, subject: subject, jti: jti}, nil
+	if jti == "" {
+		return EnrollmentIdentity{}, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, msgEnrollmentJTIMissing)
+	}
+	return EnrollmentIdentity{tenant: canonicalTenant, subject: subject, jti: jti}, nil
 }
 
 // EnrollmentCredentialIssuer mints device first-enrollment credentials. It is the
@@ -130,6 +148,13 @@ type EnrollmentCredentialIssuer struct {
 // keys / issuer string / clock with the rest of auth; the composition root
 // (G2/PR-8b) decides the concrete wiring.
 //
+// opts are forwarded to the inner JWTIssuer and only influence audience/issuer
+// declaration (e.g. WithIssuerAudiencesFromSlice); they do NOT override the TTL,
+// which is fixed at EnrollmentCredentialTTL. Pass WithIssuerAudiencesFromSlice
+// with the EST audience: a JWTVerifier requires an expected audience
+// (NewJWTVerifier errors without one), so an issuer left without an audience mints
+// credentials the verifier rejects on every call (a silent 401, hard to diagnose).
+//
 // clk is required; pass clock.Real() at the composition root or clockmock.New(...)
 // in tests. Panics on nil or typed-nil clock.
 func NewEnrollmentCredentialIssuer(
@@ -144,15 +169,21 @@ func NewEnrollmentCredentialIssuer(
 }
 
 // Issue mints a device first-enrollment credential for the given tenant and
-// device subject. It fails closed on empty tenant or subject. The returned token
-// is a short-lived RS256 JWT with token_use=enrollment, principal_kind=device,
-// and a random jti.
+// device subject. It fails closed on an empty subject or a non-canonical/empty
+// tenant id (validated here at mint time so the issuer never produces a token the
+// verifier is bound to reject). The returned token is a short-lived RS256 JWT with
+// token_use=enrollment, principal_kind=device, and a random jti.
 func (i *EnrollmentCredentialIssuer) Issue(tenantID, deviceSubject string) (string, error) {
 	if deviceSubject == "" {
 		return "", errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, msgEnrollmentSubjectMissing)
 	}
-	if tenantID == "" {
-		return "", errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, msgEnrollmentTenantMissing)
+	// Validate + canonicalize at mint time (defense-in-depth with VerifyIntent's
+	// own tenant validation): a device credential is always tenant-scoped, and a
+	// non-canonical tenant would only fail later at the verifier.
+	canonicalTenant, err := tenant.ParseTenantID(tenantID)
+	if err != nil {
+		return "", errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, msgEnrollmentTenantInvalid,
+			errcode.WithInternal(errcode.InternalAttr("_", err.Error())))
 	}
 	jti, err := newEnrollmentJTI()
 	if err != nil {
@@ -162,7 +193,7 @@ func (i *EnrollmentCredentialIssuer) Issue(tenantID, deviceSubject string) (stri
 	// (ENROLLMENT-CREDENTIAL-MINT-CALLER-01): device-scoped, short-TTL, jti-bound.
 	return i.jwt.Issue(TokenIntentEnrollment, deviceSubject, IssueOptions{
 		PrincipalKind: PrincipalKindClaimDevice,
-		TenantID:      tenantID,
+		TenantID:      canonicalTenant.String(),
 		JTI:           jti,
 	})
 }

--- a/framework/runtime/auth/enrollment_credential.go
+++ b/framework/runtime/auth/enrollment_credential.go
@@ -1,0 +1,182 @@
+package auth
+
+// INVARIANT: ENROLLMENT-CREDENTIAL-MINT-CALLER-01
+//
+// # Enrollment-credential scheme (FR-012, epic #2299 G4, #2303)
+//
+// A device that has no certificate yet authenticates its FIRST EST enrollment
+// (/simpleenroll) with a dedicated enrollment credential — NOT the setup
+// bootstrap token (FMT-28 limits auth.bootstrap:true to /api/v{N}/*/setup/admin;
+// EST is a different path, and reuse would be fail-closed). EnrollmentCredentialIssuer
+// mints that credential; EnrollmentCredentialVerifier checks it and yields a
+// sealed EnrollmentIdentity the EST front-end (G2/PR-8b) turns into a
+// certsigning.EnrollmentClaim. Subsequent re-enroll uses the device's existing
+// certificate (mTLS), not this credential.
+//
+// The credential is a short-lived, device-scoped, RS256-signed JWT carrying
+// TokenIntentEnrollment. The two-channel token-confusion defense (JOSE typ
+// header "enroll+jwt" + token_use="enrollment" claim, cross-checked in
+// JWTVerifier.VerifyIntent) makes "an enrollment credential can never be used as
+// a business access token, and vice-versa" a type/crypto fact — this IS FR-012's
+// "dedicated scheme, not reused", with no runtime policy required.
+//
+// # Sealing / AI-robust rating (charter §"Funnel 双向锁评级")
+//
+//   - EnrollmentIdentity has ONLY unexported fields and a single unexported
+//     constructor (newEnrollmentIdentity, which fail-closes on empty tenant /
+//     subject). An out-of-package composite literal can therefore only produce the
+//     zero value (empty, accessors return ""), never a usable identity — so a
+//     downstream that trusts an EnrollmentIdentity has proof it came through
+//     verification. Out-of-package forgery of a usable identity is NOT expressible
+//     (Hard). No separate seal sentinel is needed (unlike Principal.device, which
+//     guards an EXPORTED Kind field).
+//   - The enrollment-credential mint funnel — EnrollmentCredentialIssuer.Issue is
+//     the sole sanctioned caller of JWTIssuer.Issue(TokenIntentEnrollment, ...) —
+//     is Medium: Issue and TokenIntentEnrollment are necessarily exported (the
+//     verifier needs the const), so Go visibility cannot express "only this
+//     wrapper may pass the enrollment intent". The archtest backstop
+//     ENROLLMENT-CREDENTIAL-MINT-CALLER-01 (tools/archtest) pins the call site and
+//     the in-package EnrollmentIdentity construction to this file. Same documented
+//     Go ceiling as COMMAND-ASYNC-EMIT-CALLER-01 / DEVICE-PRINCIPAL-MINT-CALLER-01.
+//     The funnel's value is a single policy-enforcing mint path (short TTL + jti +
+//     non-empty tenant/subject) that cannot drift.
+//
+// # One-time / replay (deferred to G2/PR-8b)
+//
+// Each credential carries a random jti (surfaced on EnrollmentIdentity.JTI) as a
+// forward hook. Single-use / replay defense belongs at the EST /simpleenroll
+// handler — where an enroll request (and thus a jti ledger / nonce) exists — and
+// is intentionally NOT wired here (G4 has no request context to key it on).
+//
+// ref: smallstep/certificates — JWK provisioner token (short-lived, audience-bound
+// JWT swapped once for a cert). ref: spiffe/spire — node join token (short-lived
+// attestation credential). ref: RFC 7030 §3.2.3 (EST first-enroll bearer
+// credential); RFC 8725 §3.11 (token-confusion isolation).
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/validation"
+)
+
+// EnrollmentCredentialTTL is the time-to-live of a device first-enrollment
+// credential. Enrollment credentials are presented once, immediately, by a
+// provisioning flow, so the window is deliberately short to bound the blast
+// radius of a leaked credential (shorter than DefaultAccessTokenTTL).
+const EnrollmentCredentialTTL = 5 * time.Minute
+
+const (
+	msgEnrollmentSubjectMissing = "enrollment credential subject missing"
+	msgEnrollmentTenantMissing  = "enrollment credential tenant missing"
+	msgEnrollmentKindForbidden  = "enrollment credential is not device-scoped"
+	msgEnrollmentVerifierNil    = "enrollment credential verifier requires a token verifier"
+	msgEnrollmentJTIFailed      = "enrollment credential id generation failed"
+)
+
+// EnrollmentIdentity is the sealed result of verifying a device first-enrollment
+// credential: the tenant and device subject the credential was minted for. All
+// fields are unexported and the sole constructor is newEnrollmentIdentity, so an
+// out-of-package literal can only be the (empty, inert) zero value — a usable
+// identity proves it came through EnrollmentCredentialVerifier.Verify. The EST
+// front-end (G2/PR-8b) maps it into a certsigning.EnrollmentClaim.
+type EnrollmentIdentity struct {
+	tenant  string
+	subject string
+	jti     string
+}
+
+// Tenant returns the tenant isolation boundary the credential was minted for.
+func (e EnrollmentIdentity) Tenant() string { return e.tenant }
+
+// Subject returns the device subject (device id) the credential was minted for.
+func (e EnrollmentIdentity) Subject() string { return e.subject }
+
+// JTI returns the credential's JWT ID — the forward hook for the EST front-end's
+// one-time / replay ledger (G2/PR-8b). Empty if the credential carried no jti.
+func (e EnrollmentIdentity) JTI() string { return e.jti }
+
+// newEnrollmentIdentity is the SOLE constructor of a usable EnrollmentIdentity.
+// It fails closed on empty tenant or subject so a verified enrollment identity is
+// always tenant-scoped and device-identified (mirrors certsigning.NewEnrollmentClaim
+// and mintDevicePrincipal). It exists only in this file; the archtest funnel
+// ENROLLMENT-CREDENTIAL-MINT-CALLER-01 rejects any other in-package construction.
+func newEnrollmentIdentity(tenant, subject, jti string) (EnrollmentIdentity, error) {
+	panic("TODO #2303: not implemented")
+}
+
+// EnrollmentCredentialIssuer mints device first-enrollment credentials. It is the
+// sole sanctioned producer of TokenIntentEnrollment tokens
+// (ENROLLMENT-CREDENTIAL-MINT-CALLER-01): it forces principal_kind=device, a
+// short TTL, and a random jti, and fails closed on empty tenant/subject so a
+// credential is always device-scoped and tenant-bound.
+type EnrollmentCredentialIssuer struct {
+	jwt *JWTIssuer
+}
+
+// NewEnrollmentCredentialIssuer builds an EnrollmentCredentialIssuer over an inner
+// JWTIssuer constructed with EnrollmentCredentialTTL (NOT the 15-minute access
+// issuer — JWTIssuer.Issue uses the construction-time TTL). It shares the signing
+// keys / issuer string / clock with the rest of auth; the composition root
+// (G2/PR-8b) decides the concrete wiring.
+//
+// clk is required; pass clock.Real() at the composition root or clockmock.New(...)
+// in tests. Panics on nil or typed-nil clock.
+func NewEnrollmentCredentialIssuer(keys SigningKeyProvider, issuer string, clk clock.Clock, opts ...JWTIssuerOption) (*EnrollmentCredentialIssuer, error) {
+	clock.MustHaveClock(clk, "auth.NewEnrollmentCredentialIssuer")
+	inner, err := NewJWTIssuer(keys, issuer, EnrollmentCredentialTTL, clk, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &EnrollmentCredentialIssuer{jwt: inner}, nil
+}
+
+// Issue mints a device first-enrollment credential for the given tenant and
+// device subject. It fails closed on empty tenant or subject. The returned token
+// is a short-lived RS256 JWT with token_use=enrollment, principal_kind=device,
+// and a random jti.
+func (i *EnrollmentCredentialIssuer) Issue(tenantID, deviceSubject string) (string, error) {
+	panic("TODO #2303: not implemented")
+}
+
+// EnrollmentCredentialVerifier verifies a device first-enrollment credential and
+// yields a sealed EnrollmentIdentity. It wraps any IntentTokenVerifier (the
+// production verifier is *JWTVerifier) so the EST front-end (G2/PR-8b) shares the
+// single canonical verification path.
+type EnrollmentCredentialVerifier struct {
+	verifier IntentTokenVerifier
+}
+
+// NewEnrollmentCredentialVerifier builds an EnrollmentCredentialVerifier over a
+// token verifier. Fails closed (not a silent noop) on a nil/typed-nil verifier.
+func NewEnrollmentCredentialVerifier(verifier IntentTokenVerifier) (*EnrollmentCredentialVerifier, error) {
+	if validation.IsNilInterface(verifier) {
+		return nil, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthVerifierConfig, msgEnrollmentVerifierNil)
+	}
+	return &EnrollmentCredentialVerifier{verifier: verifier}, nil
+}
+
+// Verify checks a device first-enrollment credential and returns the sealed
+// EnrollmentIdentity it asserts. It fails closed when the credential is not an
+// enrollment-intent token (TokenIntent isolation, via VerifyIntent), when it is
+// not device-scoped (principal_kind != device), or when tenant/subject is empty
+// (newEnrollmentIdentity). An access token presented here — or an enrollment
+// credential presented at a business access endpoint — is rejected by the
+// two-channel token-confusion defense in VerifyIntent.
+func (v *EnrollmentCredentialVerifier) Verify(ctx context.Context, token string) (EnrollmentIdentity, error) {
+	panic("TODO #2303: not implemented")
+}
+
+// newEnrollmentJTI returns a fresh random JWT ID for an enrollment credential.
+func newEnrollmentJTI() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", errcode.New(errcode.KindInternal, errcode.ErrInternal, msgEnrollmentJTIFailed,
+			errcode.WithInternal(errcode.InternalAttr("_", err.Error())))
+	}
+	return hex.EncodeToString(b[:]), nil
+}

--- a/framework/runtime/auth/enrollment_credential.go
+++ b/framework/runtime/auth/enrollment_credential.go
@@ -106,7 +106,13 @@ func (e EnrollmentIdentity) JTI() string { return e.jti }
 // and mintDevicePrincipal). It exists only in this file; the archtest funnel
 // ENROLLMENT-CREDENTIAL-MINT-CALLER-01 rejects any other in-package construction.
 func newEnrollmentIdentity(tenant, subject, jti string) (EnrollmentIdentity, error) {
-	panic("TODO #2303: not implemented")
+	if tenant == "" {
+		return EnrollmentIdentity{}, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, msgEnrollmentTenantMissing)
+	}
+	if subject == "" {
+		return EnrollmentIdentity{}, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, msgEnrollmentSubjectMissing)
+	}
+	return EnrollmentIdentity{tenant: tenant, subject: subject, jti: jti}, nil
 }
 
 // EnrollmentCredentialIssuer mints device first-enrollment credentials. It is the
@@ -126,7 +132,9 @@ type EnrollmentCredentialIssuer struct {
 //
 // clk is required; pass clock.Real() at the composition root or clockmock.New(...)
 // in tests. Panics on nil or typed-nil clock.
-func NewEnrollmentCredentialIssuer(keys SigningKeyProvider, issuer string, clk clock.Clock, opts ...JWTIssuerOption) (*EnrollmentCredentialIssuer, error) {
+func NewEnrollmentCredentialIssuer(
+	keys SigningKeyProvider, issuer string, clk clock.Clock, opts ...JWTIssuerOption,
+) (*EnrollmentCredentialIssuer, error) {
 	clock.MustHaveClock(clk, "auth.NewEnrollmentCredentialIssuer")
 	inner, err := NewJWTIssuer(keys, issuer, EnrollmentCredentialTTL, clk, opts...)
 	if err != nil {
@@ -140,7 +148,23 @@ func NewEnrollmentCredentialIssuer(keys SigningKeyProvider, issuer string, clk c
 // is a short-lived RS256 JWT with token_use=enrollment, principal_kind=device,
 // and a random jti.
 func (i *EnrollmentCredentialIssuer) Issue(tenantID, deviceSubject string) (string, error) {
-	panic("TODO #2303: not implemented")
+	if deviceSubject == "" {
+		return "", errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, msgEnrollmentSubjectMissing)
+	}
+	if tenantID == "" {
+		return "", errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, msgEnrollmentTenantMissing)
+	}
+	jti, err := newEnrollmentJTI()
+	if err != nil {
+		return "", err
+	}
+	// Sole sanctioned JWTIssuer.Issue(TokenIntentEnrollment, ...) call site
+	// (ENROLLMENT-CREDENTIAL-MINT-CALLER-01): device-scoped, short-TTL, jti-bound.
+	return i.jwt.Issue(TokenIntentEnrollment, deviceSubject, IssueOptions{
+		PrincipalKind: PrincipalKindClaimDevice,
+		TenantID:      tenantID,
+		JTI:           jti,
+	})
 }
 
 // EnrollmentCredentialVerifier verifies a device first-enrollment credential and
@@ -168,7 +192,19 @@ func NewEnrollmentCredentialVerifier(verifier IntentTokenVerifier) (*EnrollmentC
 // credential presented at a business access endpoint — is rejected by the
 // two-channel token-confusion defense in VerifyIntent.
 func (v *EnrollmentCredentialVerifier) Verify(ctx context.Context, token string) (EnrollmentIdentity, error) {
-	panic("TODO #2303: not implemented")
+	claims, err := v.verifier.VerifyIntent(ctx, token, TokenIntentEnrollment)
+	if err != nil {
+		return EnrollmentIdentity{}, err
+	}
+	// principal_kind absent/unknown is already fail-closed at decode
+	// (validatePrincipalKind); here we only assert it IS device — an
+	// enrollment credential must be device-scoped (not a user/service token).
+	if claims.PrincipalKind != PrincipalKindClaimDevice {
+		return EnrollmentIdentity{}, errcode.New(errcode.KindUnauthenticated, errcode.ErrAuthUnauthorized, msgEnrollmentKindForbidden)
+	}
+	// claims.TenantID is canonical-UUID-or-empty (validated in VerifyIntent);
+	// newEnrollmentIdentity fail-closes on empty tenant/subject.
+	return newEnrollmentIdentity(claims.TenantID, claims.Subject, claims.JTI)
 }
 
 // newEnrollmentJTI returns a fresh random JWT ID for an enrollment credential.

--- a/framework/runtime/auth/enrollment_credential_test.go
+++ b/framework/runtime/auth/enrollment_credential_test.go
@@ -131,7 +131,10 @@ func TestEnrollmentCredentialVerifier_Verify_NonReuseBothDirections(t *testing.T
 	enrollVer, err := NewEnrollmentCredentialVerifier(jwtVer)
 	require.NoError(t, err)
 
-	accessTok, err := accessIss.Issue(TokenIntentAccess, testEnrollDevice, IssueOptions{TenantID: testEnrollTenant, PrincipalKind: PrincipalKindClaimDevice})
+	accessTok, err := accessIss.Issue(TokenIntentAccess, testEnrollDevice, IssueOptions{
+		TenantID:      testEnrollTenant,
+		PrincipalKind: PrincipalKindClaimDevice,
+	})
 	require.NoError(t, err)
 	enrollTok, err := enrollIss.Issue(testEnrollTenant, testEnrollDevice)
 	require.NoError(t, err)
@@ -212,4 +215,10 @@ func TestNewEnrollmentCredentialVerifier_RejectsNilVerifier(t *testing.T) {
 	_, err := NewEnrollmentCredentialVerifier(nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ERR_AUTH_VERIFIER_CONFIG")
+}
+
+func TestNewEnrollmentCredentialIssuer_RejectsNilKeys(t *testing.T) {
+	_, err := NewEnrollmentCredentialIssuer(nil, "gocell", clock.Real())
+	require.Error(t, err, "nil signing key provider must fail-fast, not silently noop")
+	assert.Contains(t, err.Error(), "ERR_AUTH_KEY_INVALID")
 }

--- a/framework/runtime/auth/enrollment_credential_test.go
+++ b/framework/runtime/auth/enrollment_credential_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ghbvf/gocell/framework/kernel/clock"
 	"github.com/ghbvf/gocell/framework/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/framework/pkg/tenant"
 )
 
 const (
@@ -91,6 +92,8 @@ func TestEnrollmentCredentialIssuer_Issue_FailsClosed(t *testing.T) {
 	}{
 		{"empty subject", testEnrollTenant, ""},
 		{"empty tenant", "", testEnrollDevice},
+		{"non-canonical tenant", "not-a-uuid", testEnrollDevice},
+		{"nil-uuid tenant", "00000000-0000-0000-0000-000000000000", testEnrollDevice},
 		{"both empty", "", ""},
 	}
 	for _, tc := range tests {
@@ -103,14 +106,14 @@ func TestEnrollmentCredentialIssuer_Issue_FailsClosed(t *testing.T) {
 }
 
 func TestEnrollmentCredentialVerifier_Verify_ReturnsSealedIdentity(t *testing.T) {
-	iss, ver := newTestEnrollmentScheme(t, clock.Real())
+	iss, ver := newTestEnrollmentScheme(t, clockmock.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)))
 
 	tok, err := iss.Issue(testEnrollTenant, testEnrollDevice)
 	require.NoError(t, err)
 
 	id, err := ver.Verify(context.Background(), tok)
 	require.NoError(t, err)
-	assert.Equal(t, testEnrollTenant, id.Tenant())
+	assert.Equal(t, tenant.TenantID(testEnrollTenant), id.Tenant(), "tenant must be typed + canonical")
 	assert.Equal(t, testEnrollDevice, id.Subject())
 	assert.NotEmpty(t, id.JTI(), "verified identity must surface the jti for the one-time hook")
 }
@@ -120,7 +123,7 @@ func TestEnrollmentCredentialVerifier_Verify_ReturnsSealedIdentity(t *testing.T)
 // credential cannot be used at a business access endpoint.
 func TestEnrollmentCredentialVerifier_Verify_NonReuseBothDirections(t *testing.T) {
 	ks := mustTestKeySet(t)
-	clk := clock.Real()
+	clk := clockmock.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 
 	enrollIss, err := NewEnrollmentCredentialIssuer(ks, "gocell", clk, WithIssuerAudiencesFromSlice([]string{testEnrollAud}))
 	require.NoError(t, err)
@@ -168,6 +171,25 @@ func TestEnrollmentCredentialVerifier_Verify_RejectsNonDevice(t *testing.T) {
 	assert.Contains(t, err.Error(), "ERR_AUTH_UNAUTHORIZED")
 }
 
+// TestEnrollmentCredentialVerifier_Verify_RejectsMissingJTI forges a well-formed,
+// device-scoped enrollment token that carries NO jti. The verifier must fail
+// closed (S3): a credential without a jti cannot be keyed in the EST front-end's
+// replay ledger, so accepting it would open a replay hole.
+func TestEnrollmentCredentialVerifier_Verify_RejectsMissingJTI(t *testing.T) {
+	ks := mustTestKeySet(t)
+	clk := clock.Real()
+	jwtVer, err := NewJWTVerifier(ks, clk, WithExpectedAudiences(testEnrollAud))
+	require.NoError(t, err)
+	ver, err := NewEnrollmentCredentialVerifier(jwtVer)
+	require.NoError(t, err)
+
+	// device-scoped + canonical tenant, but signRawEnrollmentJWT writes no jti claim.
+	noJTITok := signRawEnrollmentJWT(t, ks, clk, string(PrincipalKindClaimDevice), testEnrollTenant)
+	_, err = ver.Verify(context.Background(), noJTITok)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_AUTH_UNAUTHORIZED")
+}
+
 func TestEnrollmentCredentialVerifier_Verify_RejectsExpired(t *testing.T) {
 	fixedNow := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	fc := clockmock.New(fixedNow)
@@ -182,31 +204,35 @@ func TestEnrollmentCredentialVerifier_Verify_RejectsExpired(t *testing.T) {
 }
 
 // TestNewEnrollmentIdentity_FailsClosed exercises the sealed constructor directly:
-// empty tenant or subject is rejected, independent of the verification path.
+// a non-canonical/empty tenant, empty subject, or empty jti is rejected,
+// independent of the verification path.
 func TestNewEnrollmentIdentity_FailsClosed(t *testing.T) {
 	tests := []struct {
 		name    string
 		tenant  string
 		subject string
+		jti     string
 		wantErr bool
 	}{
-		{"valid", testEnrollTenant, testEnrollDevice, false},
-		{"empty tenant", "", testEnrollDevice, true},
-		{"empty subject", testEnrollTenant, "", true},
-		{"both empty", "", "", true},
+		{"valid", testEnrollTenant, testEnrollDevice, "jti-1", false},
+		{"empty tenant", "", testEnrollDevice, "jti-1", true},
+		{"non-canonical tenant", "not-a-uuid", testEnrollDevice, "jti-1", true},
+		{"empty subject", testEnrollTenant, "", "jti-1", true},
+		{"empty jti", testEnrollTenant, testEnrollDevice, "", true},
+		{"all empty", "", "", "", true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			id, err := newEnrollmentIdentity(tc.tenant, tc.subject, "jti-1")
+			id, err := newEnrollmentIdentity(tc.tenant, tc.subject, tc.jti)
 			if tc.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "ERR_AUTH_UNAUTHORIZED")
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tc.tenant, id.Tenant())
+			assert.Equal(t, tenant.TenantID(tc.tenant), id.Tenant())
 			assert.Equal(t, tc.subject, id.Subject())
-			assert.Equal(t, "jti-1", id.JTI())
+			assert.Equal(t, tc.jti, id.JTI())
 		})
 	}
 }

--- a/framework/runtime/auth/enrollment_credential_test.go
+++ b/framework/runtime/auth/enrollment_credential_test.go
@@ -1,0 +1,215 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/clock/clockmock"
+)
+
+const (
+	testEnrollTenant = "11111111-1111-1111-1111-111111111111"
+	testEnrollDevice = "device-abc"
+	testEnrollAud    = "gocell-est"
+)
+
+// newTestEnrollmentScheme builds an issuer + verifier pair over a shared key set,
+// issuer string, audience and clock. The enrollment issuer bakes the audience so
+// the (audience-required) verifier accepts the credential.
+func newTestEnrollmentScheme(t *testing.T, clk clock.Clock) (*EnrollmentCredentialIssuer, *EnrollmentCredentialVerifier) {
+	t.Helper()
+	ks := mustTestKeySet(t)
+	iss, err := NewEnrollmentCredentialIssuer(ks, "gocell", clk, WithIssuerAudiencesFromSlice([]string{testEnrollAud}))
+	require.NoError(t, err)
+	jwtVer, err := NewJWTVerifier(ks, clk, WithExpectedAudiences(testEnrollAud))
+	require.NoError(t, err)
+	ver, err := NewEnrollmentCredentialVerifier(jwtVer)
+	require.NoError(t, err)
+	return iss, ver
+}
+
+// signRawEnrollmentJWT forges an enrollment-typed JWT with caller-controlled
+// principal_kind / tenant_id, signed by ks at the given clock. Used to exercise
+// the verifier's post-VerifyIntent fail-closed assertions.
+func signRawEnrollmentJWT(t *testing.T, ks *KeySet, clk clock.Clock, principalKind, tenantID string) string {
+	t.Helper()
+	now := clk.Now()
+	claims := jwt.MapClaims{
+		"sub":       testEnrollDevice,
+		"iss":       "gocell",
+		"aud":       []string{testEnrollAud},
+		"iat":       now.Unix(),
+		"exp":       now.Add(time.Hour).Unix(),
+		"token_use": string(TokenIntentEnrollment),
+	}
+	if tenantID != "" {
+		claims["tenant_id"] = tenantID
+	}
+	if principalKind != "" {
+		claims["principal_kind"] = principalKind
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = ks.SigningKeyID()
+	tok.Header["typ"] = jwtTypEnroll
+	s, err := tok.SignedString(ks.SigningKey())
+	require.NoError(t, err)
+	return s
+}
+
+func TestEnrollmentCredentialIssuer_Issue_MintsDeviceScopedToken(t *testing.T) {
+	fixedNow := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	iss, _ := newTestEnrollmentScheme(t, clockmock.New(fixedNow))
+
+	tok, err := iss.Issue(testEnrollTenant, testEnrollDevice)
+	require.NoError(t, err)
+
+	header := decodeJWTHeader(t, tok)
+	assert.Equal(t, jwtTypEnroll, header["typ"], "enrollment credential must carry typ=enroll+jwt")
+
+	p := decodeJWTPayload(t, tok)
+	assert.Equal(t, string(TokenIntentEnrollment), p["token_use"], "token_use must be enrollment")
+	assert.Equal(t, string(PrincipalKindClaimDevice), p["principal_kind"], "enrollment credential is always device-scoped")
+	assert.Equal(t, testEnrollTenant, p["tenant_id"], "tenant_id must be carried")
+	assert.Equal(t, testEnrollDevice, p["sub"], "sub must be the device subject")
+	assert.NotEmpty(t, p["jti"], "enrollment credential must carry a jti (one-time hook)")
+	assert.Equal(t, float64(fixedNow.Add(EnrollmentCredentialTTL).Unix()), p["exp"],
+		"exp must be now + EnrollmentCredentialTTL (short window), not the access TTL")
+}
+
+func TestEnrollmentCredentialIssuer_Issue_FailsClosed(t *testing.T) {
+	iss, _ := newTestEnrollmentScheme(t, clock.Real())
+	tests := []struct {
+		name    string
+		tenant  string
+		subject string
+	}{
+		{"empty subject", testEnrollTenant, ""},
+		{"empty tenant", "", testEnrollDevice},
+		{"both empty", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := iss.Issue(tc.tenant, tc.subject)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "ERR_AUTH_UNAUTHORIZED")
+		})
+	}
+}
+
+func TestEnrollmentCredentialVerifier_Verify_ReturnsSealedIdentity(t *testing.T) {
+	iss, ver := newTestEnrollmentScheme(t, clock.Real())
+
+	tok, err := iss.Issue(testEnrollTenant, testEnrollDevice)
+	require.NoError(t, err)
+
+	id, err := ver.Verify(context.Background(), tok)
+	require.NoError(t, err)
+	assert.Equal(t, testEnrollTenant, id.Tenant())
+	assert.Equal(t, testEnrollDevice, id.Subject())
+	assert.NotEmpty(t, id.JTI(), "verified identity must surface the jti for the one-time hook")
+}
+
+// TestEnrollmentCredentialVerifier_Verify_NonReuseBothDirections proves FR-012's
+// "dedicated scheme, not reused": an access token cannot enroll and an enrollment
+// credential cannot be used at a business access endpoint.
+func TestEnrollmentCredentialVerifier_Verify_NonReuseBothDirections(t *testing.T) {
+	ks := mustTestKeySet(t)
+	clk := clock.Real()
+
+	enrollIss, err := NewEnrollmentCredentialIssuer(ks, "gocell", clk, WithIssuerAudiencesFromSlice([]string{testEnrollAud}))
+	require.NoError(t, err)
+	accessIss, err := NewJWTIssuer(ks, "gocell", time.Hour, clk, WithIssuerAudiencesFromSlice([]string{testEnrollAud}))
+	require.NoError(t, err)
+	jwtVer, err := NewJWTVerifier(ks, clk, WithExpectedAudiences(testEnrollAud))
+	require.NoError(t, err)
+	enrollVer, err := NewEnrollmentCredentialVerifier(jwtVer)
+	require.NoError(t, err)
+
+	accessTok, err := accessIss.Issue(TokenIntentAccess, testEnrollDevice, IssueOptions{TenantID: testEnrollTenant, PrincipalKind: PrincipalKindClaimDevice})
+	require.NoError(t, err)
+	enrollTok, err := enrollIss.Issue(testEnrollTenant, testEnrollDevice)
+	require.NoError(t, err)
+
+	// access token presented to the enrollment verifier → rejected (intent isolation)
+	_, err = enrollVer.Verify(context.Background(), accessTok)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_AUTH_INVALID_TOKEN_INTENT")
+
+	// enrollment credential presented at a business access endpoint → rejected
+	_, err = jwtVer.VerifyIntent(context.Background(), enrollTok, TokenIntentAccess)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_AUTH_INVALID_TOKEN_INTENT")
+}
+
+// TestEnrollmentCredentialVerifier_Verify_RejectsNonDevice forges a well-formed
+// enrollment-intent token that is NOT device-scoped (principal_kind absent =
+// user). The verifier must fail closed even though VerifyIntent accepts it.
+func TestEnrollmentCredentialVerifier_Verify_RejectsNonDevice(t *testing.T) {
+	ks := mustTestKeySet(t)
+	clk := clock.Real()
+	jwtVer, err := NewJWTVerifier(ks, clk, WithExpectedAudiences(testEnrollAud))
+	require.NoError(t, err)
+	ver, err := NewEnrollmentCredentialVerifier(jwtVer)
+	require.NoError(t, err)
+
+	// principal_kind omitted → decodes to user; tenant present and canonical.
+	userKindTok := signRawEnrollmentJWT(t, ks, clk, "", testEnrollTenant)
+	_, err = ver.Verify(context.Background(), userKindTok)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_AUTH_UNAUTHORIZED")
+}
+
+func TestEnrollmentCredentialVerifier_Verify_RejectsExpired(t *testing.T) {
+	fixedNow := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	fc := clockmock.New(fixedNow)
+	iss, ver := newTestEnrollmentScheme(t, fc)
+
+	tok, err := iss.Issue(testEnrollTenant, testEnrollDevice)
+	require.NoError(t, err)
+
+	fc.Advance(EnrollmentCredentialTTL + time.Second)
+	_, err = ver.Verify(context.Background(), tok)
+	require.Error(t, err, "expired enrollment credential must be rejected")
+}
+
+// TestNewEnrollmentIdentity_FailsClosed exercises the sealed constructor directly:
+// empty tenant or subject is rejected, independent of the verification path.
+func TestNewEnrollmentIdentity_FailsClosed(t *testing.T) {
+	tests := []struct {
+		name    string
+		tenant  string
+		subject string
+		wantErr bool
+	}{
+		{"valid", testEnrollTenant, testEnrollDevice, false},
+		{"empty tenant", "", testEnrollDevice, true},
+		{"empty subject", testEnrollTenant, "", true},
+		{"both empty", "", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id, err := newEnrollmentIdentity(tc.tenant, tc.subject, "jti-1")
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "ERR_AUTH_UNAUTHORIZED")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.tenant, id.Tenant())
+			assert.Equal(t, tc.subject, id.Subject())
+			assert.Equal(t, "jti-1", id.JTI())
+		})
+	}
+}
+
+func TestNewEnrollmentCredentialVerifier_RejectsNilVerifier(t *testing.T) {
+	_, err := NewEnrollmentCredentialVerifier(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_AUTH_VERIFIER_CONFIG")
+}

--- a/framework/runtime/auth/jwt.go
+++ b/framework/runtime/auth/jwt.go
@@ -27,7 +27,12 @@ const msgTokenIntentFailed = "token intent validation failed"
 // JOSE typ header values written per TokenIntent. RFC 9068 §2.1 mandates
 // "at+jwt" for access tokens.
 const (
-	jwtTypAccess    = "at+jwt"
+	jwtTypAccess = "at+jwt"
+	// jwtTypEnroll is the JOSE typ header for a device first-enrollment credential
+	// (TokenIntentEnrollment). A distinct typ keeps the typ↔token_use agreement
+	// check (VerifyIntent) able to reject an enrollment credential replayed as an
+	// access token on the JOSE-header channel as well as the claim channel.
+	jwtTypEnroll    = "enroll+jwt"
 	msgInvalidToken = "invalid token"
 	// tokenUseClaim is the JWT payload key carrying the TokenIntent value.
 	// Named after AWS Cognito's convention, which is the most widely-adopted
@@ -52,6 +57,8 @@ func TypHeaderForIntent(intent TokenIntent) string {
 	switch intent {
 	case TokenIntentAccess:
 		return jwtTypAccess
+	case TokenIntentEnrollment:
+		return jwtTypEnroll
 	default:
 		return ""
 	}
@@ -63,6 +70,8 @@ func intentForJWTTyp(typ string) (TokenIntent, bool) {
 	switch typ {
 	case jwtTypAccess:
 		return TokenIntentAccess, true
+	case jwtTypEnroll:
+		return TokenIntentEnrollment, true
 	default:
 		return "", false
 	}

--- a/framework/runtime/auth/jwt_intent_test.go
+++ b/framework/runtime/auth/jwt_intent_test.go
@@ -347,5 +347,37 @@ func TestJWTVerifier_VerifyIntent_RejectsNonStringTypHeader(t *testing.T) {
 		"non-string typ header must be rejected and must not panic")
 }
 
+// TestJWTIntent_EnrollmentTypMapping pins the enroll+jwt ↔ enrollment typ mapping
+// (both directions) so a device first-enrollment credential survives the
+// typ↔token_use agreement check, and a typ/intent confusion is rejected.
+func TestJWTIntent_EnrollmentTypMapping(t *testing.T) {
+	assert.Equal(t, "enroll+jwt", TypHeaderForIntent(TokenIntentEnrollment),
+		"enrollment credential must carry typ=enroll+jwt")
+
+	intent, ok := intentForJWTTyp("enroll+jwt")
+	require.True(t, ok, "enroll+jwt must map back to an intent")
+	assert.Equal(t, TokenIntentEnrollment, intent)
+
+	// enroll+jwt must NOT decode to access, and at+jwt must NOT decode to enrollment.
+	accessIntent, ok := intentForJWTTyp("at+jwt")
+	require.True(t, ok)
+	assert.NotEqual(t, TokenIntentEnrollment, accessIntent)
+}
+
+// TestJWTVerifier_VerifyIntent_RejectsEnrollmentTypAtAccessPath verifies that a
+// token whose typ/token_use say enrollment is rejected when access is expected
+// (the JOSE-header channel of the non-reuse guarantee).
+func TestJWTVerifier_VerifyIntent_RejectsEnrollmentTypAtAccessPath(t *testing.T) {
+	ks := mustTestKeySet(t)
+	verifier, err := NewJWTVerifier(ks, clock.Real(), WithExpectedAudiences("gocell"))
+	require.NoError(t, err)
+
+	enroll := signRawIntentJWT(t, ks, string(TokenIntentEnrollment), "enroll+jwt", []string{"gocell"})
+
+	_, err = verifier.VerifyIntent(context.Background(), enroll, TokenIntentAccess)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_AUTH_INVALID_TOKEN_INTENT")
+}
+
 // Compile-time check: *JWTVerifier satisfies IntentTokenVerifier.
 var _ IntentTokenVerifier = (*JWTVerifier)(nil)

--- a/tools/archtest/enrollment_credential_mint_caller_test.go
+++ b/tools/archtest/enrollment_credential_mint_caller_test.go
@@ -1,0 +1,290 @@
+//go:build archtest
+
+// enrollment_credential_mint_caller_test.go — the in-package backstop for the
+// SOLE sanctioned device first-enrollment credential mint path (#2303, epic
+// #2299 G4, FR-012).
+//
+// INVARIANT: ENROLLMENT-CREDENTIAL-MINT-CALLER-01
+//
+// # What this guards
+//
+// runtime/auth.EnrollmentCredentialIssuer.Issue (enrollment_credential.go) is the
+// only sanctioned producer of a TokenIntentEnrollment credential. It is the sole
+// place that calls JWTIssuer.Issue(TokenIntentEnrollment, ...) and the sole place
+// that constructs a field-bearing EnrollmentIdentity — so every enrollment
+// credential flows through one policy-enforcing path (principal_kind=device +
+// short TTL + random jti + non-empty tenant/subject), and every verified
+// EnrollmentIdentity carries proof it came through the verifier.
+//
+// Two arms, one allowlist (enrollment_credential.go):
+//
+//   - Arm ① (main, externally expressible) — every production callsite of
+//     (*auth.JWTIssuer).Issue whose first argument const-evaluates to the
+//     TokenIntentEnrollment value. Issue and TokenIntentEnrollment are necessarily
+//     exported (the verifier needs the const), so any package holding a *JWTIssuer
+//     could mint an enrollment credential directly, bypassing the wrapper's policy.
+//     The RED fixture exercises this arm.
+//   - Arm ② (in-package backstop) — every production EnrollmentIdentity composite
+//     literal that SETS a field. EnrollmentIdentity's fields are unexported, so an
+//     out-of-package literal can only be the inert zero value (never flagged, and
+//     a field-setting literal there does not even compile). A field-bearing literal
+//     can therefore only appear inside runtime/auth — this arm pins it to
+//     enrollment_credential.go so a sibling file cannot forge a usable identity
+//     bypassing newEnrollmentIdentity's fail-closed validation.
+//
+// # AI-robust rating (charter §"Funnel 双向锁评级")
+//
+//   - Downstream (a consumer trusting an EnrollmentIdentity): HARD — type system.
+//     A usable (field-bearing) EnrollmentIdentity cannot be constructed
+//     out-of-package (unexported fields + unexported constructor).
+//   - Upstream (only enrollment_credential.go mints): MEDIUM, this archtest being
+//     the file-discipline backstop. Issue / TokenIntentEnrollment are exported, so
+//     Go visibility cannot express "only EnrollmentCredentialIssuer may pass the
+//     enrollment intent". This is the same documented Go ceiling as
+//     COMMAND-ASYNC-EMIT-CALLER-01 / DEVICE-PRINCIPAL-MINT-CALLER-01; no low-cost
+//     Hard path exists and no backlog issue is opened for this split.
+//
+// # Tool blind spots (charter §"强制盲区自检")
+//
+//   - Arm ① is const-folded over the first argument (EvaluateConstString) and
+//     typed (arg type is kauth.TokenIntent); an intent laundered through a
+//     non-const TokenIntent variable evades the scan — but the resulting credential
+//     still must pass EnrollmentCredentialVerifier (device assert + non-empty
+//     tenant/subject), so the bypass payoff is bounded.
+//   - Arm ② is composite-literal based; an identity assembled field-by-field after
+//     a zero-value construction would evade it — but only the sealed constructor
+//     produces a non-empty identity any consumer honors.
+//   - The anti-vacuity guard requires the allowlisted file to host BOTH a live
+//     enrollment Issue call and a field-bearing EnrollmentIdentity literal, so a
+//     stale allowlist entry cannot become a silent bypass slot.
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	kauth "github.com/ghbvf/gocell/framework/kernel/auth"
+)
+
+// wantEnrollmentIntent is the const-folded wire value of TokenIntentEnrollment.
+// Sourced from the real kernel const so the scanner cannot drift from the value
+// it guards.
+const wantEnrollmentIntent = string(kauth.TokenIntentEnrollment)
+
+// enrollmentCredentialMintAllowlist is the set of module-relative production files
+// allowed to mint an enrollment credential (call Issue with the enrollment intent)
+// or construct a field-bearing EnrollmentIdentity. See the file godoc.
+var enrollmentCredentialMintAllowlist = map[string]struct{}{
+	"runtime/auth/enrollment_credential.go": {}, // EnrollmentCredentialIssuer.Issue + newEnrollmentIdentity
+}
+
+// enrollmentCredentialMintFixturePkg is the build-tagged RED fixture exercised by
+// the reverse self-check.
+const enrollmentCredentialMintFixturePkg = "./tools/archtest/internal/enrollmentcredentialfixture"
+
+// TestEnrollmentCredentialMintCaller01 asserts every production enrollment-intent
+// Issue callsite and every field-bearing EnrollmentIdentity construction sits in
+// enrollmentCredentialMintAllowlist, and that the allowlist entry is live
+// (anti-vacuity reverse check for both arms).
+func TestEnrollmentCredentialMintCaller01(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	observedIssue := map[string]struct{}{}
+	observedIdentity := map[string]struct{}{}
+
+	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
+		d, oi, oid := checkEnrollmentCredentialMint(p, enrollmentCredentialMintAllowlist)
+		for f := range oi {
+			observedIssue[f] = struct{}{}
+		}
+		for f := range oid {
+			observedIdentity[f] = struct{}{}
+		}
+		return d
+	})
+
+	// Anti-vacuity: the sole allowlisted file must host BOTH a live enrollment
+	// Issue call and a field-bearing EnrollmentIdentity construction, else an arm
+	// guards nothing.
+	const allowed = "runtime/auth/enrollment_credential.go"
+	if _, seen := observedIssue[allowed]; !seen {
+		diags = append(diags, Diagnostic{
+			Message: "ENROLLMENT-CREDENTIAL-MINT-CALLER-01 anti-vacuity: no live (*auth.JWTIssuer).Issue(" +
+				"TokenIntentEnrollment, ...) call observed in " + allowed + " — EnrollmentCredentialIssuer.Issue " +
+				"was removed/renamed or the scanner regressed; the mint funnel guards nothing.",
+		})
+	}
+	if _, seen := observedIdentity[allowed]; !seen {
+		diags = append(diags, Diagnostic{
+			Message: "ENROLLMENT-CREDENTIAL-MINT-CALLER-01 anti-vacuity: no live field-bearing " +
+				"auth.EnrollmentIdentity construction observed in " + allowed + " — newEnrollmentIdentity " +
+				"was removed/renamed or the scanner regressed; the identity backstop guards nothing.",
+		})
+	}
+
+	Report(t, "ENROLLMENT-CREDENTIAL-MINT-CALLER-01", diags)
+}
+
+// TestEnrollmentCredentialMintCaller01_ScannerCatchesViolation is the reverse
+// self-check: it runs the SAME production detector against the RED fixture,
+// asserting it flags EXACTLY the fixture's bare enrollment Issue call and that an
+// allowlisted run suppresses it.
+func TestEnrollmentCredentialMintCaller01_ScannerCatchesViolation(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	diags := Run(t, Fixture(FixtureOpts{Tests: false}, []string{enrollmentCredentialMintFixturePkg}), func(p *Pass) []Diagnostic {
+		d, _, _ := checkEnrollmentCredentialMint(p, nil)
+		return d
+	})
+
+	const wantFlagged = 1 // the bare enrollment Issue call (the access Issue control is NOT flagged)
+	if len(diags) != wantFlagged {
+		t.Fatalf("ENROLLMENT-CREDENTIAL-MINT-CALLER-01 scanner self-check: expected the production detector to "+
+			"flag exactly %d enrollment Issue callsite in the fixture (and NOT the access-intent control), got %d: %+v",
+			wantFlagged, len(diags), diags)
+	}
+	if len(diags) > 0 {
+		// Same detector, fixture file IN the allowlist → ZERO diagnostics.
+		allowFixture := map[string]struct{}{diags[0].Rel: {}}
+		suppressed := Run(t, Fixture(FixtureOpts{Tests: false}, []string{enrollmentCredentialMintFixturePkg}), func(p *Pass) []Diagnostic {
+			d, _, _ := checkEnrollmentCredentialMint(p, allowFixture)
+			return d
+		})
+		assert.Empty(t, suppressed,
+			"ENROLLMENT-CREDENTIAL-MINT-CALLER-01 scanner self-check: allowlisting the fixture file must suppress "+
+				"all diagnostics on the identical detector path")
+	}
+}
+
+// checkEnrollmentCredentialMint scans one typed Pass for (a) (*auth.JWTIssuer).Issue
+// callsites whose first argument const-evaluates to TokenIntentEnrollment, and
+// (b) field-bearing auth.EnrollmentIdentity composite literals; it flags any not in
+// allowlist. It returns the diagnostics plus the sets of module-relative files in
+// which each kind of mint was observed (anti-vacuity). SINGLE detection path shared
+// by the production test and the fixture self-check.
+func checkEnrollmentCredentialMint(p *Pass, allowlist map[string]struct{}) (diags []Diagnostic, issueObs, identityObs map[string]struct{}) {
+	issueObs = map[string]struct{}{}
+	identityObs = map[string]struct{}{}
+	if !p.Typed() {
+		return nil, issueObs, identityObs
+	}
+	for _, file := range p.Files {
+		rel := p.Rel(file)
+		EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+			if !isEnrollmentIssueCall(p, call) {
+				return
+			}
+			issueObs[rel] = struct{}{}
+			if _, allowed := allowlist[rel]; allowed {
+				return
+			}
+			pos := p.Fset.Position(call.Pos())
+			diags = append(diags, Diagnostic{
+				Rel:  rel,
+				Line: pos.Line,
+				Message: fmt.Sprintf(
+					"ENROLLMENT-CREDENTIAL-MINT-CALLER-01: %s calls (*auth.JWTIssuer).Issue with TokenIntentEnrollment "+
+						"outside the sole sanctioned enrollment-credential issuer. A device first-enrollment credential "+
+						"MUST be minted by runtime/auth.EnrollmentCredentialIssuer.Issue (enrollment_credential.go), which "+
+						"forces principal_kind=device + short TTL + jti + non-empty tenant/subject. Route through it; or, if "+
+						"this is a genuinely new sanctioned issuer, add it to enrollmentCredentialMintAllowlist with a rationale.",
+					rel),
+			})
+		})
+		EachInSubtree[ast.CompositeLit](file, func(lit *ast.CompositeLit) {
+			if !isFieldBearingEnrollmentIdentityLiteral(p.TypesInfo, lit) {
+				return
+			}
+			identityObs[rel] = struct{}{}
+			if _, allowed := allowlist[rel]; allowed {
+				return
+			}
+			pos := p.Fset.Position(lit.Pos())
+			diags = append(diags, Diagnostic{
+				Rel:  rel,
+				Line: pos.Line,
+				Message: fmt.Sprintf(
+					"ENROLLMENT-CREDENTIAL-MINT-CALLER-01: %s constructs a field-bearing auth.EnrollmentIdentity outside "+
+						"the sole sanctioned constructor. A usable enrollment identity MUST come from "+
+						"runtime/auth.newEnrollmentIdentity (enrollment_credential.go), which fail-closes on empty "+
+						"tenant/subject so a verified identity proves it came through EnrollmentCredentialVerifier.",
+					rel),
+			})
+		})
+	}
+	return diags, issueObs, identityObs
+}
+
+// isEnrollmentIssueCall reports whether call is (*auth.JWTIssuer).Issue(...) whose
+// first argument is the compile-time constant TokenIntentEnrollment.
+func isEnrollmentIssueCall(p *Pass, call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel == nil || sel.Sel.Name != "Issue" {
+		return false
+	}
+	selection := p.TypesInfo.Selections[sel]
+	if selection == nil {
+		return false
+	}
+	fn, ok := selection.Obj().(*types.Func)
+	if !ok || !isAuthJWTIssuerRecv(fn) {
+		return false
+	}
+	if len(call.Args) < 1 {
+		return false
+	}
+	val, isConst := EvaluateConstString(p.TypesInfo, call.Args[0])
+	return isConst && val == wantEnrollmentIntent
+}
+
+// isAuthJWTIssuerRecv reports whether fn is a method whose receiver base type is
+// runtime/auth.JWTIssuer (pointer or value), alias-proof.
+func isAuthJWTIssuerRecv(fn *types.Func) bool {
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok || sig.Recv() == nil {
+		return false
+	}
+	t := sig.Recv().Type()
+	if ptr, isPtr := types.Unalias(t).(*types.Pointer); isPtr {
+		t = ptr.Elem()
+	}
+	named, ok := types.Unalias(t).(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Pkg() != nil &&
+		obj.Pkg().Path() == authRuntimePkgPath && obj.Name() == "JWTIssuer"
+}
+
+// isFieldBearingEnrollmentIdentityLiteral reports whether lit is an
+// auth.EnrollmentIdentity composite literal that sets at least one field. A bare
+// EnrollmentIdentity{} (the inert zero, used as an error-path return) is NOT
+// flagged; out-of-package code cannot set the unexported fields, so a
+// field-bearing literal can only appear inside runtime/auth.
+func isFieldBearingEnrollmentIdentityLiteral(info *types.Info, lit *ast.CompositeLit) bool {
+	if info == nil || lit.Type == nil || len(lit.Elts) == 0 {
+		return false
+	}
+	tv, ok := info.Types[lit.Type]
+	if !ok {
+		return false
+	}
+	named, ok := types.Unalias(tv.Type).(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Pkg() != nil &&
+		obj.Pkg().Path() == authRuntimePkgPath && obj.Name() == "EnrollmentIdentity"
+}

--- a/tools/archtest/enrollment_credential_mint_caller_test.go
+++ b/tools/archtest/enrollment_credential_mint_caller_test.go
@@ -46,11 +46,18 @@
 //
 // # Tool blind spots (charter §"强制盲区自检")
 //
-//   - Arm ① is const-folded over the first argument (EvaluateConstString) and
-//     typed (arg type is kauth.TokenIntent); an intent laundered through a
-//     non-const TokenIntent variable evades the scan — but the resulting credential
-//     still must pass EnrollmentCredentialVerifier (device assert + non-empty
-//     tenant/subject), so the bypass payoff is bounded.
+//   - Arm ① matches the first argument either as a direct compile-time constant
+//     (EvaluateConstString) OR as a same-package identifier whose single assignment
+//     const-folds to the enrollment intent (collectEnrollmentValuedIdents — closes
+//     the variable-relay bypass `intent := TokenIntentEnrollment; iss.Issue(intent, ...)`,
+//     #2382 review F1). RESIDUAL (still uncaught, intentionally — keeps this a
+//     lightweight typed-AST scan, not full value-flow): the intent relayed through a
+//     CROSS-FUNCTION param/return, or a variable REASSIGNED after an enrollment
+//     assignment. The Hard close of these is the SSA value-flow scan OR the larger
+//     "make a bare Issue(TokenIntentEnrollment, ...) unexpressible via a dedicated
+//     typed mint API" refactor (codex's 重构 option) — a deliberate Cx3 deferral,
+//     not adopted here. Either residual still leaves the credential bounded: it must
+//     pass EnrollmentCredentialVerifier (device assert + non-empty tenant/subject/jti).
 //   - Arm ② is composite-literal based; an identity assembled field-by-field after
 //     a zero-value construction would evade it — but only the sealed constructor
 //     produces a non-empty identity any consumer honors.
@@ -147,10 +154,14 @@ func TestEnrollmentCredentialMintCaller01_ScannerCatchesViolation(t *testing.T) 
 		return d
 	})
 
-	const wantFlagged = 1 // the bare enrollment Issue call (the access Issue control is NOT flagged)
+	// Two RED cases: the direct enrollment Issue call + the variable-relay one
+	// (intent := TokenIntentEnrollment; iss.Issue(intent, ...)). The two access
+	// controls (direct + via var) are NOT flagged.
+	const wantFlagged = 2
 	if len(diags) != wantFlagged {
 		t.Fatalf("ENROLLMENT-CREDENTIAL-MINT-CALLER-01 scanner self-check: expected the production detector to "+
-			"flag exactly %d enrollment Issue callsite in the fixture (and NOT the access-intent control), got %d: %+v",
+			"flag exactly %d enrollment Issue callsites in the fixture (direct + variable-relay; and NOT the two "+
+			"access-intent controls), got %d: %+v",
 			wantFlagged, len(diags), diags)
 	}
 	if len(diags) > 0 {
@@ -178,10 +189,14 @@ func checkEnrollmentCredentialMint(p *Pass, allowlist map[string]struct{}) (diag
 	if !p.Typed() {
 		return nil, issueObs, identityObs
 	}
+	// Local def-use: vars/consts whose single assignment const-folds to the
+	// enrollment intent, so a relayed `intent := TokenIntentEnrollment; iss.Issue(intent, ...)`
+	// is caught, not just a direct const argument (#2382 review F1).
+	enrollVars := collectEnrollmentValuedIdents(p)
 	for _, file := range p.Files {
 		rel := p.Rel(file)
 		EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
-			if !isEnrollmentIssueCall(p, call) {
+			if !isEnrollmentIssueCall(p, call, enrollVars) {
 				return
 			}
 			issueObs[rel] = struct{}{}
@@ -226,8 +241,12 @@ func checkEnrollmentCredentialMint(p *Pass, allowlist map[string]struct{}) (diag
 }
 
 // isEnrollmentIssueCall reports whether call is (*auth.JWTIssuer).Issue(...) whose
-// first argument is the compile-time constant TokenIntentEnrollment.
-func isEnrollmentIssueCall(p *Pass, call *ast.CallExpr) bool {
+// first argument resolves to TokenIntentEnrollment — either as a direct
+// compile-time constant OR as a same-package identifier whose single assignment
+// const-folds to it (local def-use, enrollVars). The latter closes the
+// variable-relay bypass (#2382 review F1); cross-function relay and reassignment
+// remain the documented residual (see file godoc blind spots).
+func isEnrollmentIssueCall(p *Pass, call *ast.CallExpr, enrollVars map[types.Object]struct{}) bool {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok || sel.Sel == nil || sel.Sel.Name != "Issue" {
 		return false
@@ -243,8 +262,54 @@ func isEnrollmentIssueCall(p *Pass, call *ast.CallExpr) bool {
 	if len(call.Args) < 1 {
 		return false
 	}
-	val, isConst := EvaluateConstString(p.TypesInfo, call.Args[0])
-	return isConst && val == wantEnrollmentIntent
+	if val, isConst := EvaluateConstString(p.TypesInfo, call.Args[0]); isConst {
+		return val == wantEnrollmentIntent
+	}
+	// Variable relay: the first arg is a non-const identifier — match it against
+	// the set of identifiers whose assignment const-folds to the enrollment intent.
+	if id, isID := call.Args[0].(*ast.Ident); isID {
+		if obj := p.TypesInfo.ObjectOf(id); obj != nil {
+			_, relayed := enrollVars[obj]
+			return relayed
+		}
+	}
+	return false
+}
+
+// collectEnrollmentValuedIdents returns the set of var/const objects in the Pass
+// whose single-value assignment (`x := <const>`, `x = <const>`, `var x = <const>`,
+// `const x = <const>`) const-folds to the enrollment intent. It is the local
+// def-use backing for isEnrollmentIssueCall's variable-relay arm. Multi-assignment
+// and later reassignment are intentionally out of scope (the documented residual):
+// over-approximating to "any ident ever assigned enrollment" only ever flags MORE
+// Issue callsites, which is fail-closed-safe for a mint funnel.
+func collectEnrollmentValuedIdents(p *Pass) map[types.Object]struct{} {
+	out := map[types.Object]struct{}{}
+	add := func(lhs ast.Expr, rhs ast.Expr) {
+		id, isID := lhs.(*ast.Ident)
+		if !isID || id.Name == "_" {
+			return
+		}
+		if val, isConst := EvaluateConstString(p.TypesInfo, rhs); !isConst || val != wantEnrollmentIntent {
+			return
+		}
+		if obj := p.TypesInfo.ObjectOf(id); obj != nil {
+			out[obj] = struct{}{}
+		}
+	}
+	for _, file := range p.Files {
+		EachInSubtree[ast.AssignStmt](file, func(as *ast.AssignStmt) {
+			if len(as.Lhs) == 1 && len(as.Rhs) == 1 {
+				add(as.Lhs[0], as.Rhs[0])
+			}
+		})
+		EachInSubtree[ast.ValueSpec](file, func(vs *ast.ValueSpec) {
+			if len(vs.Names) == 1 && len(vs.Values) == 1 {
+				add(vs.Names[0], vs.Values[0])
+			}
+		})
+	}
+	return out
 }
 
 // isAuthJWTIssuerRecv reports whether fn is a method whose receiver base type is

--- a/tools/archtest/internal/enrollmentcredentialfixture/fixture.go
+++ b/tools/archtest/internal/enrollmentcredentialfixture/fixture.go
@@ -18,10 +18,15 @@
 // RED (MUST be flagged):
 //   - ForgeEnrollmentCredential — (*auth.JWTIssuer).Issue(auth.TokenIntentEnrollment, ...)
 //     outside enrollment_credential.go, bypassing the wrapper's policy enforcement.
+//   - ForgeEnrollmentCredentialViaVar — the same bypass but with the intent relayed
+//     through a local variable (intent := TokenIntentEnrollment; iss.Issue(intent, ...)),
+//     which a const-only scanner would miss (#2382 review F1).
 //
 // GREEN (MUST NOT be flagged):
 //   - MakeAccessToken — (*auth.JWTIssuer).Issue(auth.TokenIntentAccess, ...); proves
 //     the detector is scoped to the enrollment intent, not "any Issue call".
+//   - MakeAccessTokenViaVar — access intent relayed through a local variable; proves
+//     the variable-relay arm is enrollment-specific, not "any relayed intent".
 package enrollmentcredentialfixture
 
 import "github.com/ghbvf/gocell/framework/runtime/auth"
@@ -39,8 +44,27 @@ func ForgeEnrollmentCredential() (string, error) {
 	})
 }
 
+// ForgeEnrollmentCredentialViaVar is the variable-relay RED case: the enrollment
+// intent is bound to a local variable before the bare Issue call. A const-only
+// scanner misses this; the local def-use arm must still flag it.
+func ForgeEnrollmentCredentialViaVar() (string, error) {
+	intent := auth.TokenIntentEnrollment
+	return iss.Issue(intent, "forged-via-var", auth.IssueOptions{
+		PrincipalKind: auth.PrincipalKindClaimDevice,
+		TenantID:      "11111111-1111-1111-1111-111111111111",
+	})
+}
+
 // MakeAccessToken is the GREEN control: an ordinary access token, which the
 // detector must NOT flag.
 func MakeAccessToken() (string, error) {
 	return iss.Issue(auth.TokenIntentAccess, "real-user", auth.IssueOptions{})
+}
+
+// MakeAccessTokenViaVar is the variable-relay GREEN control: an access intent
+// relayed through a local variable must NOT be flagged (the def-use arm is
+// enrollment-specific, not "any relayed TokenIntent").
+func MakeAccessTokenViaVar() (string, error) {
+	intent := auth.TokenIntentAccess
+	return iss.Issue(intent, "real-user-var", auth.IssueOptions{})
 }

--- a/tools/archtest/internal/enrollmentcredentialfixture/fixture.go
+++ b/tools/archtest/internal/enrollmentcredentialfixture/fixture.go
@@ -1,0 +1,46 @@
+//go:build archtest_fixture
+
+// Package enrollmentcredentialfixture provides a deliberate RED fixture for the
+// ENROLLMENT-CREDENTIAL-MINT-CALLER-01 archtest. Loaded only under the
+// archtest_fixture build tag (the tag literal must agree with the unexported
+// fixtureBuildTag const in tools/archtest/fixture.go; Go build directives cannot
+// reference a Go const). The tag excludes this package from `go build ./...` /
+// `go test ./...`, so it never pollutes real-repo scans and is never executed
+// (the nil *auth.JWTIssuer is only type-checked, never dereferenced).
+//
+// # Cases covered
+//
+// The funnel pins every production (*auth.JWTIssuer).Issue(TokenIntentEnrollment,
+// ...) call to the sole sanctioned issuer (EnrollmentCredentialIssuer.Issue). The
+// RED case mints an enrollment credential from another package; the GREEN control
+// proves the detector is enrollment-intent-specific (it does not flag every Issue).
+//
+// RED (MUST be flagged):
+//   - ForgeEnrollmentCredential — (*auth.JWTIssuer).Issue(auth.TokenIntentEnrollment, ...)
+//     outside enrollment_credential.go, bypassing the wrapper's policy enforcement.
+//
+// GREEN (MUST NOT be flagged):
+//   - MakeAccessToken — (*auth.JWTIssuer).Issue(auth.TokenIntentAccess, ...); proves
+//     the detector is scoped to the enrollment intent, not "any Issue call".
+package enrollmentcredentialfixture
+
+import "github.com/ghbvf/gocell/framework/runtime/auth"
+
+// iss is a nil issuer used only for type-checking; the fixture is never executed.
+var iss *auth.JWTIssuer
+
+// ForgeEnrollmentCredential is the RED case: an enrollment credential minted via a
+// bare (*auth.JWTIssuer).Issue outside the sanctioned EnrollmentCredentialIssuer.
+// The funnel archtest must flag this callsite.
+func ForgeEnrollmentCredential() (string, error) {
+	return iss.Issue(auth.TokenIntentEnrollment, "forged-device", auth.IssueOptions{
+		PrincipalKind: auth.PrincipalKindClaimDevice,
+		TenantID:      "11111111-1111-1111-1111-111111111111",
+	})
+}
+
+// MakeAccessToken is the GREEN control: an ordinary access token, which the
+// detector must NOT flag.
+func MakeAccessToken() (string, error) {
+	return iss.Issue(auth.TokenIntentAccess, "real-user", auth.IssueOptions{})
+}


### PR DESCRIPTION
## Summary

新增框架层 **enrollment-credential scheme**（签发器 + 验证器）：设备首次 EST enroll 用专用短期 device-scoped 签名 JWT 鉴权，不复用 setup bootstrap token（FR-012）。

## Why / 背景

device principal issuer 已落地（#1811），但设备**首次** EST `/simpleenroll`（无证书时）的鉴权凭据签发缺失，示例 PR-2 只能用「最简 enrollment token 占位，标注等本 issue」。

FR-012 要求 EST 首次 enroll 用**专用 enrollment-credential scheme**、缺鉴权 fail-closed，且**不复用** setup `auth.bootstrap:true`（FMT-28 限其只在 `^/api/v\d+/[^/]+/setup/admin$`，EST 非该路径）。本 PR 交付该框架原语，让 G2（EST 前端）与示例 PR-2 有真正可依赖的 scheme。

**核心设计**：enrollment-credential = 带专用 `TokenIntentEnrollment`（typ `enroll+jwt` + `token_use=enrollment`）的短期（5min）device-scoped RS256 JWT，复用既有 `JWTIssuer`/`JWTVerifier`。双通道 token-confusion 防御（typ 头 + token_use claim 交叉校验，已实现）使「enrollment 凭据不能当 access token 用、反之亦然」成为**类型/密码学事实** —— 即 FR-012「专用 scheme 不复用」，无需运行时策略。对标 step-ca JWK provisioner token / SPIRE join token / RFC 7030 §3.2.3。

**实现要点**：
- `TokenIntentEnrollment` 枚举 + `enroll+jwt` typ 双向映射。
- `EnrollmentCredentialIssuer`（唯一 mint 出口：短 TTL 内层 issuer + 强制 `principal_kind=device` + 随机 `jti` + 非空 tenant/subject fail-closed）。
- sealed `EnrollmentIdentity`（全 unexported 字段 + 唯一构造器拒空 → 包外不可伪造可用身份 = Hard）。
- `EnrollmentCredentialVerifier`（`VerifyIntent(…,TokenIntentEnrollment)` + device 断言 + 构造器拒空 fail-closed）。
- archtest `ENROLLMENT-CREDENTIAL-MINT-CALLER-01`（mint funnel，上游 Medium 同 `COMMAND-ASYNC-EMIT-CALLER-01` Go 天花板）+ RED/GREEN fixture。

严格 TDD：RED commit（panic 骨架 + 全测试）→ GREEN commit（实现转绿）。

## Refs

- Closes #2303 · Epic #2299 G4 · 规划单源 `docs/plans/202606172304-048-mdm-example-cell-epic-plan.md`（G4）· spec FR-012 `docs/plans/specs/1895-device-identity-cert-framework/spec.md`
- ADR 威胁矩阵重评：`docs/architecture/202606121500-1895-adr-device-cert-framework-pivot.md`（Amendment 2026-06-18）
- ref: smallstep/certificates JWK provisioner token；spiffe/spire node join token；RFC 7030 §3.2.3；RFC 8725 §3.11

## Risk / 兼容性

- **无契约扇出**：纯框架 Go 原语，无 contract.yaml / generated / event / command / `auth.Route` 改动 —— reviewer 无需期待 FMT-28 / serving-scan 触碰。
- `TokenIntent` 枚举新增值：纯加性，`IsValid` 改 switch；无 exhaustive-switch 消费方破坏（仅 `IsValid`/`TypHeaderForIntent`/`intentForJWTTyp` 三处 switch，均已更新；其余消费方均为 `TokenIntentAccess` 显式调用）。
- **归 G2/PR-8b（本 PR OUT）**：EST 端点（`runtime/http/est`）+ `auth.Route` scheme 声明；`EnrollmentIdentity → certsigning.EnrollmentClaim` 适配器（避免 auth↔certsigning 互 import 分层陷阱）；**一次性/replay**（jti 账本/nonce —— 本 PR 已写入随机 jti + `EnrollmentIdentity.JTI()` 前向 hook，消费需 enroll 请求上下文）。

## Test plan

- [x] `go build ./...` 本地通过（framework + corecells/cellmodules/cmd/examples/tools 消费方）
- [x] `go test ./runtime/... ./kernel/auth/...` 本地通过（新增 table-driven：签发/验证往返、非复用双向、fail-closed 空 tenant/subject/非 device/过期、构造器拒空、kernel IsValid）
- [x] `go test -tags=archtest ./tools/archtest/ -run TestEnrollmentCredentialMintCaller01` 通过（funnel + RED fixture 自检）
- [x] `golangci-lint run ./...` 0 issues
