### PR TITLE
feat(registrycore): #2236 contract_registrations 表 + PG store（L1 事务 + append-only 历史）[303-US5]

### DIFF
--- a/adapters/postgres/appendonly_serving_role_integration_test.go
+++ b/adapters/postgres/appendonly_serving_role_integration_test.go
@@ -1,0 +1,47 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// servingRoleName / servingRolePassword identify the CLUSTER-GLOBAL gocell_app
+// serving role shared by every *_appendonly test. The role is cluster-global, and
+// CREATE ROLE ... IF NOT EXISTS does NOT update an existing role's password, so all
+// these tests MUST agree on one password — provisionServingRole is the single
+// source so they cannot drift (a mismatch fails SASL auth, SQLSTATE 28P01).
+const (
+	servingRoleName = "gocell_app"
+	//nolint:gosec // G101 false positive: a test-only password for an ephemeral
+	// test-scoped PG role in a throwaway testcontainer, not a real credential.
+	servingRolePassword = "gocell_app_appendonly_testkey"
+)
+
+// provisionServingRole reproduces deploy/postgres/init/10-restricted-role.sh
+// ordering: it idempotently creates the gocell_app serving role (NOSUPERUSER
+// NOBYPASSRLS) and grants it the default DML on future tables in owner's database
+// — BEFORE migrations run, so an append-only table is born with UPDATE/DELETE that
+// the migration's REVOKE then removes. ALTER DEFAULT PRIVILEGES (no FOR ROLE)
+// targets the current migrating role, matching deploy where the table owner grants
+// to gocell_app. Shared by the projection_events and contract_registration_events
+// append-only tests.
+func provisionServingRole(t *testing.T, ctx context.Context, owner *Pool) {
+	t.Helper()
+	stmts := []string{
+		`DO $$ BEGIN
+		   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '` + servingRoleName + `') THEN
+		     CREATE ROLE ` + servingRoleName + ` LOGIN PASSWORD '` + servingRolePassword + `' NOSUPERUSER NOBYPASSRLS;
+		   END IF;
+		 END $$;`,
+		`GRANT USAGE ON SCHEMA public TO ` + servingRoleName,
+		`ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO ` + servingRoleName,
+	}
+	for _, s := range stmts {
+		_, err := owner.DB().Exec(ctx, s)
+		require.NoErrorf(t, err, "provision serving role\nstmt: %s", s)
+	}
+}

--- a/adapters/postgres/contract_registration_events_appendonly_integration_test.go
+++ b/adapters/postgres/contract_registration_events_appendonly_integration_test.go
@@ -1,0 +1,88 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestContractRegistrationEvents_AppendOnly_ServingRoleRevoked is the regression
+// guard for the 303-US5 (#2236) append-only migration-history invariant: the
+// serving role must never UPDATE or DELETE contract_registration_events. The
+// guard is the DB-engine REVOKE in migration 066 (unbypassable); this test proves
+// the REVOKE fires after a re-grant of the deploy default privileges, and that the
+// projection table contract_registrations stays mutable (state transitions UPDATE
+// it). Mirrors TestProjectionEvents_AppendOnly_ServingRoleRevoked (migration 058).
+//
+// Not parallel: it provisions the cluster-global gocell_app role + per-DB default
+// privileges.
+func TestContractRegistrationEvents_AppendOnly_ServingRoleRevoked(t *testing.T) {
+	ctx := context.Background()
+	const (
+		appRole = "gocell_app"
+		appPass = "contractreg_appkey"
+	)
+
+	dsn := sharedPG.EmptyDSN(t)
+	owner := openPerTestPool(t, dsn)
+
+	// Reproduce 10-restricted-role.sh ordering: role + default DML grant BEFORE
+	// migrations, so the history table is born with UPDATE/DELETE for gocell_app
+	// and migration 066's REVOKE has something to remove.
+	provision := []string{
+		`DO $$ BEGIN
+		   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '` + appRole + `') THEN
+		     CREATE ROLE ` + appRole + ` LOGIN PASSWORD '` + appPass + `' NOSUPERUSER NOBYPASSRLS;
+		   END IF;
+		 END $$;`,
+		`GRANT USAGE ON SCHEMA public TO ` + appRole,
+		`ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO ` + appRole,
+	}
+	for _, s := range provision {
+		_, err := owner.DB().Exec(ctx, s)
+		require.NoErrorf(t, err, "provision serving role\nstmt: %s", s)
+	}
+
+	fsys, err := MigrationsFS()
+	require.NoError(t, err)
+	migrator, err := newMigratorForTable(owner, fsys, "schema_migrations")
+	require.NoError(t, err)
+	defer func() { _ = migrator.Close() }()
+	require.NoError(t, migrator.Up(ctx), "migrate up")
+
+	// Static assertion: append-only on the history table; mutable projection.
+	var evSelect, evInsert, evUpdate, evDelete, projUpdate bool
+	require.NoError(t, owner.DB().QueryRow(ctx,
+		`SELECT has_table_privilege($1, 'contract_registration_events', 'SELECT'),
+		        has_table_privilege($1, 'contract_registration_events', 'INSERT'),
+		        has_table_privilege($1, 'contract_registration_events', 'UPDATE'),
+		        has_table_privilege($1, 'contract_registration_events', 'DELETE'),
+		        has_table_privilege($1, 'contract_registrations', 'UPDATE')`,
+		appRole).Scan(&evSelect, &evInsert, &evUpdate, &evDelete, &projUpdate))
+	assert.True(t, evSelect, "serving role must keep SELECT on the history (replay/read)")
+	assert.True(t, evInsert, "serving role must keep INSERT on the history (append)")
+	assert.False(t, evUpdate, "append-only: serving role UPDATE on history must be revoked (066)")
+	assert.False(t, evDelete, "append-only: serving role DELETE on history must be revoked (066)")
+	assert.True(t, projUpdate, "projection contract_registrations must stay mutable (state transitions UPDATE it)")
+
+	// Behavioral assertion: connect AS gocell_app and prove it at the wire.
+	app, err := NewPool(ctx, Config{DSN: swapUserInDSN(t, dsn, appRole, appPass)})
+	require.NoError(t, err, "open serving-role pool")
+	defer func() { _ = app.Close(ctx) }()
+
+	_, err = app.DB().Exec(ctx,
+		`INSERT INTO contract_registration_events
+		   (tenant_id, registration_id, seq, from_state, to_state, actor, reason, occurred_at)
+		 VALUES ('00000000-0000-0000-0000-000000000001', 'evt-ao-1', 1, '', 'submitted', 'alice', '', now())`)
+	require.NoError(t, err, "serving role must be able to append (INSERT)")
+
+	_, err = app.DB().Exec(ctx, `UPDATE contract_registration_events SET actor = 'mutated' WHERE registration_id = 'evt-ao-1'`)
+	assertInsufficientPrivilege(t, err, "UPDATE")
+
+	_, err = app.DB().Exec(ctx, `DELETE FROM contract_registration_events WHERE registration_id = 'evt-ao-1'`)
+	assertInsufficientPrivilege(t, err, "DELETE")
+}

--- a/adapters/postgres/contract_registration_events_appendonly_integration_test.go
+++ b/adapters/postgres/contract_registration_events_appendonly_integration_test.go
@@ -22,34 +22,13 @@ import (
 // privileges.
 func TestContractRegistrationEvents_AppendOnly_ServingRoleRevoked(t *testing.T) {
 	ctx := context.Background()
-	const (
-		appRole = "gocell_app"
-		// gocell_app is a CLUSTER-GLOBAL role shared with the other *_appendonly
-		// tests (e.g. projection_events). CREATE ROLE ... IF NOT EXISTS does NOT
-		// update an existing role's password, so all such tests MUST use the same
-		// password or whichever runs second fails SASL auth (28P01). Keep in sync.
-		appPass = "projevents_appkey"
-	)
 
 	dsn := sharedPG.EmptyDSN(t)
 	owner := openPerTestPool(t, dsn)
 
-	// Reproduce 10-restricted-role.sh ordering: role + default DML grant BEFORE
-	// migrations, so the history table is born with UPDATE/DELETE for gocell_app
-	// and migration 066's REVOKE has something to remove.
-	provision := []string{
-		`DO $$ BEGIN
-		   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '` + appRole + `') THEN
-		     CREATE ROLE ` + appRole + ` LOGIN PASSWORD '` + appPass + `' NOSUPERUSER NOBYPASSRLS;
-		   END IF;
-		 END $$;`,
-		`GRANT USAGE ON SCHEMA public TO ` + appRole,
-		`ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO ` + appRole,
-	}
-	for _, s := range provision {
-		_, err := owner.DB().Exec(ctx, s)
-		require.NoErrorf(t, err, "provision serving role\nstmt: %s", s)
-	}
+	// Provision the shared serving role + default DML grant BEFORE migrations, so the
+	// history table is born with UPDATE/DELETE that migration 066's REVOKE removes.
+	provisionServingRole(t, ctx, owner)
 
 	fsys, err := MigrationsFS()
 	require.NoError(t, err)
@@ -67,7 +46,7 @@ func TestContractRegistrationEvents_AppendOnly_ServingRoleRevoked(t *testing.T) 
 		        has_table_privilege($1, 'contract_registration_events', 'DELETE'),
 		        has_table_privilege($1, 'contract_registration_events', 'TRUNCATE'),
 		        has_table_privilege($1, 'contract_registrations', 'UPDATE')`,
-		appRole).Scan(&evSelect, &evInsert, &evUpdate, &evDelete, &evTruncate, &projUpdate))
+		servingRoleName).Scan(&evSelect, &evInsert, &evUpdate, &evDelete, &evTruncate, &projUpdate))
 	assert.True(t, evSelect, "serving role must keep SELECT on the history (replay/read)")
 	assert.True(t, evInsert, "serving role must keep INSERT on the history (append)")
 	assert.False(t, evUpdate, "append-only: serving role UPDATE on history must be revoked (066)")
@@ -77,7 +56,7 @@ func TestContractRegistrationEvents_AppendOnly_ServingRoleRevoked(t *testing.T) 
 
 	// Behavioral assertion: connect AS gocell_app (NOSUPERUSER NOBYPASSRLS) and
 	// prove append-only at the wire.
-	app, err := NewPool(ctx, Config{DSN: swapUserInDSN(t, dsn, appRole, appPass)})
+	app, err := NewPool(ctx, Config{DSN: swapUserInDSN(t, dsn, servingRoleName, servingRolePassword)})
 	require.NoError(t, err, "open serving-role pool")
 	defer func() { _ = app.Close(ctx) }()
 

--- a/adapters/postgres/contract_registration_events_appendonly_integration_test.go
+++ b/adapters/postgres/contract_registration_events_appendonly_integration_test.go
@@ -24,7 +24,11 @@ func TestContractRegistrationEvents_AppendOnly_ServingRoleRevoked(t *testing.T) 
 	ctx := context.Background()
 	const (
 		appRole = "gocell_app"
-		appPass = "contractreg_appkey"
+		// gocell_app is a CLUSTER-GLOBAL role shared with the other *_appendonly
+		// tests (e.g. projection_events). CREATE ROLE ... IF NOT EXISTS does NOT
+		// update an existing role's password, so all such tests MUST use the same
+		// password or whichever runs second fails SASL auth (28P01). Keep in sync.
+		appPass = "projevents_appkey"
 	)
 
 	dsn := sharedPG.EmptyDSN(t)

--- a/adapters/postgres/contract_registration_events_appendonly_integration_test.go
+++ b/adapters/postgres/contract_registration_events_appendonly_integration_test.go
@@ -55,34 +55,53 @@ func TestContractRegistrationEvents_AppendOnly_ServingRoleRevoked(t *testing.T) 
 	require.NoError(t, migrator.Up(ctx), "migrate up")
 
 	// Static assertion: append-only on the history table; mutable projection.
-	var evSelect, evInsert, evUpdate, evDelete, projUpdate bool
+	var evSelect, evInsert, evUpdate, evDelete, evTruncate, projUpdate bool
 	require.NoError(t, owner.DB().QueryRow(ctx,
 		`SELECT has_table_privilege($1, 'contract_registration_events', 'SELECT'),
 		        has_table_privilege($1, 'contract_registration_events', 'INSERT'),
 		        has_table_privilege($1, 'contract_registration_events', 'UPDATE'),
 		        has_table_privilege($1, 'contract_registration_events', 'DELETE'),
+		        has_table_privilege($1, 'contract_registration_events', 'TRUNCATE'),
 		        has_table_privilege($1, 'contract_registrations', 'UPDATE')`,
-		appRole).Scan(&evSelect, &evInsert, &evUpdate, &evDelete, &projUpdate))
+		appRole).Scan(&evSelect, &evInsert, &evUpdate, &evDelete, &evTruncate, &projUpdate))
 	assert.True(t, evSelect, "serving role must keep SELECT on the history (replay/read)")
 	assert.True(t, evInsert, "serving role must keep INSERT on the history (append)")
 	assert.False(t, evUpdate, "append-only: serving role UPDATE on history must be revoked (066)")
 	assert.False(t, evDelete, "append-only: serving role DELETE on history must be revoked (066)")
+	assert.False(t, evTruncate, "append-only: serving role must never hold TRUNCATE on history")
 	assert.True(t, projUpdate, "projection contract_registrations must stay mutable (state transitions UPDATE it)")
 
-	// Behavioral assertion: connect AS gocell_app and prove it at the wire.
+	// Behavioral assertion: connect AS gocell_app (NOSUPERUSER NOBYPASSRLS) and
+	// prove append-only at the wire.
 	app, err := NewPool(ctx, Config{DSN: swapUserInDSN(t, dsn, appRole, appPass)})
 	require.NoError(t, err, "open serving-role pool")
 	defer func() { _ = app.Close(ctx) }()
 
-	_, err = app.DB().Exec(ctx,
+	const tenantA = "00000000-0000-0000-0000-000000000001"
+	// The INSERT must satisfy FORCE ROW LEVEL SECURITY WITH CHECK (tenant_isolation),
+	// so set the tenant GUC for the inserting transaction (SET LOCAL is tx-scoped).
+	// Unlike projection_events (no RLS), this table is tenant-scoped — a bare INSERT
+	// with an unset GUC is correctly rejected by RLS.
+	appTx, err := app.DB().Begin(ctx)
+	require.NoError(t, err)
+	_, err = appTx.Exec(ctx, `SET LOCAL app.tenant_id = '`+tenantA+`'`)
+	require.NoError(t, err)
+	_, err = appTx.Exec(ctx,
 		`INSERT INTO contract_registration_events
 		   (tenant_id, registration_id, seq, from_state, to_state, actor, reason, occurred_at)
-		 VALUES ('00000000-0000-0000-0000-000000000001', 'evt-ao-1', 1, '', 'submitted', 'alice', '', now())`)
-	require.NoError(t, err, "serving role must be able to append (INSERT)")
+		 VALUES ($1, 'evt-ao-1', 1, '', 'submitted', 'alice', '', now())`, tenantA)
+	require.NoError(t, err, "serving role must be able to append (INSERT) within its tenant scope")
+	require.NoError(t, appTx.Commit(ctx))
 
+	// UPDATE / DELETE / TRUNCATE are denied at the privilege layer (SQLSTATE 42501,
+	// evaluated before RLS, so no GUC needed): UPDATE/DELETE by migration-066 REVOKE,
+	// TRUNCATE because it is never default-granted to the serving role.
 	_, err = app.DB().Exec(ctx, `UPDATE contract_registration_events SET actor = 'mutated' WHERE registration_id = 'evt-ao-1'`)
 	assertInsufficientPrivilege(t, err, "UPDATE")
 
 	_, err = app.DB().Exec(ctx, `DELETE FROM contract_registration_events WHERE registration_id = 'evt-ao-1'`)
 	assertInsufficientPrivilege(t, err, "DELETE")
+
+	_, err = app.DB().Exec(ctx, `TRUNCATE contract_registration_events`)
+	assertInsufficientPrivilege(t, err, "TRUNCATE")
 }

--- a/adapters/postgres/contract_registrations_rls_integration_test.go
+++ b/adapters/postgres/contract_registrations_rls_integration_test.go
@@ -1,0 +1,85 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestContractRegistrations_RLS_TenantIsolation_ServingRole proves the migration-066
+// FORCE ROW LEVEL SECURITY + tenant_isolation policy actually isolates at runtime —
+// not just that the policy shape exists (that is schema_guard's static job). It runs
+// AS the restricted gocell_app serving role (NOSUPERUSER NOBYPASSRLS), where RLS is
+// effective, unlike the superuser/owner pool used by the cell repo integration tests.
+//
+// This is the read-side complement to the #2236 review finding F1: a tenant-scoped
+// read MUST run with the app.tenant_id GUC set (a tenant-scoped tx) — an UNSCOPED
+// read fail-closes to 0 rows under FORCE RLS, and an unscoped INSERT is rejected by
+// WITH CHECK. (The production read-scoping funnel — wrapping repo reads in
+// tenant.WithScope + RunInTx, à la configcore/internal/scopedread — is wired in US6;
+// this test pins the DB-engine guarantee the funnel rests on.)
+//
+// Not parallel: provisions the cluster-global gocell_app role.
+func TestContractRegistrations_RLS_TenantIsolation_ServingRole(t *testing.T) {
+	ctx := context.Background()
+	const (
+		tenantA = "00000000-0000-0000-0000-000000000001"
+		tenantB = "00000000-0000-0000-0000-000000000002"
+	)
+
+	dsn := sharedPG.EmptyDSN(t)
+	owner := openPerTestPool(t, dsn)
+	provisionServingRole(t, ctx, owner)
+
+	fsys, err := MigrationsFS()
+	require.NoError(t, err)
+	migrator, err := newMigratorForTable(owner, fsys, "schema_migrations")
+	require.NoError(t, err)
+	defer func() { _ = migrator.Close() }()
+	require.NoError(t, migrator.Up(ctx), "migrate up")
+
+	app, err := NewPool(ctx, Config{DSN: swapUserInDSN(t, dsn, servingRoleName, servingRolePassword)})
+	require.NoError(t, err, "open serving-role pool")
+	defer func() { _ = app.Close(ctx) }()
+
+	// Scoped write under tenant A: SET LOCAL app.tenant_id satisfies WITH CHECK.
+	txA, err := app.DB().Begin(ctx)
+	require.NoError(t, err)
+	_, err = txA.Exec(ctx, `SET LOCAL app.tenant_id = '`+tenantA+`'`)
+	require.NoError(t, err)
+	_, err = txA.Exec(ctx,
+		`INSERT INTO contract_registrations (tenant_id, id, kind, submitter, state, created_at, updated_at)
+		 VALUES ($1, 'r1', 'http', 'alice', 'submitted', now(), now())`, tenantA)
+	require.NoError(t, err, "scoped INSERT under own tenant must satisfy WITH CHECK")
+	var scopedCount int
+	require.NoError(t, txA.QueryRow(ctx, `SELECT count(*) FROM contract_registrations`).Scan(&scopedCount))
+	assert.Equal(t, 1, scopedCount, "scoped read under own tenant sees the row")
+	require.NoError(t, txA.Commit(ctx))
+
+	// Unscoped read (no GUC) → FORCE RLS fail-closes to 0 rows (USING predicate
+	// evaluates tenant_id = NULL). This is exactly the F1 hazard: a bare-pool read
+	// returns empty under the restricted role.
+	var unscopedCount int
+	require.NoError(t, app.DB().QueryRow(ctx, `SELECT count(*) FROM contract_registrations`).Scan(&unscopedCount))
+	assert.Equal(t, 0, unscopedCount, "unscoped read (GUC unset) must fail-close to 0 rows under FORCE RLS")
+
+	// Cross-tenant scoped read (tenant B) → 0 rows (tenant_isolation).
+	txB, err := app.DB().Begin(ctx)
+	require.NoError(t, err)
+	_, err = txB.Exec(ctx, `SET LOCAL app.tenant_id = '`+tenantB+`'`)
+	require.NoError(t, err)
+	var crossCount int
+	require.NoError(t, txB.QueryRow(ctx, `SELECT count(*) FROM contract_registrations`).Scan(&crossCount))
+	assert.Equal(t, 0, crossCount, "tenant B must not see tenant A's registration")
+	require.NoError(t, txB.Rollback(ctx))
+
+	// Unscoped INSERT → rejected by WITH CHECK (tenant_id = NULL).
+	_, err = app.DB().Exec(ctx,
+		`INSERT INTO contract_registrations (tenant_id, id, kind, submitter, state, created_at, updated_at)
+		 VALUES ($1, 'r2', 'http', 'bob', 'submitted', now(), now())`, tenantA)
+	require.Error(t, err, "unscoped INSERT (GUC unset) must be rejected by FORCE RLS WITH CHECK")
+}

--- a/adapters/postgres/migrations/066_create_contract_registrations.sql
+++ b/adapters/postgres/migrations/066_create_contract_registrations.sql
@@ -1,0 +1,110 @@
+-- Migration 066: create contract_registrations (+ contract_registration_events)
+-- — the durable store for the runtime contract registry (303-US5, #2236). Until
+-- now the registrycore cell backed submit/list with the in-mem kernel
+-- registry.ContractRegistrar (US4 #2235), which persists nothing. This adds the
+-- PG-backed store behind ports.Registry (the in-mem implementation conforms to the
+-- same contract).
+--
+-- Two-table shape mirrors the kernel's two-truth model:
+--   * contract_registrations         — projection of the CURRENT state per
+--     registration (mutable: state/approver/updated_at advance on each
+--     transition). One row per (tenant_id, id).
+--   * contract_registration_events   — the APPEND-ONLY migration history (source
+--     of truth). One row per state transition; seq is 1-based contiguous per
+--     registration. from_state = '' is the zero sentinel of the initial submit
+--     event (folding from '' reproduces the lifecycle). Never UPDATEd/DELETEd.
+--
+-- payload_schema is an opaque schema reference/hash recorded at submit (the
+-- kernel does not interpret it) — TEXT, not JSONB.
+--
+-- Tenancy: tenant_id TEXT NOT NULL (canonical lowercase UUID at the app layer,
+-- migration-050 convention). A registration id is unique only within a tenant, so
+-- the composite PRIMARY KEY (tenant_id, id) — and (tenant_id, registration_id, seq)
+-- for the history — covers Get (full PK), List (PK-prefix range scan
+-- `WHERE tenant_id=$1 AND id > $2 ORDER BY id`) and History (PK-prefix
+-- `WHERE tenant_id=$1 AND registration_id=$2 ORDER BY seq`), so NO secondary index
+-- is added (same rationale as migration 059). FORCE ROW LEVEL SECURITY + the
+-- tenant_isolation policy give the DB-kernel backstop: the predicate
+-- `tenant_id = NULLIF(current_setting('app.tenant_id', true), '')` yields 0 rows
+-- visible AND 0 rows insertable when the GUC is unset (fail-closed), the same shape
+-- as policies/users/roles (migrations 059/053).
+--
+-- Append-only enforcement (history table): the serving role gocell_app must never
+-- UPDATE or DELETE contract_registration_events — the DB engine, not application
+-- discipline, is the unbypassable guard. deploy/postgres/init/10-restricted-role.sh
+-- runs BEFORE migrations and default-grants gocell_app SELECT/INSERT/UPDATE/DELETE
+-- on every future table, so this table is born with the two destructive privileges;
+-- revoke them here. The role keeps SELECT (replay/History read) + INSERT (the
+-- same-transaction append). The projection table stays fully mutable (transitions
+-- UPDATE state/approver). The IF EXISTS guard makes the REVOKE a no-op where
+-- gocell_app is not provisioned (dev/memory mode, template-build migration in
+-- testmain). Mirrors migration 058 (projection_events).
+--
+-- [F-B11] DEPLOYMENT REQUIREMENT (provisioning, not schema): the application PG
+-- role MUST NOT own these tables AND MUST NOT have BYPASSRLS (or be superuser).
+-- FORCE ROW LEVEL SECURITY applies RLS even to the table OWNER, but a
+-- BYPASSRLS/superuser role still bypasses ALL row security. Same as migration 059.
+--
+-- Non-destructive DDL (CREATE TABLE / ENABLE / FORCE / CREATE POLICY / REVOKE add
+-- no column, drop nothing, rewrite no row): NO `+gocell forward-rebuild` annotation
+-- and NO Go destructive permit. The Down section is a true reversible rollback.
+--
+-- ref: adapters/postgres/migrations/059_create_policies.sql (tenant_id + FORCE RLS shape, copied)
+-- ref: adapters/postgres/migrations/058_create_projection_events.sql (append-only REVOKE shape, copied)
+-- ref: confluent/schema-registry (append-only log) · pact-foundation/pact (immutable verification record)
+
+-- +goose Up
+
+CREATE TABLE contract_registrations (
+    tenant_id      TEXT        NOT NULL,
+    id             TEXT        NOT NULL,
+    kind           TEXT        NOT NULL,
+    payload_schema TEXT        NOT NULL DEFAULT '',
+    submitter      TEXT        NOT NULL,
+    approver       TEXT        NOT NULL DEFAULT '',
+    state          TEXT        NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL,
+    updated_at     TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, id)
+);
+
+ALTER TABLE contract_registrations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE contract_registrations FORCE  ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON contract_registrations
+    USING      (tenant_id = NULLIF(current_setting('app.tenant_id', true), ''))
+    WITH CHECK (tenant_id = NULLIF(current_setting('app.tenant_id', true), ''));
+
+CREATE TABLE contract_registration_events (
+    tenant_id       TEXT        NOT NULL,
+    registration_id TEXT        NOT NULL,
+    seq             INTEGER     NOT NULL,
+    from_state      TEXT        NOT NULL DEFAULT '',
+    to_state        TEXT        NOT NULL,
+    actor           TEXT        NOT NULL,
+    reason          TEXT        NOT NULL DEFAULT '',
+    occurred_at     TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, registration_id, seq)
+);
+
+ALTER TABLE contract_registration_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE contract_registration_events FORCE  ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON contract_registration_events
+    USING      (tenant_id = NULLIF(current_setting('app.tenant_id', true), ''))
+    WITH CHECK (tenant_id = NULLIF(current_setting('app.tenant_id', true), ''));
+
+-- Append-only enforcement at the DB-engine layer for the history table. No-op
+-- where gocell_app is absent (dev/memory/template); real REVOKE in deploy/e2e.
+-- +goose StatementBegin
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'gocell_app') THEN
+    REVOKE UPDATE, DELETE ON contract_registration_events FROM gocell_app;
+  END IF;
+END $$;
+-- +goose StatementEnd
+
+-- +goose Down
+-- Reversible: 066 INTRODUCES both tables, so DROP TABLE removes each tenant_isolation
+-- policy and the RLS flags atomically with it. No pre-existing data is affected.
+DROP TABLE IF EXISTS contract_registration_events;
+DROP TABLE IF EXISTS contract_registrations;

--- a/adapters/postgres/projection_events_appendonly_integration_test.go
+++ b/adapters/postgres/projection_events_appendonly_integration_test.go
@@ -28,33 +28,14 @@ import (
 // privileges.
 func TestProjectionEvents_AppendOnly_ServingRoleRevoked(t *testing.T) {
 	ctx := context.Background()
-	const (
-		appRole = "gocell_app"
-		appPass = "projevents_appkey"
-	)
 
 	// Fresh empty DB; the pool connects as the owning/migrating superuser.
 	dsn := sharedPG.EmptyDSN(t)
 	owner := openPerTestPool(t, dsn)
 
-	// Reproduce 10-restricted-role.sh ordering: role + default DML grant BEFORE
-	// migrations, so projection_events is born with UPDATE/DELETE for gocell_app
-	// and migration 058's REVOKE has something to remove. ALTER DEFAULT PRIVILEGES
-	// (no FOR ROLE) targets the current migrating role, matching deploy where the
-	// table owner grants to gocell_app.
-	provision := []string{
-		`DO $$ BEGIN
-		   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '` + appRole + `') THEN
-		     CREATE ROLE ` + appRole + ` LOGIN PASSWORD '` + appPass + `' NOSUPERUSER NOBYPASSRLS;
-		   END IF;
-		 END $$;`,
-		`GRANT USAGE ON SCHEMA public TO ` + appRole,
-		`ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO ` + appRole,
-	}
-	for _, s := range provision {
-		_, err := owner.DB().Exec(ctx, s)
-		require.NoErrorf(t, err, "provision serving role\nstmt: %s", s)
-	}
+	// Provision the shared serving role + default DML grant BEFORE migrations, so
+	// projection_events is born with UPDATE/DELETE that migration 058's REVOKE removes.
+	provisionServingRole(t, ctx, owner)
 
 	// Run the full platform migration set (058 creates projection_events and, with
 	// gocell_app present, revokes UPDATE/DELETE).
@@ -72,7 +53,7 @@ func TestProjectionEvents_AppendOnly_ServingRoleRevoked(t *testing.T) {
 		        has_table_privilege($1, 'projection_events', 'INSERT'),
 		        has_table_privilege($1, 'projection_events', 'UPDATE'),
 		        has_table_privilege($1, 'projection_events', 'DELETE')`,
-		appRole).Scan(&canSelect, &canInsert, &canUpdate, &canDelete))
+		servingRoleName).Scan(&canSelect, &canInsert, &canUpdate, &canDelete))
 	assert.True(t, canSelect, "serving role must keep SELECT (replay/Position read)")
 	assert.True(t, canInsert, "serving role must keep INSERT (same-tx journaling writer)")
 	assert.False(t, canUpdate, "append-only: serving role UPDATE must be revoked (058)")
@@ -80,7 +61,7 @@ func TestProjectionEvents_AppendOnly_ServingRoleRevoked(t *testing.T) {
 
 	// Behavioral assertion: connect AS gocell_app and prove it at the wire — INSERT
 	// succeeds, UPDATE/DELETE are denied by the engine (42501 insufficient_privilege).
-	app, err := NewPool(ctx, Config{DSN: swapUserInDSN(t, dsn, appRole, appPass)})
+	app, err := NewPool(ctx, Config{DSN: swapUserInDSN(t, dsn, servingRoleName, servingRolePassword)})
 	require.NoError(t, err, "open serving-role pool")
 	defer func() { _ = app.Close(ctx) }()
 

--- a/adapters/postgres/schema_guard.go
+++ b/adapters/postgres/schema_guard.go
@@ -721,6 +721,29 @@ var expectedColumns = []expectedColumn{
 	{Table: "webhook_sources", Column: "value_nonce", Type: "bytea", NotNull: false},
 	{Table: "webhook_sources", Column: "created_at", Type: pgTypeTSTZ, NotNull: true},
 	{Table: "webhook_sources", Column: "updated_at", Type: pgTypeTSTZ, NotNull: true},
+	// contract_registrations + contract_registration_events (066, #2236 303-US5).
+	// The runtime contract-registry store: registering the full load-bearing column
+	// shape (the colsProjection set the repo SELECTs/INSERTs by name) so a future
+	// migration that drops/retypes a column the repo depends on surfaces at readyz,
+	// not as a runtime scan error. payload_schema is an opaque ref/hash (TEXT, not
+	// JSONB); state/kind are sealed/opaque strings.
+	{Table: "contract_registrations", Column: "tenant_id", Type: "text", NotNull: true},
+	{Table: "contract_registrations", Column: "id", Type: "text", NotNull: true},
+	{Table: "contract_registrations", Column: "kind", Type: "text", NotNull: true},
+	{Table: "contract_registrations", Column: "payload_schema", Type: "text", NotNull: true},
+	{Table: "contract_registrations", Column: "submitter", Type: "text", NotNull: true},
+	{Table: "contract_registrations", Column: "approver", Type: "text", NotNull: true},
+	{Table: "contract_registrations", Column: "state", Type: "text", NotNull: true},
+	{Table: "contract_registrations", Column: "created_at", Type: pgTypeTSTZ, NotNull: true},
+	{Table: "contract_registrations", Column: "updated_at", Type: pgTypeTSTZ, NotNull: true},
+	{Table: "contract_registration_events", Column: "tenant_id", Type: "text", NotNull: true},
+	{Table: "contract_registration_events", Column: "registration_id", Type: "text", NotNull: true},
+	{Table: "contract_registration_events", Column: "seq", Type: "integer", NotNull: true},
+	{Table: "contract_registration_events", Column: "from_state", Type: "text", NotNull: true},
+	{Table: "contract_registration_events", Column: "to_state", Type: "text", NotNull: true},
+	{Table: "contract_registration_events", Column: "actor", Type: "text", NotNull: true},
+	{Table: "contract_registration_events", Column: "reason", Type: "text", NotNull: true},
+	{Table: "contract_registration_events", Column: "occurred_at", Type: pgTypeTSTZ, NotNull: true},
 }
 
 // frozenColumnTables lists tables for which the schema guard enforces an
@@ -781,6 +804,12 @@ var expectedPKs = []expectedPK{
 	// webhook_sources (063_create_webhook_sources.sql): PK on source_id (global,
 	// no tenant — one source identity per deployment).
 	{Table: "webhook_sources", Columns: []string{"source_id"}},
+	// contract_registrations / _events (066, #2236): composite per-tenant PKs — a
+	// registration id is unique only within a tenant, and a history event is keyed
+	// (tenant_id, registration_id, seq). The repo relies on these PKs (Create
+	// dedups via ON CONFLICT (tenant_id, id); the event seq is per-registration).
+	{Table: "contract_registrations", Columns: []string{"tenant_id", "id"}},
+	{Table: "contract_registration_events", Columns: []string{"tenant_id", "registration_id", "seq"}},
 }
 
 // expectedDefaults is the load-bearing column-default registry. Only defaults a
@@ -806,6 +835,12 @@ var expectedDefaults = []expectedDefault{
 	// to fail NOT NULL.
 	{Table: "devices", Column: "cert_epoch", Default: "1"},
 	// devices.renewal_requested_epoch was dropped by 062 (#1820).
+	// contract_registrations.approver (066, #2236) — Create OMITS the approver
+	// column and relies on DEFAULT '' (a submission has no approver until the
+	// pending-approval → approved transition records one). A dropped default would
+	// fail every Create at write time. payload_schema/from_state/reason also default
+	// to '' but the write path supplies them explicitly, so only approver is load-bearing.
+	{Table: "contract_registrations", Column: "approver", Default: "''::text"},
 }
 
 // expectedIndexes covers both unique and non-unique indexes across S3F tables.

--- a/adapters/postgres/schema_guard.go
+++ b/adapters/postgres/schema_guard.go
@@ -1029,6 +1029,13 @@ var expectedRLSTables = []expectedRLS{
 	{Table: "roles", Policy: "tenant_isolation"},
 	{Table: "role_assignments", Policy: "tenant_isolation"},
 	{Table: "policies", Policy: "tenant_isolation"}, // 059 NEW — ABAC policy store (#1346 PR-8)
+	// contract_registrations + its append-only history (migration 066, #2236
+	// 303-US5): runtime contract-registry store. Both tenant-scoped with the
+	// standard tenant_isolation predicate; the history table additionally has
+	// UPDATE/DELETE revoked from gocell_app (append-only, asserted separately by
+	// TestContractRegistrationEvents_AppendOnly_ServingRoleRevoked).
+	{Table: "contract_registrations", Policy: "tenant_isolation"},       // 066 NEW
+	{Table: "contract_registration_events", Policy: "tenant_isolation"}, // 066 NEW
 	// audit_entries (migration 055, #1618): SystemRowsReadable variant — the
 	// `OR tenant_id = ''` clause keeps tenant-less system/framework rows readable
 	// by every tenant AND insertable by the GUC-unset pre-auth appender.

--- a/adapters/postgres/schema_guard_test.go
+++ b/adapters/postgres/schema_guard_test.go
@@ -113,8 +113,12 @@ func TestExpectedVersion_FromEmbedFS(t *testing.T) {
 	// reads (#1810). Both steps are wrapped in IF EXISTS guards — inert where the role
 	// is absent. schema_guard.go verifyRLS expects this second policy ONLY when
 	// gocell_audit_admin is provisioned, preserving the #1622 F1 invariant.
-	assert.Equal(t, int64(65), v,
-		"expected version should be exactly 65 (current migration max — 065_audit_admin_read_role)")
+	// 066 creates contract_registrations + contract_registration_events (runtime
+	// contract registry store, #2236 303-US5): both tenant-scoped under
+	// tenant_isolation; the history table has UPDATE/DELETE revoked from gocell_app
+	// (append-only). Registered in expectedRLSTables (verifyRLS).
+	assert.Equal(t, int64(66), v,
+		"expected version should be exactly 66 (current migration max — 066_create_contract_registrations)")
 }
 
 func TestExpectedVersion_SyntheticFS(t *testing.T) {

--- a/corecells/registrycore/internal/adapters/postgres/registry_repo.go
+++ b/corecells/registrycore/internal/adapters/postgres/registry_repo.go
@@ -1,0 +1,78 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ghbvf/gocell/corecells/registrycore/internal/ports"
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/registry"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/tenant"
+)
+
+// Compile-time check.
+var _ ports.Registry = (*Registry)(nil)
+
+// Registry is the PostgreSQL ports.Registry backed by the contract_registrations
+// projection table and the append-only contract_registration_events history
+// table (migration 066). (Wave 0 RED stub — real SQL lands in Wave 3.)
+//
+// The struct carries either a *Session (production: resolves the ambient tx via
+// persistence.TxCtxKey) or a bare DBTX (test-only: injected by
+// newRegistryFromDBTX), mirroring configcore.
+type Registry struct {
+	db      DBTX     // test-only: set by newRegistryFromDBTX
+	session *Session // production path: resolves ambient tx via persistence.TxCtxKey
+	clk     clock.Clock
+}
+
+// NewRegistry builds the PG registry over pool. clk stamps registration and event
+// timestamps (clock.Clock convention).
+func NewRegistry(pool *pgxpool.Pool, clk clock.Clock) *Registry {
+	clock.MustHaveClock(clk, "registrycore/postgres.NewRegistry")
+	return &Registry{session: NewSession(pool), clk: clk}
+}
+
+// resolveRead returns the DBTX for read paths (ambient tx if present, else pool).
+func (r *Registry) resolveRead(ctx context.Context) DBTX {
+	if r.session != nil {
+		return r.session.resolve(ctx)
+	}
+	return r.db
+}
+
+// resolveWrite returns the DBTX for write paths, requiring an ambient tx in
+// production so the projection + history writes are atomic (L1).
+func (r *Registry) resolveWrite(ctx context.Context) (DBTX, error) {
+	if r.session != nil {
+		return r.session.resolveWrite(ctx)
+	}
+	return r.db, nil
+}
+
+func errStub() error {
+	return errcode.New(errcode.KindInternal, errcode.ErrNotImplemented,
+		"registrycore pg registry: not implemented (Wave 0 RED stub)")
+}
+
+func (r *Registry) Create(context.Context, tenant.TenantID, registry.SubmitInput) (registry.ContractRegistration, error) {
+	return registry.ContractRegistration{}, errStub()
+}
+
+func (r *Registry) Transition(context.Context, tenant.TenantID, registry.AdvanceInput) (registry.ContractRegistration, error) {
+	return registry.ContractRegistration{}, errStub()
+}
+
+func (r *Registry) Get(context.Context, tenant.TenantID, string) (registry.ContractRegistration, bool, error) {
+	return registry.ContractRegistration{}, false, errStub()
+}
+
+func (r *Registry) List(context.Context, tenant.TenantID, string, int) ([]registry.ContractRegistration, error) {
+	return nil, errStub()
+}
+
+func (r *Registry) History(context.Context, tenant.TenantID, string) ([]registry.RegistrationEvent, error) {
+	return nil, errStub()
+}

--- a/corecells/registrycore/internal/adapters/postgres/registry_repo.go
+++ b/corecells/registrycore/internal/adapters/postgres/registry_repo.go
@@ -79,10 +79,12 @@ func (r *Registry) Create(ctx context.Context, t tenant.TenantID, in registry.Su
 	submitted := registry.StateSubmitted()
 	// ON CONFLICT DO NOTHING + RowsAffected detects the per-tenant duplicate
 	// without aborting the transaction (so the caller's tx stays usable).
+	// approver is omitted — the column's DB DEFAULT '' applies (a submission has no
+	// approver until the pending-approval → approved transition records one).
 	n, err := db.Exec(ctx,
 		`INSERT INTO contract_registrations
-		   (tenant_id, id, kind, payload_schema, submitter, approver, state, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, '', $6, $7, $7)
+		   (tenant_id, id, kind, payload_schema, submitter, state, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $7)
 		 ON CONFLICT (tenant_id, id) DO NOTHING`,
 		t.String(), in.ID, in.Kind, in.PayloadSchema, in.Submitter, submitted.String(), now)
 	if err != nil {
@@ -163,18 +165,19 @@ func (r *Registry) loadForUpdate(ctx context.Context, db DBTX, t tenant.TenantID
 }
 
 // appendEvent inserts one append-only migration event, assigning the next 1-based
-// per-registration seq. Shared by Create (from = zero sentinel) and Transition.
+// per-registration seq via a scalar subquery so the seq read and the insert are a
+// SINGLE atomic statement (no read-then-write window). Shared by Create (from =
+// zero sentinel) and Transition.
+//
+// Concurrency: same-registration writes are already serialized upstream — Create
+// by the projection PK (ON CONFLICT lets only one Create win) and Transition by
+// the FOR UPDATE row lock in loadForUpdate — so two appendEvent calls never race
+// the same (tenant_id, registration_id). The single-statement seq is defense in
+// depth on top of that, not the primary guard.
 func (r *Registry) appendEvent(
 	ctx context.Context, db DBTX, t tenant.TenantID, regID string,
 	from, to registry.RegistrationState, actor, reason string, now time.Time,
 ) error {
-	var seq int
-	if err := db.QueryRow(ctx,
-		`SELECT COALESCE(MAX(seq), 0) + 1 FROM contract_registration_events
-		 WHERE tenant_id = $1 AND registration_id = $2`,
-		t.String(), regID).Scan(&seq); err != nil {
-		return queryErr("append-event-seq", err)
-	}
 	fromStr := "" // zero sentinel persists as '' (ParseState("") → zero)
 	if !from.IsZero() {
 		fromStr = from.String()
@@ -182,8 +185,12 @@ func (r *Registry) appendEvent(
 	if _, err := db.Exec(ctx,
 		`INSERT INTO contract_registration_events
 		   (tenant_id, registration_id, seq, from_state, to_state, actor, reason, occurred_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-		t.String(), regID, seq, fromStr, to.String(), actor, reason, now); err != nil {
+		 VALUES (
+		   $1, $2,
+		   (SELECT COALESCE(MAX(seq), 0) + 1 FROM contract_registration_events
+		     WHERE tenant_id = $1 AND registration_id = $2),
+		   $3, $4, $5, $6, $7)`,
+		t.String(), regID, fromStr, to.String(), actor, reason, now); err != nil {
 		return queryErr("append-event", err)
 	}
 	return nil
@@ -254,10 +261,15 @@ func (r *Registry) History(ctx context.Context, t tenant.TenantID, id string) ([
 		if err := rows.Scan(&seq, &fromStr, &toStr, &actor, &reason, &occurredAt); err != nil {
 			return nil, queryErr("history-scan", err)
 		}
-		from, okFrom := registry.ParseState(fromStr) // '' → zero sentinel
+		from, okFrom := registry.ParseState(fromStr) // '' → zero sentinel (initial event)
+		if !okFrom {
+			return nil, corruptStateErr(id, fromStr)
+		}
+		// to_state is NOT NULL and always a real state (never the zero sentinel),
+		// symmetric with the projection-state guard in buildRegistration.
 		to, okTo := registry.ParseState(toStr)
-		if !okFrom || !okTo {
-			return nil, corruptStateErr(id, fromStr+"/"+toStr)
+		if !okTo || to.IsZero() {
+			return nil, corruptStateErr(id, toStr)
 		}
 		out = append(out, registry.RegistrationEvent{
 			RegistrationID: id, Seq: seq, From: from, To: to, Actor: actor, Reason: reason, OccurredAt: occurredAt,
@@ -267,6 +279,24 @@ func (r *Registry) History(ctx context.Context, t tenant.TenantID, id string) ([
 		return nil, queryErr("history-rows", err)
 	}
 	return out, nil
+}
+
+// buildRegistration assembles a ContractRegistration from scanned column values,
+// parsing the sealed state and fail-closing on a corrupt (unparseable or zero)
+// state read from the store. Single source for both scan helpers so adding a
+// projection column changes one place. A projection state is always a real,
+// non-zero state.
+func buildRegistration(
+	id, kind, payloadSchema, submitter, approver, stateStr string, createdAt, updatedAt time.Time,
+) (registry.ContractRegistration, error) {
+	state, ok := registry.ParseState(stateStr)
+	if !ok || state.IsZero() {
+		return registry.ContractRegistration{}, corruptStateErr(id, stateStr)
+	}
+	return registry.ContractRegistration{
+		ID: id, Kind: kind, PayloadSchema: payloadSchema, Submitter: submitter,
+		Approver: approver, State: state, CreatedAt: createdAt, UpdatedAt: updatedAt,
+	}, nil
 }
 
 // scanRegistration builds a ContractRegistration from a single-row scanner
@@ -282,14 +312,11 @@ func scanRegistration(row RowScanner, id string) (registry.ContractRegistration,
 		}
 		return registry.ContractRegistration{}, false, queryErr("scan", err)
 	}
-	state, ok := registry.ParseState(stateStr)
-	if !ok || state.IsZero() { // projection state is always a real state
-		return registry.ContractRegistration{}, false, corruptStateErr(id, stateStr)
+	reg, err := buildRegistration(id, kind, payloadSchema, submitter, approver, stateStr, createdAt, updatedAt)
+	if err != nil {
+		return registry.ContractRegistration{}, false, err
 	}
-	return registry.ContractRegistration{
-		ID: id, Kind: kind, PayloadSchema: payloadSchema, Submitter: submitter,
-		Approver: approver, State: state, CreatedAt: createdAt, UpdatedAt: updatedAt,
-	}, true, nil
+	return reg, true, nil
 }
 
 // scanRegistrationRow builds a ContractRegistration from a multi-row scanner
@@ -302,14 +329,7 @@ func scanRegistrationRow(rows Rows) (registry.ContractRegistration, error) {
 	if err := rows.Scan(&id, &kind, &payloadSchema, &submitter, &approver, &stateStr, &createdAt, &updatedAt); err != nil {
 		return registry.ContractRegistration{}, queryErr("list-scan", err)
 	}
-	state, ok := registry.ParseState(stateStr)
-	if !ok || state.IsZero() {
-		return registry.ContractRegistration{}, corruptStateErr(id, stateStr)
-	}
-	return registry.ContractRegistration{
-		ID: id, Kind: kind, PayloadSchema: payloadSchema, Submitter: submitter,
-		Approver: approver, State: state, CreatedAt: createdAt, UpdatedAt: updatedAt,
-	}, nil
+	return buildRegistration(id, kind, payloadSchema, submitter, approver, stateStr, createdAt, updatedAt)
 }
 
 func invalidTenant(err error) error {

--- a/corecells/registrycore/internal/adapters/postgres/registry_repo.go
+++ b/corecells/registrycore/internal/adapters/postgres/registry_repo.go
@@ -43,6 +43,13 @@ func NewRegistry(pool *pgxpool.Pool, clk clock.Clock) *Registry {
 }
 
 // resolveRead returns the DBTX for read paths (ambient tx if present, else pool).
+//
+// RLS caller obligation (#2236 review F1): under FORCE ROW LEVEL SECURITY + the
+// restricted serving role, a pool read with no app.tenant_id GUC fail-closes to 0
+// rows. The GUC is set only inside TxManager.RunInTx, so the bound service MUST run
+// tenant-scoped reads within a tenant.WithScope + RunInTx (scopedread funnel, US6) —
+// the pool fallback here is for superuser/test paths and bootstrap reads only. See
+// the ports.Registry godoc "Read scoping under RLS".
 func (r *Registry) resolveRead(ctx context.Context) DBTX {
 	if r.session != nil {
 		return r.session.resolve(ctx)

--- a/corecells/registrycore/internal/adapters/postgres/registry_repo.go
+++ b/corecells/registrycore/internal/adapters/postgres/registry_repo.go
@@ -2,7 +2,11 @@ package postgres
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/ghbvf/gocell/corecells/registrycore/internal/ports"
@@ -17,11 +21,14 @@ var _ ports.Registry = (*Registry)(nil)
 
 // Registry is the PostgreSQL ports.Registry backed by the contract_registrations
 // projection table and the append-only contract_registration_events history
-// table (migration 066). (Wave 0 RED stub — real SQL lands in Wave 3.)
+// table (migration 066). The two writes of a Create/Transition land in one L1
+// transaction (the caller's TxManager.RunInTx supplies the ambient tx via
+// persistence.TxCtxKey; resolveWrite requires it), so a failure rolls both back.
+// State-machine legality is the kernel's single source of truth — Transition
+// validates via registry.Transition and never re-encodes the table in SQL.
 //
-// The struct carries either a *Session (production: resolves the ambient tx via
-// persistence.TxCtxKey) or a bare DBTX (test-only: injected by
-// newRegistryFromDBTX), mirroring configcore.
+// The struct carries either a *Session (production: resolves the ambient tx) or a
+// bare DBTX (test-only: injected by newRegistryFromDBTX), mirroring configcore.
 type Registry struct {
 	db      DBTX     // test-only: set by newRegistryFromDBTX
 	session *Session // production path: resolves ambient tx via persistence.TxCtxKey
@@ -52,27 +59,283 @@ func (r *Registry) resolveWrite(ctx context.Context) (DBTX, error) {
 	return r.db, nil
 }
 
-func errStub() error {
-	return errcode.New(errcode.KindInternal, errcode.ErrNotImplemented,
-		"registrycore pg registry: not implemented (Wave 0 RED stub)")
+const (
+	colsProjection = `kind, payload_schema, submitter, approver, state, created_at, updated_at`
+)
+
+func (r *Registry) Create(ctx context.Context, t tenant.TenantID, in registry.SubmitInput) (registry.ContractRegistration, error) {
+	if err := t.Validate(); err != nil {
+		return registry.ContractRegistration{}, invalidTenant(err)
+	}
+	in = in.Normalized()
+	if err := in.Validate(); err != nil { // kernel validation — single source, no mem/PG fork
+		return registry.ContractRegistration{}, err
+	}
+	db, err := r.resolveWrite(ctx)
+	if err != nil {
+		return registry.ContractRegistration{}, err
+	}
+	now := r.clk.Now()
+	submitted := registry.StateSubmitted()
+	// ON CONFLICT DO NOTHING + RowsAffected detects the per-tenant duplicate
+	// without aborting the transaction (so the caller's tx stays usable).
+	n, err := db.Exec(ctx,
+		`INSERT INTO contract_registrations
+		   (tenant_id, id, kind, payload_schema, submitter, approver, state, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, '', $6, $7, $7)
+		 ON CONFLICT (tenant_id, id) DO NOTHING`,
+		t.String(), in.ID, in.Kind, in.PayloadSchema, in.Submitter, submitted.String(), now)
+	if err != nil {
+		return registry.ContractRegistration{}, queryErr("create", err)
+	}
+	if n == 0 {
+		return registry.ContractRegistration{}, dupErr(in.ID)
+	}
+	// Initial migration event: From = zero sentinel (stored as ''), To = submitted.
+	if err := r.appendEvent(ctx, db, t, in.ID, registry.RegistrationState{}, submitted, in.Submitter, "", now); err != nil {
+		return registry.ContractRegistration{}, err
+	}
+	return registry.ContractRegistration{
+		ID:            in.ID,
+		Kind:          in.Kind,
+		PayloadSchema: in.PayloadSchema,
+		Submitter:     in.Submitter,
+		State:         submitted,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}, nil
 }
 
-func (r *Registry) Create(context.Context, tenant.TenantID, registry.SubmitInput) (registry.ContractRegistration, error) {
-	return registry.ContractRegistration{}, errStub()
+func (r *Registry) Transition(ctx context.Context, t tenant.TenantID, in registry.AdvanceInput) (registry.ContractRegistration, error) {
+	if err := t.Validate(); err != nil {
+		return registry.ContractRegistration{}, invalidTenant(err)
+	}
+	in = in.Normalized()
+	if err := in.Validate(); err != nil {
+		return registry.ContractRegistration{}, err
+	}
+	db, err := r.resolveWrite(ctx)
+	if err != nil {
+		return registry.ContractRegistration{}, err
+	}
+	cur, err := r.loadForUpdate(ctx, db, t, in.ID)
+	if err != nil {
+		return registry.ContractRegistration{}, err
+	}
+	if err := registry.Transition(cur.State, in.To); err != nil { // single-source legality
+		return registry.ContractRegistration{}, err
+	}
+	now := r.clk.Now()
+	approver := cur.Approver
+	if in.To == registry.StateApproved() {
+		approver = in.Actor
+	}
+	if _, err := db.Exec(ctx,
+		`UPDATE contract_registrations SET state = $1, approver = $2, updated_at = $3
+		 WHERE tenant_id = $4 AND id = $5`,
+		in.To.String(), approver, now, t.String(), in.ID); err != nil {
+		return registry.ContractRegistration{}, queryErr("transition", err)
+	}
+	if err := r.appendEvent(ctx, db, t, in.ID, cur.State, in.To, in.Actor, in.Reason, now); err != nil {
+		return registry.ContractRegistration{}, err
+	}
+	cur.State = in.To
+	cur.Approver = approver
+	cur.UpdatedAt = now
+	return cur, nil
 }
 
-func (r *Registry) Transition(context.Context, tenant.TenantID, registry.AdvanceInput) (registry.ContractRegistration, error) {
-	return registry.ContractRegistration{}, errStub()
+// loadForUpdate reads the current projection row under a row lock (FOR UPDATE) so
+// the read-validate-write of a transition is serialized per registration.
+func (r *Registry) loadForUpdate(ctx context.Context, db DBTX, t tenant.TenantID, id string) (registry.ContractRegistration, error) {
+	row := db.QueryRow(ctx,
+		`SELECT `+colsProjection+`
+		 FROM contract_registrations WHERE tenant_id = $1 AND id = $2 FOR UPDATE`,
+		t.String(), id)
+	reg, ok, err := scanRegistration(row, id)
+	if err != nil {
+		return registry.ContractRegistration{}, err
+	}
+	if !ok {
+		return registry.ContractRegistration{}, notFoundErr(id)
+	}
+	return reg, nil
 }
 
-func (r *Registry) Get(context.Context, tenant.TenantID, string) (registry.ContractRegistration, bool, error) {
-	return registry.ContractRegistration{}, false, errStub()
+// appendEvent inserts one append-only migration event, assigning the next 1-based
+// per-registration seq. Shared by Create (from = zero sentinel) and Transition.
+func (r *Registry) appendEvent(
+	ctx context.Context, db DBTX, t tenant.TenantID, regID string,
+	from, to registry.RegistrationState, actor, reason string, now time.Time,
+) error {
+	var seq int
+	if err := db.QueryRow(ctx,
+		`SELECT COALESCE(MAX(seq), 0) + 1 FROM contract_registration_events
+		 WHERE tenant_id = $1 AND registration_id = $2`,
+		t.String(), regID).Scan(&seq); err != nil {
+		return queryErr("append-event-seq", err)
+	}
+	fromStr := "" // zero sentinel persists as '' (ParseState("") → zero)
+	if !from.IsZero() {
+		fromStr = from.String()
+	}
+	if _, err := db.Exec(ctx,
+		`INSERT INTO contract_registration_events
+		   (tenant_id, registration_id, seq, from_state, to_state, actor, reason, occurred_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		t.String(), regID, seq, fromStr, to.String(), actor, reason, now); err != nil {
+		return queryErr("append-event", err)
+	}
+	return nil
 }
 
-func (r *Registry) List(context.Context, tenant.TenantID, string, int) ([]registry.ContractRegistration, error) {
-	return nil, errStub()
+func (r *Registry) Get(ctx context.Context, t tenant.TenantID, id string) (registry.ContractRegistration, bool, error) {
+	if err := t.Validate(); err != nil {
+		return registry.ContractRegistration{}, false, invalidTenant(err)
+	}
+	row := r.resolveRead(ctx).QueryRow(ctx,
+		`SELECT `+colsProjection+`
+		 FROM contract_registrations WHERE tenant_id = $1 AND id = $2`,
+		t.String(), id)
+	return scanRegistration(row, id)
 }
 
-func (r *Registry) History(context.Context, tenant.TenantID, string) ([]registry.RegistrationEvent, error) {
-	return nil, errStub()
+func (r *Registry) List(ctx context.Context, t tenant.TenantID, afterID string, limit int) ([]registry.ContractRegistration, error) {
+	if err := t.Validate(); err != nil {
+		return nil, invalidTenant(err)
+	}
+	var limitArg any = limit
+	if limit <= 0 {
+		limitArg = nil // LIMIT NULL = unbounded (parity with the mem impl)
+	}
+	rows, err := r.resolveRead(ctx).Query(ctx,
+		`SELECT id, `+colsProjection+`
+		 FROM contract_registrations
+		 WHERE tenant_id = $1 AND id > $2 ORDER BY id ASC LIMIT $3`,
+		t.String(), afterID, limitArg)
+	if err != nil {
+		return nil, queryErr("list", err)
+	}
+	defer rows.Close()
+	var out []registry.ContractRegistration
+	for rows.Next() {
+		reg, err := scanRegistrationRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, reg)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, queryErr("list-rows", err)
+	}
+	return out, nil
+}
+
+func (r *Registry) History(ctx context.Context, t tenant.TenantID, id string) ([]registry.RegistrationEvent, error) {
+	if err := t.Validate(); err != nil {
+		return nil, invalidTenant(err)
+	}
+	rows, err := r.resolveRead(ctx).Query(ctx,
+		`SELECT seq, from_state, to_state, actor, reason, occurred_at
+		 FROM contract_registration_events
+		 WHERE tenant_id = $1 AND registration_id = $2 ORDER BY seq ASC`,
+		t.String(), id)
+	if err != nil {
+		return nil, queryErr("history", err)
+	}
+	defer rows.Close()
+	var out []registry.RegistrationEvent
+	for rows.Next() {
+		var (
+			seq                           int
+			fromStr, toStr, actor, reason string
+			occurredAt                    time.Time
+		)
+		if err := rows.Scan(&seq, &fromStr, &toStr, &actor, &reason, &occurredAt); err != nil {
+			return nil, queryErr("history-scan", err)
+		}
+		from, okFrom := registry.ParseState(fromStr) // '' → zero sentinel
+		to, okTo := registry.ParseState(toStr)
+		if !okFrom || !okTo {
+			return nil, corruptStateErr(id, fromStr+"/"+toStr)
+		}
+		out = append(out, registry.RegistrationEvent{
+			RegistrationID: id, Seq: seq, From: from, To: to, Actor: actor, Reason: reason, OccurredAt: occurredAt,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, queryErr("history-rows", err)
+	}
+	return out, nil
+}
+
+// scanRegistration builds a ContractRegistration from a single-row scanner
+// selecting colsProjection. Returns ok=false (nil error) when the row is absent.
+func scanRegistration(row RowScanner, id string) (registry.ContractRegistration, bool, error) {
+	var (
+		kind, payloadSchema, submitter, approver, stateStr string
+		createdAt, updatedAt                               time.Time
+	)
+	if err := row.Scan(&kind, &payloadSchema, &submitter, &approver, &stateStr, &createdAt, &updatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return registry.ContractRegistration{}, false, nil
+		}
+		return registry.ContractRegistration{}, false, queryErr("scan", err)
+	}
+	state, ok := registry.ParseState(stateStr)
+	if !ok || state.IsZero() { // projection state is always a real state
+		return registry.ContractRegistration{}, false, corruptStateErr(id, stateStr)
+	}
+	return registry.ContractRegistration{
+		ID: id, Kind: kind, PayloadSchema: payloadSchema, Submitter: submitter,
+		Approver: approver, State: state, CreatedAt: createdAt, UpdatedAt: updatedAt,
+	}, true, nil
+}
+
+// scanRegistrationRow builds a ContractRegistration from a multi-row scanner
+// selecting id + colsProjection (List path).
+func scanRegistrationRow(rows Rows) (registry.ContractRegistration, error) {
+	var (
+		id, kind, payloadSchema, submitter, approver, stateStr string
+		createdAt, updatedAt                                   time.Time
+	)
+	if err := rows.Scan(&id, &kind, &payloadSchema, &submitter, &approver, &stateStr, &createdAt, &updatedAt); err != nil {
+		return registry.ContractRegistration{}, queryErr("list-scan", err)
+	}
+	state, ok := registry.ParseState(stateStr)
+	if !ok || state.IsZero() {
+		return registry.ContractRegistration{}, corruptStateErr(id, stateStr)
+	}
+	return registry.ContractRegistration{
+		ID: id, Kind: kind, PayloadSchema: payloadSchema, Submitter: submitter,
+		Approver: approver, State: state, CreatedAt: createdAt, UpdatedAt: updatedAt,
+	}, nil
+}
+
+func invalidTenant(err error) error {
+	return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, "registry repo: invalid tenant", err)
+}
+
+func dupErr(id string) error {
+	return errcode.New(errcode.KindConflict, errcode.ErrRegistrationDuplicate,
+		"registry repo: registration id already exists",
+		errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("id=%q", id))))
+}
+
+func notFoundErr(id string) error {
+	return errcode.New(errcode.KindNotFound, errcode.ErrRegistrationNotFound,
+		"registry repo: registration not found",
+		errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("id=%q", id))))
+}
+
+func corruptStateErr(id, state string) error {
+	return errcode.New(errcode.KindInternal, errcode.ErrRegistrationRepoQuery,
+		"registry repo: unparseable state from store",
+		errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("id=%q state=%q", id, state))))
+}
+
+func queryErr(op string, err error) error {
+	return errcode.Wrap(errcode.KindInternal, errcode.ErrRegistrationRepoQuery,
+		"registry repo query failed", err,
+		errcode.WithInternal(errcode.InternalAttr("_", "op="+op)))
 }

--- a/corecells/registrycore/internal/adapters/postgres/registry_repo_integration_test.go
+++ b/corecells/registrycore/internal/adapters/postgres/registry_repo_integration_test.go
@@ -1,0 +1,198 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	adapterpg "github.com/ghbvf/gocell/adapters/postgres"
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/registry"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/tenant"
+)
+
+var (
+	itTenantA = mustTenant("00000000-0000-0000-0000-000000000001")
+	itTenantB = mustTenant("00000000-0000-0000-0000-000000000002")
+)
+
+func mustTenant(s string) tenant.TenantID {
+	t, err := tenant.ParseTenantID(s)
+	if err != nil {
+		panic("mustTenant: " + err.Error())
+	}
+	return t
+}
+
+// setupRegistryPG clones the package-shared pre-migrated template into a fresh
+// per-test database and returns a PG Registry + TxManager over it.
+func setupRegistryPG(t *testing.T) (*Registry, *adapterpg.TxManager) {
+	t.Helper()
+	pool := sharedPG.NewPerTestPool(t)
+	repo := NewRegistry(pool.DB(), clock.Real())
+	txMgr := adapterpg.NewTxManager(pool)
+	return repo, txMgr
+}
+
+func createInTx(t *testing.T, repo *Registry, txMgr *adapterpg.TxManager, tn tenant.TenantID, in registry.SubmitInput) registry.ContractRegistration {
+	t.Helper()
+	var out registry.ContractRegistration
+	require.NoError(t, txMgr.RunInTx(context.Background(), func(ctx context.Context) error {
+		var err error
+		out, err = repo.Create(ctx, tn, in)
+		return err
+	}))
+	return out
+}
+
+func transitionInTx(t *testing.T, repo *Registry, txMgr *adapterpg.TxManager, tn tenant.TenantID, in registry.AdvanceInput) (registry.ContractRegistration, error) {
+	t.Helper()
+	var out registry.ContractRegistration
+	err := txMgr.RunInTx(context.Background(), func(ctx context.Context) error {
+		var e error
+		out, e = repo.Transition(ctx, tn, in)
+		return e
+	})
+	return out, err
+}
+
+func TestRegistryPG_Integration_CreateGetHistory(t *testing.T) {
+	repo, txMgr := setupRegistryPG(t)
+	ctx := context.Background()
+
+	reg := createInTx(t, repo, txMgr, itTenantA, registry.SubmitInput{ID: "http.foo.v1", Kind: "http", Submitter: "alice", PayloadSchema: "sha256:abc"})
+	assert.Equal(t, registry.StateSubmitted(), reg.State)
+	assert.Equal(t, "sha256:abc", reg.PayloadSchema)
+
+	got, ok, err := repo.Get(ctx, itTenantA, "http.foo.v1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "alice", got.Submitter)
+	assert.Equal(t, registry.StateSubmitted(), got.State)
+
+	evs, err := repo.History(ctx, itTenantA, "http.foo.v1")
+	require.NoError(t, err)
+	require.Len(t, evs, 1)
+	assert.True(t, evs[0].From.IsZero())
+	assert.Equal(t, registry.StateSubmitted(), evs[0].To)
+	assert.Equal(t, 1, evs[0].Seq)
+}
+
+func TestRegistryPG_Integration_DuplicateRejected(t *testing.T) {
+	repo, txMgr := setupRegistryPG(t)
+	createInTx(t, repo, txMgr, itTenantA, registry.SubmitInput{ID: "dup", Kind: "http", Submitter: "alice"})
+
+	err := txMgr.RunInTx(context.Background(), func(ctx context.Context) error {
+		_, e := repo.Create(ctx, itTenantA, registry.SubmitInput{ID: "dup", Kind: "http", Submitter: "bob"})
+		return e
+	})
+	var ce *errcode.Error
+	require.ErrorAs(t, err, &ce)
+	assert.Equal(t, errcode.ErrRegistrationDuplicate, ce.Code)
+}
+
+func TestRegistryPG_Integration_TransitionLegalAndApprover(t *testing.T) {
+	repo, txMgr := setupRegistryPG(t)
+	ctx := context.Background()
+	createInTx(t, repo, txMgr, itTenantA, registry.SubmitInput{ID: "r1", Kind: "http", Submitter: "alice"})
+
+	for _, to := range []registry.RegistrationState{
+		registry.StateProbing(), registry.StateConformant(), registry.StatePendingApproval(), registry.StateApproved(),
+	} {
+		_, err := transitionInTx(t, repo, txMgr, itTenantA, registry.AdvanceInput{ID: "r1", To: to, Actor: "admin"})
+		require.NoError(t, err)
+	}
+	got, _, err := repo.Get(ctx, itTenantA, "r1")
+	require.NoError(t, err)
+	assert.Equal(t, registry.StateApproved(), got.State)
+	assert.Equal(t, "admin", got.Approver)
+
+	evs, err := repo.History(ctx, itTenantA, "r1")
+	require.NoError(t, err)
+	require.Len(t, evs, 5) // submit + 4 transitions
+	for i, ev := range evs {
+		assert.Equal(t, i+1, ev.Seq, "seq must be 1-based contiguous")
+	}
+}
+
+func TestRegistryPG_Integration_TransitionIllegalRejected(t *testing.T) {
+	repo, txMgr := setupRegistryPG(t)
+	ctx := context.Background()
+	createInTx(t, repo, txMgr, itTenantA, registry.SubmitInput{ID: "r1", Kind: "http", Submitter: "alice"})
+
+	_, err := transitionInTx(t, repo, txMgr, itTenantA, registry.AdvanceInput{ID: "r1", To: registry.StateActive(), Actor: "admin"})
+	var ce *errcode.Error
+	require.ErrorAs(t, err, &ce)
+	assert.Equal(t, errcode.ErrRegistrationInvalidTransition, ce.Code)
+
+	// No half-write: still submitted, history length 1.
+	got, _, _ := repo.Get(ctx, itTenantA, "r1")
+	assert.Equal(t, registry.StateSubmitted(), got.State)
+	evs, _ := repo.History(ctx, itTenantA, "r1")
+	assert.Len(t, evs, 1)
+}
+
+// TestRegistryPG_Integration_L1Atomicity is T052: a transition that writes the
+// projection + history row but whose enclosing tx then fails must roll BOTH back
+// — no half state.
+func TestRegistryPG_Integration_L1Atomicity(t *testing.T) {
+	repo, txMgr := setupRegistryPG(t)
+	ctx := context.Background()
+	createInTx(t, repo, txMgr, itTenantA, registry.SubmitInput{ID: "r1", Kind: "http", Submitter: "alice"})
+
+	err := txMgr.RunInTx(ctx, func(txCtx context.Context) error {
+		if _, e := repo.Transition(txCtx, itTenantA, registry.AdvanceInput{ID: "r1", To: registry.StateProbing(), Actor: "system"}); e != nil {
+			return e
+		}
+		return errors.New("simulated failure after the transition write — roll back both")
+	})
+	require.Error(t, err)
+
+	// Projection unchanged AND no new history row (the append must have rolled back too).
+	got, _, err := repo.Get(ctx, itTenantA, "r1")
+	require.NoError(t, err)
+	assert.Equal(t, registry.StateSubmitted(), got.State, "rolled-back transition must not persist the projection update")
+	evs, err := repo.History(ctx, itTenantA, "r1")
+	require.NoError(t, err)
+	assert.Len(t, evs, 1, "rolled-back transition must not persist the appended event")
+}
+
+func TestRegistryPG_Integration_CrossTenantIsolation(t *testing.T) {
+	repo, txMgr := setupRegistryPG(t)
+	ctx := context.Background()
+	createInTx(t, repo, txMgr, itTenantA, registry.SubmitInput{ID: "shared.id", Kind: "http", Submitter: "alice"})
+
+	// Tenant B cannot see tenant A's row.
+	_, ok, err := repo.Get(ctx, itTenantB, "shared.id")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	page, err := repo.List(ctx, itTenantB, "", 50)
+	require.NoError(t, err)
+	assert.Empty(t, page)
+
+	// Per-tenant dedup: the same id is independently creatable under tenant B.
+	createInTx(t, repo, txMgr, itTenantB, registry.SubmitInput{ID: "shared.id", Kind: "http", Submitter: "bob"})
+	gotB, ok, err := repo.Get(ctx, itTenantB, "shared.id")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "bob", gotB.Submitter)
+}
+
+func TestRegistryPG_Integration_EmptyTenantGuard(t *testing.T) {
+	repo, txMgr := setupRegistryPG(t)
+	zero := tenant.TenantID("")
+
+	err := txMgr.RunInTx(context.Background(), func(ctx context.Context) error {
+		_, e := repo.Create(ctx, zero, registry.SubmitInput{ID: "x", Kind: "http", Submitter: "alice"})
+		return e
+	})
+	var ce *errcode.Error
+	require.ErrorAs(t, err, &ce)
+	assert.Equal(t, errcode.ErrValidationFailed, ce.Code, "empty tenant must fail validation, not issue a tenant-less query")
+}

--- a/corecells/registrycore/internal/adapters/postgres/registry_repo_test.go
+++ b/corecells/registrycore/internal/adapters/postgres/registry_repo_test.go
@@ -1,0 +1,306 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/registry"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/tenant"
+)
+
+var unitTenant = tenant.TenantID("00000000-0000-0000-0000-000000000001")
+
+// newRegistryFromDBTX is a test-only constructor that bypasses the Session layer,
+// injecting a mock DBTX directly. Production code always goes through NewRegistry.
+func newRegistryFromDBTX(db DBTX) *Registry {
+	return &Registry{db: db, clk: clock.Real()}
+}
+
+// --- mock DBTX (routes QueryRow/Query by SQL substring) ---
+
+type mockDB struct {
+	execN     int64
+	execErr   error
+	rowsBySQL map[string]*mockRow // SQL substring → single-row result
+	queryRows *mockRows
+	queryErr  error
+}
+
+func (m *mockDB) Exec(context.Context, string, ...any) (int64, error) {
+	if m.execErr != nil {
+		return 0, m.execErr
+	}
+	return m.execN, nil
+}
+
+func (m *mockDB) Query(_ context.Context, _ string, _ ...any) (Rows, error) {
+	if m.queryErr != nil {
+		return nil, m.queryErr
+	}
+	if m.queryRows == nil {
+		return &mockRows{}, nil
+	}
+	return m.queryRows, nil
+}
+
+func (m *mockDB) QueryRow(_ context.Context, sql string, _ ...any) RowScanner {
+	for sub, row := range m.rowsBySQL {
+		if strings.Contains(sql, sub) {
+			return row
+		}
+	}
+	return &mockRow{scanErr: pgx.ErrNoRows}
+}
+
+type mockRow struct {
+	values  []any
+	scanErr error
+}
+
+func (r *mockRow) Scan(dest ...any) error {
+	if r.scanErr != nil {
+		return r.scanErr
+	}
+	return assignScan(dest, r.values)
+}
+
+type mockRows struct {
+	rows    [][]any
+	idx     int
+	scanErr error
+}
+
+func (r *mockRows) Next() bool { return r.idx < len(r.rows) }
+func (r *mockRows) Close()     {}
+func (r *mockRows) Err() error { return nil }
+func (r *mockRows) Scan(dest ...any) error {
+	if r.scanErr != nil {
+		return r.scanErr
+	}
+	row := r.rows[r.idx]
+	r.idx++
+	return assignScan(dest, row)
+}
+
+func assignScan(dest, values []any) error {
+	for i, v := range values {
+		switch d := dest[i].(type) {
+		case *string:
+			*d = v.(string)
+		case *int:
+			*d = v.(int)
+		case *time.Time:
+			*d = v.(time.Time)
+		}
+	}
+	return nil
+}
+
+func projectionValues(kind, submitter, approver, state string) []any {
+	now := time.Unix(0, 0).UTC()
+	return []any{kind, "" /* payload_schema */, submitter, approver, state, now, now}
+}
+
+func assertCode(t *testing.T, err error, want errcode.Code) {
+	t.Helper()
+	var ce *errcode.Error
+	require.True(t, errors.As(err, &ce), "want *errcode.Error, got %v", err)
+	assert.Equal(t, want, ce.Code)
+}
+
+func validSubmit() registry.SubmitInput {
+	return registry.SubmitInput{ID: "http.foo.v1", Kind: "http", Submitter: "alice"}
+}
+
+func TestRegistry_Create_InvalidTenant(t *testing.T) {
+	r := newRegistryFromDBTX(&mockDB{})
+	_, err := r.Create(context.Background(), tenant.TenantID(""), validSubmit())
+	assertCode(t, err, errcode.ErrValidationFailed)
+}
+
+func TestRegistry_Create_InvalidInput(t *testing.T) {
+	r := newRegistryFromDBTX(&mockDB{})
+	_, err := r.Create(context.Background(), unitTenant, registry.SubmitInput{ID: "", Kind: "http", Submitter: "alice"})
+	assertCode(t, err, errcode.ErrValidationFailed)
+}
+
+func TestRegistry_Create_Duplicate(t *testing.T) {
+	r := newRegistryFromDBTX(&mockDB{execN: 0}) // ON CONFLICT DO NOTHING → 0 rows
+	_, err := r.Create(context.Background(), unitTenant, validSubmit())
+	assertCode(t, err, errcode.ErrRegistrationDuplicate)
+}
+
+func TestRegistry_Create_ExecError(t *testing.T) {
+	r := newRegistryFromDBTX(&mockDB{execErr: errors.New("boom")})
+	_, err := r.Create(context.Background(), unitTenant, validSubmit())
+	assertCode(t, err, errcode.ErrRegistrationRepoQuery)
+}
+
+func TestRegistry_Create_Success(t *testing.T) {
+	db := &mockDB{
+		execN:     1,
+		rowsBySQL: map[string]*mockRow{"MAX(seq)": {values: []any{1}}},
+	}
+	r := newRegistryFromDBTX(db)
+	reg, err := r.Create(context.Background(), unitTenant, validSubmit())
+	require.NoError(t, err)
+	assert.Equal(t, registry.StateSubmitted(), reg.State)
+	assert.Equal(t, "alice", reg.Submitter)
+}
+
+func TestRegistry_Get_NotFound(t *testing.T) {
+	r := newRegistryFromDBTX(&mockDB{}) // default QueryRow → pgx.ErrNoRows
+	_, ok, err := r.Get(context.Background(), unitTenant, "missing")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestRegistry_Get_Found(t *testing.T) {
+	db := &mockDB{rowsBySQL: map[string]*mockRow{
+		"FROM contract_registrations WHERE tenant_id": {values: projectionValues("http", "alice", "", "submitted")},
+	}}
+	r := newRegistryFromDBTX(db)
+	got, ok, err := r.Get(context.Background(), unitTenant, "http.foo.v1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, registry.StateSubmitted(), got.State)
+}
+
+func TestRegistry_Get_CorruptState(t *testing.T) {
+	db := &mockDB{rowsBySQL: map[string]*mockRow{
+		"FROM contract_registrations WHERE tenant_id": {values: projectionValues("http", "alice", "", "bogus")},
+	}}
+	r := newRegistryFromDBTX(db)
+	_, _, err := r.Get(context.Background(), unitTenant, "http.foo.v1")
+	assertCode(t, err, errcode.ErrRegistrationRepoQuery)
+}
+
+func TestRegistry_Transition_NotFound(t *testing.T) {
+	r := newRegistryFromDBTX(&mockDB{}) // FOR UPDATE QueryRow → pgx.ErrNoRows
+	_, err := r.Transition(context.Background(), unitTenant,
+		registry.AdvanceInput{ID: "missing", To: registry.StateProbing(), Actor: "system"})
+	assertCode(t, err, errcode.ErrRegistrationNotFound)
+}
+
+func TestRegistry_Transition_InvalidActor(t *testing.T) {
+	r := newRegistryFromDBTX(&mockDB{})
+	_, err := r.Transition(context.Background(), unitTenant, registry.AdvanceInput{ID: "x", To: registry.StateProbing(), Actor: ""})
+	assertCode(t, err, errcode.ErrValidationFailed)
+}
+
+func TestRegistry_Transition_IllegalRejected(t *testing.T) {
+	db := &mockDB{rowsBySQL: map[string]*mockRow{
+		"FOR UPDATE": {values: projectionValues("http", "alice", "", "submitted")},
+	}}
+	r := newRegistryFromDBTX(db)
+	// submitted → active is illegal (only approved → active).
+	_, err := r.Transition(context.Background(), unitTenant, registry.AdvanceInput{ID: "x", To: registry.StateActive(), Actor: "admin"})
+	assertCode(t, err, errcode.ErrRegistrationInvalidTransition)
+}
+
+func TestRegistry_Transition_LegalSuccess(t *testing.T) {
+	db := &mockDB{
+		execN: 1,
+		rowsBySQL: map[string]*mockRow{
+			"FOR UPDATE": {values: projectionValues("http", "alice", "", "submitted")},
+			"MAX(seq)":   {values: []any{2}},
+		},
+	}
+	r := newRegistryFromDBTX(db)
+	got, err := r.Transition(context.Background(), unitTenant, registry.AdvanceInput{ID: "x", To: registry.StateProbing(), Actor: "system"})
+	require.NoError(t, err)
+	assert.Equal(t, registry.StateProbing(), got.State)
+}
+
+func TestRegistry_List_Success(t *testing.T) {
+	db := &mockDB{queryRows: &mockRows{rows: [][]any{
+		append([]any{"a"}, projectionValues("http", "alice", "", "submitted")...),
+		append([]any{"b"}, projectionValues("event", "bob", "admin", "approved")...),
+	}}}
+	r := newRegistryFromDBTX(db)
+	out, err := r.List(context.Background(), unitTenant, "", 10)
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	assert.Equal(t, "a", out[0].ID)
+	assert.Equal(t, registry.StateApproved(), out[1].State)
+	assert.Equal(t, "admin", out[1].Approver)
+}
+
+func TestRegistry_List_QueryError(t *testing.T) {
+	r := newRegistryFromDBTX(&mockDB{queryErr: errors.New("boom")})
+	_, err := r.List(context.Background(), unitTenant, "", 10)
+	assertCode(t, err, errcode.ErrRegistrationRepoQuery)
+}
+
+func TestRegistry_History_Success(t *testing.T) {
+	now := time.Unix(0, 0).UTC()
+	db := &mockDB{queryRows: &mockRows{rows: [][]any{
+		{1, "", "submitted", "alice", "", now},
+		{2, "submitted", "probing", "system", "", now},
+	}}}
+	r := newRegistryFromDBTX(db)
+	evs, err := r.History(context.Background(), unitTenant, "x")
+	require.NoError(t, err)
+	require.Len(t, evs, 2)
+	assert.True(t, evs[0].From.IsZero())
+	assert.Equal(t, registry.StateProbing(), evs[1].To)
+	assert.Equal(t, 2, evs[1].Seq)
+}
+
+func TestRegistry_Create_AppendEventSeqError(t *testing.T) {
+	db := &mockDB{
+		execN:     1, // projection insert succeeds
+		rowsBySQL: map[string]*mockRow{"MAX(seq)": {scanErr: errors.New("boom")}},
+	}
+	r := newRegistryFromDBTX(db)
+	_, err := r.Create(context.Background(), unitTenant, validSubmit())
+	assertCode(t, err, errcode.ErrRegistrationRepoQuery)
+}
+
+func TestRegistry_Transition_UpdateExecError(t *testing.T) {
+	db := &mockDB{
+		execErr:   errors.New("boom"), // the UPDATE fails
+		rowsBySQL: map[string]*mockRow{"FOR UPDATE": {values: projectionValues("http", "alice", "", "submitted")}},
+	}
+	r := newRegistryFromDBTX(db)
+	_, err := r.Transition(context.Background(), unitTenant, registry.AdvanceInput{ID: "x", To: registry.StateProbing(), Actor: "s"})
+	assertCode(t, err, errcode.ErrRegistrationRepoQuery)
+}
+
+func TestRegistry_History_ScanError(t *testing.T) {
+	db := &mockDB{queryRows: &mockRows{rows: [][]any{{0, "", "", "", "", time.Time{}}}, scanErr: errors.New("boom")}}
+	r := newRegistryFromDBTX(db)
+	_, err := r.History(context.Background(), unitTenant, "x")
+	assertCode(t, err, errcode.ErrRegistrationRepoQuery)
+}
+
+func TestRegistry_List_CorruptState(t *testing.T) {
+	db := &mockDB{queryRows: &mockRows{rows: [][]any{
+		append([]any{"a"}, projectionValues("http", "alice", "", "bogus")...),
+	}}}
+	r := newRegistryFromDBTX(db)
+	_, err := r.List(context.Background(), unitTenant, "", 10)
+	assertCode(t, err, errcode.ErrRegistrationRepoQuery)
+}
+
+func TestRegistry_AllMethods_InvalidTenant(t *testing.T) {
+	r := newRegistryFromDBTX(&mockDB{})
+	zero := tenant.TenantID("")
+	_, _, gErr := r.Get(context.Background(), zero, "x")
+	assertCode(t, gErr, errcode.ErrValidationFailed)
+	_, lErr := r.List(context.Background(), zero, "", 10)
+	assertCode(t, lErr, errcode.ErrValidationFailed)
+	_, hErr := r.History(context.Background(), zero, "x")
+	assertCode(t, hErr, errcode.ErrValidationFailed)
+	_, tErr := r.Transition(context.Background(), zero, registry.AdvanceInput{ID: "x", To: registry.StateProbing(), Actor: "s"})
+	assertCode(t, tErr, errcode.ErrValidationFailed)
+}

--- a/corecells/registrycore/internal/adapters/postgres/registry_repo_test.go
+++ b/corecells/registrycore/internal/adapters/postgres/registry_repo_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -27,15 +28,30 @@ func newRegistryFromDBTX(db DBTX) *Registry {
 
 // --- mock DBTX (routes QueryRow/Query by SQL substring) ---
 
+type execResult struct {
+	n   int64
+	err error
+}
+
 type mockDB struct {
 	execN     int64
 	execErr   error
+	execSeq   []execResult // if non-empty, consumed in order per Exec call (last repeats)
+	execIdx   int
 	rowsBySQL map[string]*mockRow // SQL substring → single-row result
 	queryRows *mockRows
 	queryErr  error
 }
 
 func (m *mockDB) Exec(context.Context, string, ...any) (int64, error) {
+	if len(m.execSeq) > 0 {
+		i := m.execIdx
+		if i >= len(m.execSeq) {
+			i = len(m.execSeq) - 1
+		}
+		m.execIdx++
+		return m.execSeq[i].n, m.execSeq[i].err
+	}
 	if m.execErr != nil {
 		return 0, m.execErr
 	}
@@ -92,6 +108,12 @@ func (r *mockRows) Scan(dest ...any) error {
 }
 
 func assignScan(dest, values []any) error {
+	if len(dest) != len(values) {
+		// Mirror pgx, which errors on a column/dest count mismatch rather than
+		// silently truncating — so a SELECT column-list / Scan-arity drift fails
+		// the test instead of passing vacuously.
+		return fmt.Errorf("mock scan: dest len %d != values len %d", len(dest), len(values))
+	}
 	for i, v := range values {
 		switch d := dest[i].(type) {
 		case *string:
@@ -146,10 +168,9 @@ func TestRegistry_Create_ExecError(t *testing.T) {
 }
 
 func TestRegistry_Create_Success(t *testing.T) {
-	db := &mockDB{
-		execN:     1,
-		rowsBySQL: map[string]*mockRow{"MAX(seq)": {values: []any{1}}},
-	}
+	// Two Execs: projection INSERT (RowsAffected 1) then the single-statement event
+	// INSERT (seq computed in-SQL, no separate MAX query).
+	db := &mockDB{execN: 1}
 	r := newRegistryFromDBTX(db)
 	reg, err := r.Create(context.Background(), unitTenant, validSubmit())
 	require.NoError(t, err)
@@ -208,12 +229,11 @@ func TestRegistry_Transition_IllegalRejected(t *testing.T) {
 }
 
 func TestRegistry_Transition_LegalSuccess(t *testing.T) {
+	// loadForUpdate (FOR UPDATE QueryRow) → submitted; then UPDATE + event INSERT
+	// (both Exec, RowsAffected 1; seq computed in-SQL).
 	db := &mockDB{
-		execN: 1,
-		rowsBySQL: map[string]*mockRow{
-			"FOR UPDATE": {values: projectionValues("http", "alice", "", "submitted")},
-			"MAX(seq)":   {values: []any{2}},
-		},
+		execN:     1,
+		rowsBySQL: map[string]*mockRow{"FOR UPDATE": {values: projectionValues("http", "alice", "", "submitted")}},
 	}
 	r := newRegistryFromDBTX(db)
 	got, err := r.Transition(context.Background(), unitTenant, registry.AdvanceInput{ID: "x", To: registry.StateProbing(), Actor: "system"})
@@ -256,13 +276,25 @@ func TestRegistry_History_Success(t *testing.T) {
 	assert.Equal(t, 2, evs[1].Seq)
 }
 
-func TestRegistry_Create_AppendEventSeqError(t *testing.T) {
-	db := &mockDB{
-		execN:     1, // projection insert succeeds
-		rowsBySQL: map[string]*mockRow{"MAX(seq)": {scanErr: errors.New("boom")}},
-	}
+func TestRegistry_Create_AppendEventInsertError(t *testing.T) {
+	// Projection INSERT succeeds (1st Exec, RowsAffected 1); the append-only event
+	// INSERT (2nd Exec) fails → the whole Create surfaces ErrRegistrationRepoQuery
+	// (and the enclosing tx rolls back the projection write).
+	db := &mockDB{execSeq: []execResult{{n: 1}, {err: errors.New("boom")}}}
 	r := newRegistryFromDBTX(db)
 	_, err := r.Create(context.Background(), unitTenant, validSubmit())
+	assertCode(t, err, errcode.ErrRegistrationRepoQuery)
+}
+
+func TestRegistry_History_CorruptState(t *testing.T) {
+	// A to_state the store cannot have produced (NOT NULL real state) fail-closes,
+	// symmetric with Get/List corrupt-state guards.
+	now := time.Unix(0, 0).UTC()
+	db := &mockDB{queryRows: &mockRows{rows: [][]any{
+		{1, "", "bogus", "alice", "", now},
+	}}}
+	r := newRegistryFromDBTX(db)
+	_, err := r.History(context.Background(), unitTenant, "x")
 	assertCode(t, err, errcode.ErrRegistrationRepoQuery)
 }
 

--- a/corecells/registrycore/internal/adapters/postgres/session.go
+++ b/corecells/registrycore/internal/adapters/postgres/session.go
@@ -15,15 +15,17 @@ import (
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 )
 
-// DBTX abstracts the database operations needed by Registry. Both pgxpool.Pool
-// and pgx.Tx satisfy this interface (via the adapters below).
+// DBTX is the cell-local DB abstraction (mirrors pgx.Tx and pgxpool.Pool);
+// defined here rather than importing adapters/postgres, per the layering rule
+// that corecells/ must not depend on adapters/. Both pgxpool.Pool and pgx.Tx
+// satisfy it via the adapters below.
 type DBTX interface {
 	Exec(ctx context.Context, sql string, args ...any) (int64, error)
 	Query(ctx context.Context, sql string, args ...any) (Rows, error)
 	QueryRow(ctx context.Context, sql string, args ...any) RowScanner
 }
 
-// Rows abstracts a query result set.
+// Rows abstracts a query result set (cell-local copy; see DBTX).
 type Rows interface {
 	Next() bool
 	Scan(dest ...any) error

--- a/corecells/registrycore/internal/adapters/postgres/session.go
+++ b/corecells/registrycore/internal/adapters/postgres/session.go
@@ -1,0 +1,117 @@
+// Package postgres provides the PostgreSQL implementation of registrycore's
+// ports.Registry (303-US5, #2236). It does NOT import adapters/postgres — it
+// defines its own DBTX interface to match pgx.Tx / pgxpool.Pool, keeping the
+// cell decoupled from the adapter layer (per layering rules). The shape mirrors
+// configcore/internal/adapters/postgres.
+package postgres
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ghbvf/gocell/framework/kernel/persistence"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+)
+
+// DBTX abstracts the database operations needed by Registry. Both pgxpool.Pool
+// and pgx.Tx satisfy this interface (via the adapters below).
+type DBTX interface {
+	Exec(ctx context.Context, sql string, args ...any) (int64, error)
+	Query(ctx context.Context, sql string, args ...any) (Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) RowScanner
+}
+
+// Rows abstracts a query result set.
+type Rows interface {
+	Next() bool
+	Scan(dest ...any) error
+	Close()
+	Err() error
+}
+
+// RowScanner is a local copy of adapters/postgres.RowScanner; cells/ cannot
+// import adapters/ — intentional per layering rules.
+type RowScanner interface {
+	Scan(dest ...any) error
+}
+
+// Session resolves the ambient pgx.Tx from ctx (placed there by
+// adapters/postgres.TxManager via persistence.TxCtxKey) or falls back to the
+// pool for non-transactional reads.
+//
+// persistence.TxCtxKey is kernel-owned so both layers can share the key without
+// cells/ importing adapters/.
+type Session struct {
+	pool *pgxpool.Pool
+}
+
+// NewSession creates a Session backed by the given pool.
+func NewSession(pool *pgxpool.Pool) *Session {
+	return &Session{pool: pool}
+}
+
+// resolve returns the ambient pgx.Tx (wrapped as DBTX) if one is present in ctx,
+// otherwise returns the pool (wrapped as DBTX). Use for read-only paths.
+func (s *Session) resolve(ctx context.Context) DBTX {
+	if tx, ok := ctx.Value(persistence.TxCtxKey).(pgx.Tx); ok {
+		return &dbtxAdapter{tx: tx}
+	}
+	return &poolAdapter{pool: s.pool}
+}
+
+// resolveWrite returns the ambient pgx.Tx, or an error if none is present. L1
+// write paths (Create, Transition) MUST go through this so the projection write
+// and the append-only history write participate in the same transaction (write
+// fails → roll back, no half state).
+func (s *Session) resolveWrite(ctx context.Context) (DBTX, error) {
+	if tx, ok := ctx.Value(persistence.TxCtxKey).(pgx.Tx); ok {
+		return &dbtxAdapter{tx: tx}, nil
+	}
+	return nil, errcode.New(errcode.KindInternal, errcode.ErrAdapterPGNoTx,
+		"registry repo: write requires a transaction in context")
+}
+
+// dbtxAdapter wraps pgx.Tx to implement the cell-local DBTX interface.
+// pgx.Tx.Exec returns (pgconn.CommandTag, error); DBTX.Exec returns (int64, error).
+type dbtxAdapter struct {
+	tx pgx.Tx
+}
+
+func (a *dbtxAdapter) Exec(ctx context.Context, sql string, args ...any) (int64, error) {
+	tag, err := a.tx.Exec(ctx, sql, args...)
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}
+
+func (a *dbtxAdapter) Query(ctx context.Context, sql string, args ...any) (Rows, error) {
+	return a.tx.Query(ctx, sql, args...)
+}
+
+func (a *dbtxAdapter) QueryRow(ctx context.Context, sql string, args ...any) RowScanner {
+	return a.tx.QueryRow(ctx, sql, args...)
+}
+
+// poolAdapter wraps pgxpool.Pool to implement the cell-local DBTX interface.
+type poolAdapter struct {
+	pool *pgxpool.Pool
+}
+
+func (a *poolAdapter) Exec(ctx context.Context, sql string, args ...any) (int64, error) {
+	tag, err := a.pool.Exec(ctx, sql, args...)
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}
+
+func (a *poolAdapter) Query(ctx context.Context, sql string, args ...any) (Rows, error) {
+	return a.pool.Query(ctx, sql, args...)
+}
+
+func (a *poolAdapter) QueryRow(ctx context.Context, sql string, args ...any) RowScanner {
+	return a.pool.QueryRow(ctx, sql, args...)
+}

--- a/corecells/registrycore/internal/adapters/postgres/session_test.go
+++ b/corecells/registrycore/internal/adapters/postgres/session_test.go
@@ -1,0 +1,105 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/persistence"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+)
+
+// fakeTx is a minimal pgx.Tx implementation that satisfies the interface for
+// context-injection tests. resolve returns it (identity); the Exec/Query/QueryRow
+// overrides let the dbtxAdapter delegation be exercised without a real DB.
+type fakeTx struct {
+	pgx.Tx
+}
+
+func (f *fakeTx) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+
+func TestNewSession_ReturnsSession(t *testing.T) {
+	assert.NotNil(t, NewSession(nil))
+}
+
+func TestNewRegistry_ConstructsWithSession(t *testing.T) {
+	r := NewRegistry(nil, clock.Real())
+	require.NotNil(t, r)
+	require.NotNil(t, r.session)
+}
+
+func TestSession_Resolve_ReturnsTxWhenPresent(t *testing.T) {
+	tx := &fakeTx{}
+	ctx := context.WithValue(context.Background(), persistence.TxCtxKey, pgx.Tx(tx))
+	s := &Session{pool: nil}
+
+	adapter, ok := s.resolve(ctx).(*dbtxAdapter)
+	require.True(t, ok, "resolve should return *dbtxAdapter when tx is in ctx")
+	assert.Equal(t, pgx.Tx(tx), adapter.tx)
+}
+
+func TestSession_Resolve_FallsBackToPoolWhenNoTx(t *testing.T) {
+	s := &Session{pool: nil}
+	_, ok := s.resolve(context.Background()).(*poolAdapter)
+	require.True(t, ok, "resolve should return *poolAdapter when no tx in ctx")
+}
+
+func TestSession_ResolveWrite_WithTx_ReturnsAdapter(t *testing.T) {
+	tx := &fakeTx{}
+	ctx := context.WithValue(context.Background(), persistence.TxCtxKey, pgx.Tx(tx))
+	s := &Session{pool: nil}
+
+	db, err := s.resolveWrite(ctx)
+	require.NoError(t, err)
+	adapter, ok := db.(*dbtxAdapter)
+	require.True(t, ok)
+	assert.Equal(t, pgx.Tx(tx), adapter.tx)
+}
+
+func TestSession_ResolveWrite_WithoutTx_ReturnsErrAdapterPGNoTx(t *testing.T) {
+	s := &Session{pool: nil}
+	_, err := s.resolveWrite(context.Background())
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrAdapterPGNoTx, ec.Code)
+}
+
+// TestRegistry_ResolveRead_UsesSessionWhenPresent verifies the production
+// resolveRead delegates to the session (tx-in-ctx path) rather than the test db.
+func TestRegistry_ResolveRead_UsesSessionWhenPresent(t *testing.T) {
+	tx := &fakeTx{}
+	ctx := context.WithValue(context.Background(), persistence.TxCtxKey, pgx.Tx(tx))
+	r := &Registry{session: &Session{pool: nil}, clk: clock.Real()}
+
+	_, ok := r.resolveRead(ctx).(*dbtxAdapter)
+	require.True(t, ok)
+}
+
+func TestRegistry_ResolveWrite_RequiresTxInProduction(t *testing.T) {
+	r := &Registry{session: &Session{pool: nil}, clk: clock.Real()}
+	_, err := r.resolveWrite(context.Background())
+	var ec *errcode.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, errcode.ErrAdapterPGNoTx, ec.Code)
+}
+
+// TestDBTXAdapter_ExecDelegatesToTx exercises dbtxAdapter.Exec forwarding (the
+// positive tx path: pgconn.CommandTag → int64 RowsAffected) without a real DB.
+// Query/QueryRow delegation is integration-covered (they need a live cursor).
+func TestDBTXAdapter_ExecDelegatesToTx(t *testing.T) {
+	tx := &fakeTx{}
+	ctx := context.WithValue(context.Background(), persistence.TxCtxKey, pgx.Tx(tx))
+	db := (&Session{pool: nil}).resolve(ctx)
+
+	n, err := db.Exec(ctx, "INSERT 1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+}

--- a/corecells/registrycore/internal/adapters/postgres/testmain_integration_test.go
+++ b/corecells/registrycore/internal/adapters/postgres/testmain_integration_test.go
@@ -1,0 +1,22 @@
+//go:build integration
+
+package postgres
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ghbvf/gocell/adapters/postgres/pgtest"
+)
+
+// Package-shared PostgreSQL lifecycle: one container per test binary; per-test
+// isolation via `CREATE DATABASE <test> TEMPLATE <pre-migrated>` clone. See
+// adapters/postgres/pgtest (mirrors configcore's testmain).
+var sharedPG = pgtest.New("gocell_registrycore_repo_test_template")
+
+// TestMain owns shared-container teardown.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	sharedPG.Shutdown()
+	os.Exit(code)
+}

--- a/corecells/registrycore/internal/mem/registry.go
+++ b/corecells/registrycore/internal/mem/registry.go
@@ -1,13 +1,15 @@
 // Package mem provides the in-memory implementation of ports.Registry
 // (303-US5, #2236). It is the demo/no-PG topology store and the test double for
 // the durable contract_registrations store; it wraps one kernel
-// registry.ContractRegistrar per tenant, reusing the sealed state machine,
-// input validation, timestamp stamping, and append-only history wholesale (no
-// logic fork from the kernel).
+// registry.ContractRegistrar per tenant, reusing the sealed state machine, input
+// validation, timestamp stamping, dedup, and append-only history wholesale — no
+// logic fork from the kernel.
 package mem
 
 import (
 	"context"
+	"sort"
+	"sync"
 
 	"github.com/ghbvf/gocell/corecells/registrycore/internal/ports"
 	"github.com/ghbvf/gocell/framework/kernel/clock"
@@ -19,40 +21,96 @@ import (
 // Compile-time check.
 var _ ports.Registry = (*Registry)(nil)
 
-// Registry is the in-memory ports.Registry. (Wave 0 RED stub — real
-// per-tenant ContractRegistrar wrapping lands in Wave 2.)
+const msgInvalidTenant = "registry repo: invalid tenant"
+
+// Registry is the in-memory ports.Registry: one kernel registry.ContractRegistrar
+// per tenant. The kernel registrar IS the sealed state machine + append-only
+// history + dedup; this type only partitions it by tenant, so there is no logic
+// fork. Cross-tenant rows are structurally unreachable (they live in a different
+// inner registrar), so a mismatched access naturally returns not-found, and a
+// registration id is unique only within a tenant (per-tenant dedup).
 type Registry struct {
-	clk clock.Clock
+	mu         sync.Mutex
+	registrars map[tenant.TenantID]*registry.ContractRegistrar
+	clk        clock.Clock
 }
 
 // NewRegistry builds an empty in-memory registry. clk is the required positional
 // clock (clock.Clock convention) the per-tenant registrars use to stamp events.
 func NewRegistry(clk clock.Clock) *Registry {
 	clock.MustHaveClock(clk, "mem.NewRegistry")
-	return &Registry{clk: clk}
+	return &Registry{
+		registrars: make(map[tenant.TenantID]*registry.ContractRegistrar),
+		clk:        clk,
+	}
 }
 
-func errStub() error {
-	return errcode.New(errcode.KindInternal, errcode.ErrNotImplemented,
-		"registrycore mem registry: not implemented (Wave 0 RED stub)")
+// registrarFor returns t's registrar, creating it on first use. It holds the map
+// mutex only for the lookup/insert; the returned registrar is internally
+// synchronized, so per-tenant operations run concurrently.
+func (r *Registry) registrarFor(t tenant.TenantID) *registry.ContractRegistrar {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	reg, ok := r.registrars[t]
+	if !ok {
+		reg = registry.NewContractRegistrar(r.clk)
+		r.registrars[t] = reg
+	}
+	return reg
 }
 
-func (r *Registry) Create(context.Context, tenant.TenantID, registry.SubmitInput) (registry.ContractRegistration, error) {
-	return registry.ContractRegistration{}, errStub()
+func invalidTenant(err error) error {
+	return errcode.Wrap(errcode.KindInvalid, errcode.ErrValidationFailed, msgInvalidTenant, err)
 }
 
-func (r *Registry) Transition(context.Context, tenant.TenantID, registry.AdvanceInput) (registry.ContractRegistration, error) {
-	return registry.ContractRegistration{}, errStub()
+func (r *Registry) Create(_ context.Context, t tenant.TenantID, in registry.SubmitInput) (registry.ContractRegistration, error) {
+	if err := t.Validate(); err != nil {
+		return registry.ContractRegistration{}, invalidTenant(err)
+	}
+	return r.registrarFor(t).Submit(in)
 }
 
-func (r *Registry) Get(context.Context, tenant.TenantID, string) (registry.ContractRegistration, bool, error) {
-	return registry.ContractRegistration{}, false, errStub()
+func (r *Registry) Transition(_ context.Context, t tenant.TenantID, in registry.AdvanceInput) (registry.ContractRegistration, error) {
+	if err := t.Validate(); err != nil {
+		return registry.ContractRegistration{}, invalidTenant(err)
+	}
+	return r.registrarFor(t).Advance(in)
 }
 
-func (r *Registry) List(context.Context, tenant.TenantID, string, int) ([]registry.ContractRegistration, error) {
-	return nil, errStub()
+func (r *Registry) Get(_ context.Context, t tenant.TenantID, id string) (registry.ContractRegistration, bool, error) {
+	if err := t.Validate(); err != nil {
+		return registry.ContractRegistration{}, false, invalidTenant(err)
+	}
+	reg, ok := r.registrarFor(t).Get(id)
+	return reg, ok, nil
 }
 
-func (r *Registry) History(context.Context, tenant.TenantID, string) ([]registry.RegistrationEvent, error) {
-	return nil, errStub()
+func (r *Registry) List(_ context.Context, t tenant.TenantID, afterID string, limit int) ([]registry.ContractRegistration, error) {
+	if err := t.Validate(); err != nil {
+		return nil, invalidTenant(err)
+	}
+	reg := r.registrarFor(t)
+	ids := reg.AllIDs() // sorted ascending
+	start := 0
+	if afterID != "" {
+		start = sort.Search(len(ids), func(i int) bool { return ids[i] > afterID })
+	}
+	out := make([]registry.ContractRegistration, 0)
+	for _, id := range ids[start:] {
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+		if cr, ok := reg.Get(id); ok {
+			out = append(out, cr)
+		}
+	}
+	return out, nil
+}
+
+func (r *Registry) History(_ context.Context, t tenant.TenantID, id string) ([]registry.RegistrationEvent, error) {
+	if err := t.Validate(); err != nil {
+		return nil, invalidTenant(err)
+	}
+	evs, _ := r.registrarFor(t).Events(id)
+	return evs, nil
 }

--- a/corecells/registrycore/internal/mem/registry.go
+++ b/corecells/registrycore/internal/mem/registry.go
@@ -1,0 +1,58 @@
+// Package mem provides the in-memory implementation of ports.Registry
+// (303-US5, #2236). It is the demo/no-PG topology store and the test double for
+// the durable contract_registrations store; it wraps one kernel
+// registry.ContractRegistrar per tenant, reusing the sealed state machine,
+// input validation, timestamp stamping, and append-only history wholesale (no
+// logic fork from the kernel).
+package mem
+
+import (
+	"context"
+
+	"github.com/ghbvf/gocell/corecells/registrycore/internal/ports"
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/registry"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/tenant"
+)
+
+// Compile-time check.
+var _ ports.Registry = (*Registry)(nil)
+
+// Registry is the in-memory ports.Registry. (Wave 0 RED stub — real
+// per-tenant ContractRegistrar wrapping lands in Wave 2.)
+type Registry struct {
+	clk clock.Clock
+}
+
+// NewRegistry builds an empty in-memory registry. clk is the required positional
+// clock (clock.Clock convention) the per-tenant registrars use to stamp events.
+func NewRegistry(clk clock.Clock) *Registry {
+	clock.MustHaveClock(clk, "mem.NewRegistry")
+	return &Registry{clk: clk}
+}
+
+func errStub() error {
+	return errcode.New(errcode.KindInternal, errcode.ErrNotImplemented,
+		"registrycore mem registry: not implemented (Wave 0 RED stub)")
+}
+
+func (r *Registry) Create(context.Context, tenant.TenantID, registry.SubmitInput) (registry.ContractRegistration, error) {
+	return registry.ContractRegistration{}, errStub()
+}
+
+func (r *Registry) Transition(context.Context, tenant.TenantID, registry.AdvanceInput) (registry.ContractRegistration, error) {
+	return registry.ContractRegistration{}, errStub()
+}
+
+func (r *Registry) Get(context.Context, tenant.TenantID, string) (registry.ContractRegistration, bool, error) {
+	return registry.ContractRegistration{}, false, errStub()
+}
+
+func (r *Registry) List(context.Context, tenant.TenantID, string, int) ([]registry.ContractRegistration, error) {
+	return nil, errStub()
+}
+
+func (r *Registry) History(context.Context, tenant.TenantID, string) ([]registry.RegistrationEvent, error) {
+	return nil, errStub()
+}

--- a/corecells/registrycore/internal/mem/registry_test.go
+++ b/corecells/registrycore/internal/mem/registry_test.go
@@ -160,6 +160,23 @@ func TestRegistry_List_OrderedCursorPaginated(t *testing.T) {
 	assert.Equal(t, "d", page2[1].ID)
 }
 
+func TestRegistry_AllMethods_InvalidTenant(t *testing.T) {
+	r, _ := newRegistry(t)
+	zero := tenant.TenantID("")
+	ctx := context.Background()
+
+	_, cErr := r.Create(ctx, zero, registry.SubmitInput{ID: "x", Kind: "http", Submitter: "a"})
+	assertCode(t, cErr, errcode.ErrValidationFailed)
+	_, tErr := r.Transition(ctx, zero, registry.AdvanceInput{ID: "x", To: registry.StateProbing(), Actor: "s"})
+	assertCode(t, tErr, errcode.ErrValidationFailed)
+	_, _, gErr := r.Get(ctx, zero, "x")
+	assertCode(t, gErr, errcode.ErrValidationFailed)
+	_, lErr := r.List(ctx, zero, "", 10)
+	assertCode(t, lErr, errcode.ErrValidationFailed)
+	_, hErr := r.History(ctx, zero, "x")
+	assertCode(t, hErr, errcode.ErrValidationFailed)
+}
+
 func TestRegistry_CrossTenantIsolation(t *testing.T) {
 	r, _ := newRegistry(t)
 	mustCreate(t, r, testTenant, "http.foo.v1", "event", "carol") // non-http kind + distinct submitter

--- a/corecells/registrycore/internal/mem/registry_test.go
+++ b/corecells/registrycore/internal/mem/registry_test.go
@@ -162,7 +162,7 @@ func TestRegistry_List_OrderedCursorPaginated(t *testing.T) {
 
 func TestRegistry_CrossTenantIsolation(t *testing.T) {
 	r, _ := newRegistry(t)
-	mustCreate(t, r, testTenant, "http.foo.v1", "http", "alice")
+	mustCreate(t, r, testTenant, "http.foo.v1", "event", "carol") // non-http kind + distinct submitter
 
 	// Tenant B cannot see tenant A's row.
 	_, ok, err := r.Get(context.Background(), testTenantB, "http.foo.v1")

--- a/corecells/registrycore/internal/mem/registry_test.go
+++ b/corecells/registrycore/internal/mem/registry_test.go
@@ -1,0 +1,178 @@
+package mem
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/framework/kernel/clock/clockmock"
+	"github.com/ghbvf/gocell/framework/kernel/registry"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/tenant"
+)
+
+var (
+	testEpoch   = time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	testTenant  = tenant.TenantID("00000000-0000-0000-0000-000000000001")
+	testTenantB = tenant.TenantID("00000000-0000-0000-0000-000000000002")
+)
+
+func newRegistry(t *testing.T) (*Registry, *clockmock.FakeClock) {
+	t.Helper()
+	clk := clockmock.New(testEpoch)
+	return NewRegistry(clk), clk
+}
+
+func mustCreate(t *testing.T, r *Registry, tn tenant.TenantID, id, kind, submitter string) registry.ContractRegistration {
+	t.Helper()
+	reg, err := r.Create(context.Background(), tn, registry.SubmitInput{ID: id, Kind: kind, Submitter: submitter})
+	require.NoError(t, err)
+	return reg
+}
+
+func assertCode(t *testing.T, err error, want errcode.Code) {
+	t.Helper()
+	var ce *errcode.Error
+	require.True(t, errors.As(err, &ce), "want *errcode.Error, got %v", err)
+	assert.Equal(t, want, ce.Code)
+}
+
+func TestRegistry_Create_RecordsSubmitted(t *testing.T) {
+	r, _ := newRegistry(t)
+	reg := mustCreate(t, r, testTenant, "http.foo.v1", "http", "alice")
+
+	assert.Equal(t, "http.foo.v1", reg.ID)
+	assert.Equal(t, "http", reg.Kind)
+	assert.Equal(t, "alice", reg.Submitter)
+	assert.Equal(t, registry.StateSubmitted(), reg.State)
+	assert.Equal(t, testEpoch, reg.CreatedAt)
+	assert.Equal(t, testEpoch, reg.UpdatedAt)
+
+	// Read-back via Get.
+	got, ok, err := r.Get(context.Background(), testTenant, "http.foo.v1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, reg, got)
+
+	// Initial migration event: From = zero sentinel, To = submitted, Seq = 1.
+	evs, err := r.History(context.Background(), testTenant, "http.foo.v1")
+	require.NoError(t, err)
+	require.Len(t, evs, 1)
+	assert.True(t, evs[0].From.IsZero())
+	assert.Equal(t, registry.StateSubmitted(), evs[0].To)
+	assert.Equal(t, 1, evs[0].Seq)
+	assert.Equal(t, "alice", evs[0].Actor)
+}
+
+func TestRegistry_Create_DuplicateRejected(t *testing.T) {
+	r, _ := newRegistry(t)
+	mustCreate(t, r, testTenant, "http.foo.v1", "http", "alice")
+
+	_, err := r.Create(context.Background(), testTenant, registry.SubmitInput{ID: "http.foo.v1", Kind: "http", Submitter: "bob"})
+	assertCode(t, err, errcode.ErrRegistrationDuplicate)
+}
+
+func TestRegistry_Create_MissingFieldRejected(t *testing.T) {
+	r, _ := newRegistry(t)
+	_, err := r.Create(context.Background(), testTenant, registry.SubmitInput{ID: "", Kind: "http", Submitter: "alice"})
+	assertCode(t, err, errcode.ErrValidationFailed)
+}
+
+func TestRegistry_Transition_LegalAdvancesAndAppends(t *testing.T) {
+	r, clk := newRegistry(t)
+	mustCreate(t, r, testTenant, "http.foo.v1", "http", "alice")
+	clk.Advance(time.Minute)
+
+	got, err := r.Transition(context.Background(), testTenant, registry.AdvanceInput{
+		ID: "http.foo.v1", To: registry.StateProbing(), Actor: "system",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, registry.StateProbing(), got.State)
+	assert.Equal(t, testEpoch.Add(time.Minute), got.UpdatedAt)
+
+	evs, err := r.History(context.Background(), testTenant, "http.foo.v1")
+	require.NoError(t, err)
+	require.Len(t, evs, 2)
+	assert.Equal(t, registry.StateSubmitted(), evs[1].From)
+	assert.Equal(t, registry.StateProbing(), evs[1].To)
+	assert.Equal(t, 2, evs[1].Seq)
+}
+
+func TestRegistry_Transition_IllegalRejectedNoMutation(t *testing.T) {
+	r, _ := newRegistry(t)
+	mustCreate(t, r, testTenant, "http.foo.v1", "http", "alice")
+
+	_, err := r.Transition(context.Background(), testTenant, registry.AdvanceInput{
+		ID: "http.foo.v1", To: registry.StateActive(), Actor: "system", // submitted→active is illegal
+	})
+	assertCode(t, err, errcode.ErrRegistrationInvalidTransition)
+
+	// No half-write: state unchanged, history still length 1.
+	got, _, _ := r.Get(context.Background(), testTenant, "http.foo.v1")
+	assert.Equal(t, registry.StateSubmitted(), got.State)
+	evs, _ := r.History(context.Background(), testTenant, "http.foo.v1")
+	assert.Len(t, evs, 1)
+}
+
+func TestRegistry_Transition_UnknownIDNotFound(t *testing.T) {
+	r, _ := newRegistry(t)
+	_, err := r.Transition(context.Background(), testTenant, registry.AdvanceInput{
+		ID: "missing", To: registry.StateProbing(), Actor: "system",
+	})
+	assertCode(t, err, errcode.ErrRegistrationNotFound)
+}
+
+func TestRegistry_Transition_ApprovedRecordsApprover(t *testing.T) {
+	r, _ := newRegistry(t)
+	mustCreate(t, r, testTenant, "http.foo.v1", "http", "alice")
+	for _, to := range []registry.RegistrationState{
+		registry.StateProbing(), registry.StateConformant(), registry.StatePendingApproval(), registry.StateApproved(),
+	} {
+		_, err := r.Transition(context.Background(), testTenant, registry.AdvanceInput{ID: "http.foo.v1", To: to, Actor: "admin"})
+		require.NoError(t, err)
+	}
+	got, _, _ := r.Get(context.Background(), testTenant, "http.foo.v1")
+	assert.Equal(t, registry.StateApproved(), got.State)
+	assert.Equal(t, "admin", got.Approver)
+}
+
+func TestRegistry_List_OrderedCursorPaginated(t *testing.T) {
+	r, _ := newRegistry(t)
+	for _, id := range []string{"c", "a", "b", "d"} {
+		mustCreate(t, r, testTenant, id, "http", "alice")
+	}
+	// First page, limit 2 → a, b (id ascending).
+	page, err := r.List(context.Background(), testTenant, "", 2)
+	require.NoError(t, err)
+	require.Len(t, page, 2)
+	assert.Equal(t, "a", page[0].ID)
+	assert.Equal(t, "b", page[1].ID)
+
+	// Next page after "b" → c, d.
+	page2, err := r.List(context.Background(), testTenant, "b", 2)
+	require.NoError(t, err)
+	require.Len(t, page2, 2)
+	assert.Equal(t, "c", page2[0].ID)
+	assert.Equal(t, "d", page2[1].ID)
+}
+
+func TestRegistry_CrossTenantIsolation(t *testing.T) {
+	r, _ := newRegistry(t)
+	mustCreate(t, r, testTenant, "http.foo.v1", "http", "alice")
+
+	// Tenant B cannot see tenant A's row.
+	_, ok, err := r.Get(context.Background(), testTenantB, "http.foo.v1")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	page, err := r.List(context.Background(), testTenantB, "", 10)
+	require.NoError(t, err)
+	assert.Empty(t, page)
+
+	// The same id can be independently submitted in tenant B (per-tenant dedup).
+	_, err = r.Create(context.Background(), testTenantB, registry.SubmitInput{ID: "http.foo.v1", Kind: "http", Submitter: "bob"})
+	require.NoError(t, err)
+}

--- a/corecells/registrycore/internal/ports/registry.go
+++ b/corecells/registrycore/internal/ports/registry.go
@@ -62,6 +62,9 @@ type Registry interface {
 	List(ctx context.Context, t tenant.TenantID, afterID string, limit int) ([]registry.ContractRegistration, error)
 
 	// History returns the append-only migration event stream for (t, id), ordered
-	// by Seq ascending, or (nil, nil) if the id is unknown in tenant t.
+	// by Seq ascending. An empty result (nil or empty slice) means "no events" —
+	// callers MUST NOT distinguish an unknown id from one with no events (a
+	// registration always has at least its submit event, so an empty stream in
+	// practice means the id does not exist in tenant t); use Get for existence.
 	History(ctx context.Context, t tenant.TenantID, id string) ([]registry.RegistrationEvent, error)
 }

--- a/corecells/registrycore/internal/ports/registry.go
+++ b/corecells/registrycore/internal/ports/registry.go
@@ -35,6 +35,20 @@ import (
 // back, no half state). Transition's legality is the kernel's single source of
 // truth — implementations validate via registry.Transition(from, to) and MUST NOT
 // re-encode the state machine.
+//
+// # Read scoping under RLS (caller obligation; #2236 review F1)
+//
+// The PG tables carry FORCE ROW LEVEL SECURITY (migration 066). Under the restricted
+// serving role (NOBYPASSRLS) the tenant_isolation policy fail-closes any access whose
+// app.tenant_id GUC is unset — an UNSCOPED read returns 0 rows and an unscoped write
+// is rejected (proven by TestContractRegistrations_RLS_TenantIsolation_ServingRole).
+// The GUC is injected (SET LOCAL) only inside TxManager.RunInTx. Writes already require
+// an ambient tx; the read methods (Get/List/History) therefore impose the same caller
+// obligation: run them within a tenant-scoped tx (tenant.WithScope(ctx, t) + RunInTx),
+// the way the bound service wires reads through a scopedread funnel à la
+// configcore/internal/scopedread. The typed tenant param is the primary isolation;
+// RLS is the DB-Hard backstop the caller must keep effective by scoping reads. That
+// service-side funnel is wired in US6 (#2245) — tracked separately.
 type Registry interface {
 	// Create records a new submission in the submitted state plus its initial
 	// migration event (From = zero sentinel, To = submitted), atomically, scoped to

--- a/corecells/registrycore/internal/ports/registry.go
+++ b/corecells/registrycore/internal/ports/registry.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Registry persists runtime-submitted contract registrations and their
-// append-only migration history, scoped per tenant. It is the durable analogue
+// append-only migration history, scoped per tenant. It is the durable analog
 // of the in-mem kernel registry.ContractRegistrar: the method set mirrors the
 // registrar (Submit→Create, Advance→Transition, Get, AllIDs→List, Events→History)
 // so US6's service swap is mechanical.

--- a/corecells/registrycore/internal/ports/registry.go
+++ b/corecells/registrycore/internal/ports/registry.go
@@ -1,0 +1,67 @@
+// Package ports defines the driven-side interfaces for registrycore (303-US5,
+// #2236). The Registry interface is the durable contract_registrations store
+// behind which both the in-memory (internal/mem) and PostgreSQL
+// (internal/adapters/postgres) implementations sit; US6 (#2245) swaps the cell's
+// submit/list services from the bare in-mem kernel ContractRegistrar onto this
+// interface (mem in demo/no-PG topology, PG when composed).
+package ports
+
+import (
+	"context"
+
+	"github.com/ghbvf/gocell/framework/kernel/registry"
+	"github.com/ghbvf/gocell/framework/pkg/tenant"
+)
+
+// Registry persists runtime-submitted contract registrations and their
+// append-only migration history, scoped per tenant. It is the durable analogue
+// of the in-mem kernel registry.ContractRegistrar: the method set mirrors the
+// registrar (Submit→Create, Advance→Transition, Get, AllIDs→List, Events→History)
+// so US6's service swap is mechanical.
+//
+// # Tenancy (303-US5, #2236; mirrors configcore #1337 PR-2b)
+//
+// Every method takes tenant.TenantID as a mandatory typed positional parameter
+// (param[1], immediately after ctx); "漏传 tenant" is a compile error (the
+// type-system Hard guarantee) and the position is backstopped by archtest
+// TENANT-REPO-PARAM-FUNNEL-01. There is NO tenant-less carve-out: a registration
+// id is unique only within a tenant (PK (tenant_id, id)), so even the by-id Get is
+// tenant-scoped. Cross-tenant rows return not-found, never another tenant's data.
+//
+// # Atomicity & legality (L1)
+//
+// Create and Transition are L1 local-transaction operations: the projection write
+// and the append-only history write land in one transaction (write fails → roll
+// back, no half state). Transition's legality is the kernel's single source of
+// truth — implementations validate via registry.Transition(from, to) and MUST NOT
+// re-encode the state machine.
+type Registry interface {
+	// Create records a new submission in the submitted state plus its initial
+	// migration event (From = zero sentinel, To = submitted), atomically, scoped to
+	// tenant t. in is validated (registry.SubmitInput.Validate) and normalized.
+	// Returns ErrRegistrationDuplicate if (t, in.ID) already exists,
+	// ErrValidationFailed for a missing required field.
+	Create(ctx context.Context, t tenant.TenantID, in registry.SubmitInput) (registry.ContractRegistration, error)
+
+	// Transition advances (t, in.ID) to in.To in one L1 transaction: read the
+	// current state (locked), validate the transition via registry.Transition,
+	// update the projection, and append one migration event. When in.To is
+	// approved, in.Actor is recorded as the registration's Approver. Returns
+	// ErrRegistrationNotFound for an unknown id, ErrRegistrationInvalidTransition
+	// for an illegal/terminal/self transition, ErrValidationFailed for an empty
+	// in.ID or in.Actor.
+	Transition(ctx context.Context, t tenant.TenantID, in registry.AdvanceInput) (registry.ContractRegistration, error)
+
+	// Get returns the registration (t, id), or (zero, false, nil) if no such row
+	// exists in tenant t.
+	Get(ctx context.Context, t tenant.TenantID, id string) (registry.ContractRegistration, bool, error)
+
+	// List returns up to limit registrations in tenant t whose id is strictly
+	// greater than afterID (empty afterID = first page), ordered by id ascending.
+	// The caller may request limit+1 to detect a further page (N+1 hasMore).
+	List(ctx context.Context, t tenant.TenantID, afterID string, limit int) ([]registry.ContractRegistration, error)
+
+	// History returns the append-only migration event stream for (t, id), ordered
+	// by Seq ascending, or (nil, nil) if the id is unknown in tenant t.
+	History(ctx context.Context, t tenant.TenantID, id string) ([]registry.RegistrationEvent, error)
+}

--- a/framework/kernel/registry/registrar.go
+++ b/framework/kernel/registry/registrar.go
@@ -52,8 +52,8 @@ func NewContractRegistrar(clk clock.Clock) *ContractRegistrar {
 // if the id already exists. dedup is by registration id only; the
 // (kind,domain,version,owner) uniqueness quadruple is owned by US15/FR-009.
 func (r *ContractRegistrar) Submit(in SubmitInput) (ContractRegistration, error) {
-	in = in.normalized()
-	if err := in.validate(); err != nil {
+	in = in.Normalized()
+	if err := in.Validate(); err != nil {
 		return ContractRegistration{}, err
 	}
 	r.mu.Lock()
@@ -92,8 +92,8 @@ func (r *ContractRegistrar) Submit(in SubmitInput) (ContractRegistration, error)
 // ErrValidationFailed for an empty in.ID or in.Actor (attribution is required).
 // When in.To is approved, in.Actor is recorded as the registration's Approver.
 func (r *ContractRegistrar) Advance(in AdvanceInput) (ContractRegistration, error) {
-	in = in.normalized()
-	if err := in.validate(); err != nil {
+	in = in.Normalized()
+	if err := in.Validate(); err != nil {
 		return ContractRegistration{}, err
 	}
 	r.mu.Lock()

--- a/framework/kernel/registry/registration.go
+++ b/framework/kernel/registry/registration.go
@@ -73,21 +73,26 @@ type SubmitInput struct {
 	Submitter     string
 }
 
-// normalized returns a copy with the required identity fields trimmed, so padded
+// Normalized returns a copy with the required identity fields trimmed, so padded
 // values (" cell-a ") are stored canonically and a whitespace-only field is
-// caught by validate as missing. Optional free-form fields (PayloadSchema) are
+// caught by Validate as missing. Optional free-form fields (PayloadSchema) are
 // left untouched. Submit normalizes before validating and storing.
-func (in SubmitInput) normalized() SubmitInput {
+//
+// Exported (303-US5, #2236) so a durable ports.Registry implementation validates
+// and canonicalises submit input identically to the in-mem ContractRegistrar —
+// a single validation source, no mem/PG fork.
+func (in SubmitInput) Normalized() SubmitInput {
 	in.ID = strings.TrimSpace(in.ID)
 	in.Kind = strings.TrimSpace(in.Kind)
 	in.Submitter = strings.TrimSpace(in.Submitter)
 	return in
 }
 
-// validate rejects missing required fields with ErrValidationFailed, treating a
+// Validate rejects missing required fields with ErrValidationFailed, treating a
 // whitespace-only value as missing (TrimSpace) — a blank ID is a silent map-key
-// collision, and a blank Submitter is a phantom audit identity.
-func (in SubmitInput) validate() error {
+// collision, and a blank Submitter is a phantom audit identity. Exported for
+// durable-store reuse (see Normalized).
+func (in SubmitInput) Validate() error {
 	missing := ""
 	switch {
 	case strings.TrimSpace(in.ID) == "":
@@ -118,23 +123,25 @@ type AdvanceInput struct {
 	Reason string
 }
 
-// normalized returns a copy with the required identity fields (ID, Actor)
+// Normalized returns a copy with the required identity fields (ID, Actor)
 // trimmed so a padded actor is stored canonically and a whitespace-only one is
-// caught by validate. The optional free-form Reason is left untouched. Advance
-// normalizes before validating and storing.
-func (in AdvanceInput) normalized() AdvanceInput {
+// caught by Validate. The optional free-form Reason is left untouched. Advance
+// normalizes before validating and storing. Exported for durable-store reuse
+// (see SubmitInput.Normalized).
+func (in AdvanceInput) Normalized() AdvanceInput {
 	in.ID = strings.TrimSpace(in.ID)
 	in.Actor = strings.TrimSpace(in.Actor)
 	return in
 }
 
-// validate rejects missing required fields (ID, Actor) with ErrValidationFailed,
+// Validate rejects missing required fields (ID, Actor) with ErrValidationFailed,
 // treating a whitespace-only value as missing (TrimSpace). A non-blank Actor
 // closes the audit-attribution gap: an approve / retire transition must name who
 // performed it, symmetric with SubmitInput requiring a Submitter. To legality is
 // validated by Transition (an illegal/zero target surfaces as
-// ErrRegistrationInvalidTransition, not a missing-field error).
-func (in AdvanceInput) validate() error {
+// ErrRegistrationInvalidTransition, not a missing-field error). Exported for
+// durable-store reuse (see SubmitInput.Normalized).
+func (in AdvanceInput) Validate() error {
 	missing := ""
 	switch {
 	case strings.TrimSpace(in.ID) == "":

--- a/framework/kernel/registry/state.go
+++ b/framework/kernel/registry/state.go
@@ -107,3 +107,25 @@ func (s RegistrationState) IsTerminal() bool {
 		return false
 	}
 }
+
+// ParseState resolves a wire/label string back to its sealed RegistrationState —
+// the inverse of String() and the sole way a durable store reconstructs a state
+// read from its `state TEXT` column without forging one (the unexported field
+// makes a non-zero RegistrationState unconstructable outside this package). The
+// empty string maps to the zero sentinel (ok=true): it is the From of an initial
+// submit event, persisted as '' so folding from '' reproduces the lifecycle. Any
+// other unrecognised label — including [RegistrationStateUnknown] ("unknown"),
+// the fail-closed render that is never a persisted state — returns (zero, false).
+//
+// Added 303-US5 (#2236) for the PostgreSQL ports.Registry implementation.
+func ParseState(s string) (RegistrationState, bool) {
+	if s == "" {
+		return RegistrationState{}, true // zero sentinel — initial-event From
+	}
+	for _, st := range allRegistrationStates {
+		if st.v == s {
+			return st, true
+		}
+	}
+	return RegistrationState{}, false
+}

--- a/framework/kernel/registry/state.go
+++ b/framework/kernel/registry/state.go
@@ -113,9 +113,10 @@ func (s RegistrationState) IsTerminal() bool {
 // read from its `state TEXT` column without forging one (the unexported field
 // makes a non-zero RegistrationState unconstructable outside this package). The
 // empty string maps to the zero sentinel (ok=true): it is the From of an initial
-// submit event, persisted as '' so folding from '' reproduces the lifecycle. Any
-// other unrecognised label — including [RegistrationStateUnknown] ("unknown"),
-// the fail-closed render that is never a persisted state — returns (zero, false).
+// submit event, persisted as an empty string so folding from empty reproduces the
+// lifecycle. Any other unrecognized label — including [RegistrationStateUnknown]
+// ("unknown"), the fail-closed render that is never a persisted state — returns
+// (zero, false).
 //
 // Added 303-US5 (#2236) for the PostgreSQL ports.Registry implementation.
 func ParseState(s string) (RegistrationState, bool) {

--- a/framework/kernel/registry/state_test.go
+++ b/framework/kernel/registry/state_test.go
@@ -130,7 +130,7 @@ func TestParseState_EmptyIsZeroSentinel(t *testing.T) {
 	}
 }
 
-// TestParseState_UnknownRejected verifies an unrecognised label — including the
+// TestParseState_UnknownRejected verifies an unrecognized label — including the
 // fail-closed "unknown" render — is rejected, never silently folded to a state.
 func TestParseState_UnknownRejected(t *testing.T) {
 	t.Parallel()

--- a/framework/kernel/registry/state_test.go
+++ b/framework/kernel/registry/state_test.go
@@ -99,3 +99,44 @@ func TestRegistrationState_IsTerminal(t *testing.T) {
 		}
 	}
 }
+
+// TestParseState_RoundTrips verifies ParseState is the exact inverse of String()
+// for every producible state — the round-trip a durable store relies on to
+// reconstruct a sealed state from its `state TEXT` column.
+func TestParseState_RoundTrips(t *testing.T) {
+	t.Parallel()
+	for _, want := range allRegistrationStates {
+		got, ok := ParseState(want.String())
+		if !ok {
+			t.Errorf("ParseState(%q) ok=false, want true", want.String())
+			continue
+		}
+		if got != want {
+			t.Errorf("ParseState(%q) = %q, want %q", want.String(), got, want)
+		}
+	}
+}
+
+// TestParseState_EmptyIsZeroSentinel verifies the empty string maps to the zero
+// sentinel (ok=true) — the persisted From of an initial submit event.
+func TestParseState_EmptyIsZeroSentinel(t *testing.T) {
+	t.Parallel()
+	got, ok := ParseState("")
+	if !ok {
+		t.Fatal("ParseState(\"\") ok=false, want true (zero sentinel)")
+	}
+	if !got.IsZero() {
+		t.Errorf("ParseState(\"\") = %q, want zero value", got)
+	}
+}
+
+// TestParseState_UnknownRejected verifies an unrecognised label — including the
+// fail-closed "unknown" render — is rejected, never silently folded to a state.
+func TestParseState_UnknownRejected(t *testing.T) {
+	t.Parallel()
+	for _, s := range []string{RegistrationStateUnknown, "garbage", "Submitted", "SUBMITTED"} {
+		if got, ok := ParseState(s); ok {
+			t.Errorf("ParseState(%q) ok=true (=%q), want false", s, got)
+		}
+	}
+}

--- a/framework/pkg/errcode/errcode.go
+++ b/framework/pkg/errcode/errcode.go
@@ -990,6 +990,11 @@ const (
 	// ErrSagaDuplicateInstance). The (kind,domain,version,owner) uniqueness
 	// quadruple is a separate concern owned by US15/FR-009.
 	ErrRegistrationDuplicate Code = "ERR_REGISTRATION_DUPLICATE"
+	// ErrRegistrationRepoQuery signals an infrastructure failure (DB query/scan)
+	// in the durable contract_registrations store (303-US5, #2236), distinct from
+	// the business errors above. Constructed with KindInternal → HTTP 500 (mirrors
+	// ErrConfigRepoQuery).
+	ErrRegistrationRepoQuery Code = "ERR_REGISTRATION_REPO_QUERY"
 )
 
 // PublicError is the structured projection shared by HTTP responses, CLI text

--- a/tools/archtest/tenant_repo_param_funnel_test.go
+++ b/tools/archtest/tenant_repo_param_funnel_test.go
@@ -2,8 +2,8 @@
 
 // tenant_repo_param_funnel_test.go — guards that every tenant-scoped platform
 // repo interface method carries a tenant.TenantID positional parameter.
-// Enrolled repos: accesscore (RoleRepository, UserRepository, PolicyRepository)
-// and configcore (ConfigRepository, FlagRepository).
+// Enrolled repos: accesscore (RoleRepository, UserRepository, PolicyRepository),
+// configcore (ConfigRepository, FlagRepository), and registrycore (Registry).
 //
 //   - INVARIANT: TENANT-REPO-PARAM-FUNNEL-01
 //
@@ -103,8 +103,9 @@ const (
 	tenantPkgPath = PlatformFrameworkModulePath + "/pkg/tenant"
 	// accesscorePortsPkg is also reused by rowscope_repo_param_funnel_test.go
 	// (ROWSCOPE-REPO-PARAM-FUNNEL-01, #1709) — update both files if this path changes.
-	accesscorePortsPkg = PlatformCellsModulePath + "/accesscore/internal/ports"
-	configcorePortsPkg = PlatformCellsModulePath + "/configcore/internal/ports"
+	accesscorePortsPkg   = PlatformCellsModulePath + "/accesscore/internal/ports"
+	configcorePortsPkg   = PlatformCellsModulePath + "/configcore/internal/ports"
+	registrycorePortsPkg = PlatformCellsModulePath + "/registrycore/internal/ports"
 	// tenantRepoParamFixPkg is a relative load path for go/packages — NOT a
 	// platform import path — so it is intentionally not derived from PlatformModulePath.
 	tenantRepoParamFixPkg = "./tools/archtest/internal/tenantrepoparamfixture"
@@ -123,6 +124,10 @@ var tenantScopedRepoIfaces = []string{
 	// configcore ports (configcorePortsPkg)
 	"ConfigRepository",
 	"FlagRepository",
+	// registrycore ports (registrycorePortsPkg) — #2236 303-US5. A registration id
+	// is unique only within a tenant (PK (tenant_id, id)); every method is
+	// tenant-scoped, NO carve-out (no schema-probe method on this interface).
+	"Registry",
 }
 
 // tenantParamCarveOut is the by-PK tenant-deriving read and schema-probe
@@ -232,8 +237,9 @@ func scanTenantRepoParam(
 // returns nil for interfaces not declared in a given package, so the same
 // interface list works across all enrolled packages without filtering.
 var enrolledPortsPkgs = map[string]struct{}{
-	accesscorePortsPkg: {},
-	configcorePortsPkg: {},
+	accesscorePortsPkg:   {},
+	configcorePortsPkg:   {},
+	registrycorePortsPkg: {},
 }
 
 // TestTenantRepoParamFunnel01 asserts every enrolled platform repo interface
@@ -241,7 +247,8 @@ var enrolledPortsPkgs = map[string]struct{}{
 // (after ctx), and that no carve-out entry is stale.
 //
 // Enrolled ports packages: accesscore (RoleRepository, UserRepository,
-// PolicyRepository) and configcore (ConfigRepository, FlagRepository).
+// PolicyRepository), configcore (ConfigRepository, FlagRepository), and
+// registrycore (Registry, #2236).
 func TestTenantRepoParamFunnel01(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
@@ -273,7 +280,7 @@ func TestTenantRepoParamFunnel01(t *testing.T) {
 	if len(allSeen) == 0 {
 		diags = append(diags, Diagnostic{Message: "TENANT-REPO-PARAM-FUNNEL-01: scanned zero repo interface methods — " +
 			"scanner regressed or enrolled ports package paths changed (expected " +
-			accesscorePortsPkg + " and " + configcorePortsPkg + ")"})
+			accesscorePortsPkg + ", " + configcorePortsPkg + " and " + registrycorePortsPkg + ")"})
 	}
 	if totalWithTenant == 0 {
 		diags = append(diags, Diagnostic{Message: "TENANT-REPO-PARAM-FUNNEL-01: zero methods carry a tenant.TenantID " +


### PR DESCRIPTION
## Summary

为 registrycore 补齐 `contract_registrations` 持久化底座（303-US5, #2236）：migration 066 + `ports.Registry` 仓储（in-mem + PG）+ L1 事务状态迁移 + append-only 迁移历史。

## Why / 背景

US4（#2235，已关闭）建好 registrycore cell 骨架 + submit/list 契约，但二者跑在进程内、tenant-agnostic 的内核 `registry.ContractRegistrar` 上——重启即丢、无持久化。US5 补持久化真源：状态迁移走 L1 本地事务（写失败回滚不留半态），迁移历史 append-only（对标 Confluent Schema Registry append-only log / Pact 不可变 verification record）。

**范围 = 持久化底座**（migration + 仓储三层 + 测试）；接线（service swap + cellmodule/corebundle composition）是 US6（#2245）——tasks.md T060 明确「US6 接 US5 store」，cell.go 注释亦写明 composition 归 US6。新仓储在 US5 内由测试驱动验证，US6 再换下内核 registrar，这是 spec 的 wave 分解、非平行结构遗留。

## Refs

- Closes #2236
- 前置 US4 #2235（已关闭）· 接线后续 US6 #2245
- spec：`specs/070-runtime-contract-registry/{spec,tasks,research}.md` US5（T050-T052）
- ref: confluent/schema-registry（append-only log 落库）· pact-foundation/pact（immutable verification record）
- 内部范本：migration `058_create_projection_events`（append-only REVOKE）/ `059_create_policies`（tenant_id + FORCE RLS）· configcore Session/DBTX

## Risk / 兼容性

- **migration 066**（新增 `contract_registrations` 投影表 + `contract_registration_events` append-only 历史表）：非破坏式 DDL（CREATE TABLE/ENABLE/FORCE/CREATE POLICY/REVOKE），Down 可逆。history 表 `REVOKE UPDATE, DELETE FROM gocell_app`（DB 引擎 append-only 主守卫，IF EXISTS 在无该 role 的 dev/template 环境为 no-op）。
- 内核 `registry`：导出 `SubmitInput/AdvanceInput` 的 `Validate()/Normalized()`（原 unexported，纯加法重命名）+ 新增纯函数 `ParseState`；无行为变更、无外部消费方受影响。
- errcode：新增 `ErrRegistrationRepoQuery`（既有 `ERR_REGISTRATION_` 前缀下，prefix golden 不变）。

## Implementation matrix

| 变更 | contract | generated | cell/slice | tests | docs |
|------|----------|-----------|------------|-------|------|
| migration 066 两表 + RLS + REVOKE | — | — | — | append-only REVOKE 集成测试 + schema_guard expectedRLSTables 注册 + version golden | migration 注释 |
| ports.Registry + mem + PG（L1 + append-only） | — | — | registrycore/internal/{ports,mem,adapters/postgres} | mem 单测 + PG mock 单测 + L1/dup/cross-tenant/empty-tenant 集成测试 | godoc |
| 内核 ParseState + 导出校验器 | — | — | — | kernel registry 单测（round-trip / sentinel / reject） | godoc |
| tenant-funnel 入册（AI-HARD-1） | — | — | — | TENANT-REPO-PARAM-FUNNEL-01（registrycore.Registry 全方法带 tenant param） | archtest godoc |

## Test plan

- [x] `go build ./...` 本地通过（framework / corecells / adapters/postgres）
- [x] `go test ./...` 本地通过（mem + PG mock 单测 + kernel registry + errcode + archtest TENANT-REPO-PARAM-FUNNEL-01）
- [x] `golangci-lint run ./...` 0 issues（registrycore / framework registry+errcode / adapters/postgres / tools/archtest）
- [x] 集成测试编译通过（`go vet -tags integration`）；PG 容器集成（L1 原子性回滚 / append-only REVOKE 拒 UPDATE·DELETE / cross-tenant 隔离）在 CI postgres lane 运行

🤖 Generated with [Claude Code](https://claude.com/claude-code)
