### PR TITLE
refactor(archtest): RuntimeScopeConfig 运行时 scope 配置单源 + 规则可移植分类口径 [#2329 #2328]

### DIFF
--- a/cmd/gocell/internal/archtestrunner/discover.go
+++ b/cmd/gocell/internal/archtestrunner/discover.go
@@ -39,13 +39,23 @@ type Shard struct {
 
 // Request is the input to Run and ListTests.
 type Request struct {
-	WorkspaceRoot string // repo root; cwd for `go test`; from cmd/gocell findRoot()
-	Scope         Scope  // default ScopeWorkspace
-	Rule          string // optional INVARIANT rule ID, e.g. "LAYER-05"
-	Changed       bool   // optional: select only changed archtest test files
-	Shard         Shard  // optional shard selection
-	TestJSONOut   string // optional file: write the raw `go test -json` event lines
-	Timeout       string // `go test -timeout` value; default "5m" when empty
+	// WorkspaceRoot is the repo root used as cwd for `go test` (from cmd/gocell findRoot()).
+	// It is the subprocess-runner counterpart of tools/archtest.RuntimeScopeConfig.WorkspaceRoot()
+	// — when the child `go test` process resolves its own in-process RuntimeScopeConfig, it
+	// derives the workspace root from go.work discovery (WorkspaceRoot() is the result).
+	// A future --scope flag (#2331) will allow callers to supply an explicit root here instead
+	// of relying on process-cwd discovery inside the child.
+	WorkspaceRoot string
+	// Scope selects the test suite to run. Only [ScopeWorkspace] is supported today.
+	// The in-process counterpart resolved by the child subprocess is
+	// tools/archtest.RuntimeScopeConfig, which captures the full scope context
+	// (workspace root, target module path, framework/platform paths, scan dirs).
+	Scope       Scope  // default ScopeWorkspace
+	Rule        string // optional INVARIANT rule ID, e.g. "LAYER-05"
+	Changed     bool   // optional: select only changed archtest test files
+	Shard       Shard  // optional shard selection
+	TestJSONOut string // optional file: write the raw `go test -json` event lines
+	Timeout     string // `go test -timeout` value; default "5m" when empty
 }
 
 // TestResult holds the outcome of a single test function.

--- a/docs/plans/202606190832-049-archtest-portable-rule-classification.md
+++ b/docs/plans/202606190832-049-archtest-portable-rule-classification.md
@@ -1,9 +1,10 @@
 # 049 archtest 可移植规则分类口径 + 迁移 roadmap（#1878-A）
 
-> **真值源指针**：本文档是时间点迁移计划，**不是**维护中的全量映射。  
-> 权威活口径 = #2330 代码注册表（`StandardCellRules()` 函数 + 外部安全 API）；  
-> 架构背景 ADR = `docs/architecture/202606041600-1555-adr-archtest-workspace-root-model.md`、`docs/architecture/202605281200-adr-cell-development-external-repo.md`；  
-> Epic = GitHub #1878；相关 issue = #2329（RuntimeScopeConfig）、#2330（注册表 API）、#2333（batch-1 迁移 PR）。
+> **真值源指针**：本文档是时间点迁移计划，**不是**维护中的全量映射。
+>
+> - 权威活口径 = #2330 代码注册表（`StandardCellRules()` 函数 + 外部安全 API）
+> - 架构背景 ADR = `docs/architecture/202606041600-1555-adr-archtest-workspace-root-model.md`、`docs/architecture/202605281200-adr-cell-development-external-repo.md`
+> - Epic = GitHub #1878；相关 issue = #2329（RuntimeScopeConfig）、#2330（注册表 API）、#2333（batch-1 迁移 PR）
 
 ---
 
@@ -108,34 +109,36 @@ scan dirs 四维合并为单一密封值，是规则迁移的运行时载体：
 
 ## 4. 迁移 roadmap
 
-### 4.1 Batch-1（近期，~10–15 条，供 #2333 直接执行）
+### 4.1 Batch-1 候选（**须经 §2 源码信号实证**后方可注册，供 #2333 起步）
 
-**标准**：已有 importable Check*，allowlist 为 GoCell-internal 包（`isGoCellPlatformPkgPath`
-绑定），在消费仓内 allowlist 为空，故整规则是纯 ban，可直接注册无副作用。
+**入选硬标准**（缺一不可，须**逐条按 §2 信号实证**——"importable + 未注册" 仅必要非充分）：
+① 规则逻辑在非 test `.go`（external module 可编译）；② 平台符号路径全派生自 `Platform*` const；
+③ allowlist **全部**经 `isGoCellPlatformPkgPath(pkgPath)` 绑定（消费仓内 allowlist 运行时为空 → 整规则退化纯 ban）；
+④ scan target = running module 自身——**无** `corecells/`/`generated/`/`contracts/` 路径域字面量、**无** reflect
+平台类型 / AST-parse 平台源 / conformance enrollment。
 
-以下是从 signal 判定口径（§2）和已有规则源码派生出的候选 rule-id。这是 **短暂性工作列表**，
-由 #2333 消费后失去维护价值，以实际 PR 合并结果为准：
+下表是从 §2 信号**初筛**的候选——**均未确认 ready**，#2333 须先逐条核源码（尤其标准④）再注册。这是 **短暂性
+工作列表**，以实际 PR 合并结果为准：
 
-| Rule ID | 当前状态 | 迁移阻力 | 备注 |
-|---|---|---|---|
-| `CLOCK-POSITIONAL-INJECTION-01` | importable，未注册 | 低 | allowlist = composition-root carve-outs（GoCell-internal）→ 外部仓无豁免位，纯 ban；godoc 注明"vacuous/false-red 外部"但实为 allowlist 全空 = 纯 ban 而非假通过，须复核 |
-| `BCRYPT-COST-FUNNEL-01` A1 臂 | importable，未注册 | 中 | A1 callee-location 绑 `credential/hasher.go`（GoCell-internal）→ 纯 ban；A2 allowlist 含 GoCell 测试路径，注册时考虑拆臂 |
-| `AUTHZ-MUTATION-APPLY-FUNNEL-01` | importable，未注册 | 中 | allowlist 绑 `PlatformCellsModulePath/accesscore/internal/...`（isGoCellPlatformPkgPath 派生），外部仓无豁免 → 纯 ban；须确认 scan target = 消费仓模块 |
-| `DOMAIN-AUTHZ-FIELD-PRIVATE-01` | importable，未注册 | 中 | 扫 domain.User 类型，allowlist 绑 accesscore internal，外部仓 → 消费仓如无同名 domain.User 则 vacuous-green，须标注此盲区 |
-| `AFTERCOMMIT-HOOK-PURE-TRANSIENT-01` | importable，未注册 | 中-高 | A3 drain-caller allowlist 含 GoCell-internal TxRunner 路径；注册前须支持 `ConfigForExternalCell.ExtraAllowlist` 或改为纯 ban（`RegisterAfterCommit` 调用即报，无豁免）—— 二选一 |
-| `ERRCODE-PREFIX-OWNERSHIP-01` | importable，未注册 | 高 | 扫 `pkg/errcode/testdata/prefix_set.golden`（GoCell-internal 文件），外部仓该文件不存在 → false-red；需 `RuntimeScopeConfig` 参数化 golden 路径才可迁移；归 conditional 桶或 batch-2 |
+| Rule ID | 当前状态 | 待实证项（注册前 #2333 须核） |
+|---|---|---|
+| `BCRYPT-COST-FUNNEL-01` A1 臂 | importable，未注册 | A1 callee-location 绑 `credential/hasher.go`（GoCell-internal）疑似纯 ban；A2 allowlist 含 GoCell 测试路径 → 须**拆臂**后单独注册 A1 |
+| `AUTHZ-MUTATION-APPLY-FUNNEL-01` | importable，未注册 | allowlist 绑 `PlatformCellsModulePath/accesscore/internal/...`（isGoCellPlatformPkgPath 派生）疑似纯 ban；**须核** scan target = 消费仓模块而非硬编码平台路径 |
 
-> **注**：上表为派生候选，不是冻结清单。`CLOCK-POSITIONAL-INJECTION-01`
-> 须在 #2333 中实证：若 carve-out allowlist 经 `isGoCellPlatformPkgPath` 绑定，则为纯 ban；
-> 若为路径字面量，则归 conditional 桶先行参数化。
+> **移出 batch-1 → batch-2 conditional（须先参数化，非零改动）**：
+> `ERRCODE-PREFIX-OWNERSHIP-01`（扫 `pkg/errcode/testdata/prefix_set.golden`，外部仓无该文件 → false-red，须
+> `RuntimeScopeConfig` 参数化 golden 路径）；`AFTERCOMMIT-HOOK-PURE-TRANSIENT-01`（A3 drain-caller allowlist 含
+> GoCell-internal TxRunner 路径，须支持 `ConfigForExternalCell.ExtraAllowlist` 或改纯 ban）。
 >
-> **对比反例（不进 batch-1）**：`DISTLOCK-LOCK-NOT-CONTEXT-01` 经 §2 信号判定归 gocell-internal
-> ——self-check（`runtime/distlock.Lock` 不 implement `context.Context`），scan scope = GoCell
-> framework module，消费仓无该目标类型 → vacuous-green，不可迁移。列此仅示口径如何排除 self-check
-> 类规则，**不是** batch-1 工作项。
+> **排除（§2 信号判定为 gocell-internal，永不迁移）**——示范口径如何过滤 vacuous-green / self-check 类：
+> `CLOCK-POSITIONAL-INJECTION-01`（`tools/archtest/clock_invariants.go` 硬编码 GoCell carve-out，外部仓
+> vacuous-green）；`DOMAIN-AUTHZ-FIELD-PRIVATE-01`（`domain_authz_mutation_funnel_invariants.go` 硬编码
+> `./corecells/accesscore/internal/domain`，消费仓无同名 `domain.User` → vacuous-green）；
+> `DISTLOCK-LOCK-NOT-CONTEXT-01`（self-check `runtime/distlock.Lock` 不 implement `context.Context`，消费仓无
+> 该目标类型 → vacuous-green）。
 
-**真正适合 batch-1 的核心条件**：allowlist 要么为空（纯 ban），要么全部经 `isGoCellPlatformPkgPath`
-绑定（消费仓无对应包 → allowlist 运行时为空 → 等价纯 ban）。满足此条件的规则零改动可注册。
+**核心闭环**：候选**不靠 "importable+未注册" 入选**，而须按 §2 机读信号（尤其标准③④）实证为消费仓纯 ban——
+未过实证者归 batch-2 参数化或排除，避免 #2333 从含 vacuous-green 的错误工作列表起步。
 
 ### 4.2 Batch-2（signal-category，conditional 类，不逐一枚举）
 

--- a/docs/plans/202606190832-049-archtest-portable-rule-classification.md
+++ b/docs/plans/202606190832-049-archtest-portable-rule-classification.md
@@ -1,0 +1,188 @@
+# 049 archtest 可移植规则分类口径 + 迁移 roadmap（#1878-A）
+
+> **真值源指针**：本文档是时间点迁移计划，**不是**维护中的全量映射。  
+> 权威活口径 = #2330 代码注册表（`StandardCellRules()` 函数 + 外部安全 API）；  
+> 架构背景 ADR = `docs/architecture/202606041600-1555-adr-archtest-workspace-root-model.md`、`docs/architecture/202605281200-adr-cell-development-external-repo.md`；  
+> Epic = GitHub #1878；相关 issue = #2329（RuntimeScopeConfig）、#2330（注册表 API）、#2333（batch-1 迁移 PR）。
+
+---
+
+## 1. 焊接点 / 定位
+
+### 1.1 活口径单源是代码注册表，不是本文档
+
+`tools/archtest/external.go` 的 `StandardCellRules()` 是已迁移外部安全规则的权威集合；其
+godoc 块同时列出了"明确不注册"的内部规则及原因。任何规则的当前桶归属，以该文件为准。
+
+本文档的职责仅有两个：
+
+1. 给出**机读派生口径**（§2），让"某规则属于哪个桶"可从规则代码本身计算，而不依赖手工清单；
+2. 给出**迁移 roadmap**（§4），为 #2333 提供可操作的 batch-1 列表，并为 batch-2/3 描述信号品类。
+
+若本文档与 `StandardCellRules()` 冲突，**以代码为准，本文档应更新**。刻意不在此维护全量
+370-ID 映射——手工映射是第二真值源，规则一旦新增或修改便立即漂移，制造虚假安全感。
+
+### 1.2 与 #2329 RuntimeScopeConfig 的关系
+
+`tools/archtest/scope_config.go` 引入的 `RuntimeScopeConfig`（sealed 构造，`DefaultScopeConfig()`
+唯一工厂）将 workspace root、target module path、platform/framework module path、platform cell
+scan dirs 四维合并为单一密封值，是规则迁移的运行时载体：
+
+- **conditional 桶规则**迁移的关键在于将 scan dir / platform cells path 从硬编码字面量切换为
+  从 `RuntimeScopeConfig` 派生。迁移前规则写死 `"corecells/..."` 扫描目标；迁移后从
+  `cfg.PlatformCellScanDirs()` 取，外部消费仓替换为自身 cells 目录即可正确 fire。
+- `TestDefaultScopeConfig_ReproducesGoCellDefaults`（#2329 单测锁）保证替换对 GoCell 自身
+  行为字节兼容。
+
+---
+
+## 2. 三桶判定口径（可派生机读信号）
+
+下表的三列信号**机器可扫**（grep 路径域字面量、检查 `Production` scope 使用、检查派生 vs 字面量），
+故任何规则的桶归属无需查手工清单——从规则源码计算即可。
+
+| 桶 | 判定信号（机器可扫） | 外部仓行为 |
+|---|---|---|
+| **external-safe** | ① 扫描目标 = running module 自身 Go 包（`Run(t, Typed(...))`/`Production(...)`，路径从 go.mod 推导）；② 平台符号路径从 `PlatformModulePath` / `PlatformFrameworkModulePath` 派生（无裸字面量，由 `ARCHTEST-MODULE-PATH-FUNNEL-01` 守）；③ allowlist 均为 GoCell-internal 包（`isGoCellPlatformPkgPath` 绑定），故在消费仓无豁免位，整规则变成**纯 ban**；④ 无 `corecells/` / `generated/` / `contracts/` / `examples/` 路径域字面量；⑤ 无 sealed self-check / reflect 平台类型 AST-parse | 真实 fire——消费仓代码满足 ban 条件即报错；allowlist 为空（消费仓无 GoCell-internal 豁免路径）→ 纯 ban，无假安全 |
+| **gocell-internal** | 任意一项：引用 GoCell 内部布局路径域（`corecells/` / `generated/` / `contracts/` / `examples/`）；或 AST-parse GoCell 平台源文件（如 `pkg/errcode/details.go`）；或 reflect GoCell 平台类型（如 `errcode.PublicDetail`）；或 conformance enrollment 扫描；或 `Production` scope 下扫描硬编码的 GoCell composition root | vacuous-green（消费仓无对应路径/类型，扫零目标→零违规→假通过）或 false-red（消费仓有合理代码被误报） |
+| **conditional** | scan dir / module path 通过字面量写死（如 `"./corecells/accesscore/..."`），但将字面量替换为 `RuntimeScopeConfig` 派生后对消费仓有意义；allowlist 不依赖 GoCell-specific 文件路径 | 替换后 fire；迁移成本低，值得列入 batch-2 |
+
+### 2.1 信号的机器可验证性
+
+| 信号 | 怎么扫 |
+|---|---|
+| 路径域字面量 | `grep -r '"corecells/\|/generated/\|/contracts/'` archtest 源码 |
+| Production scope 使用 | `grep 'Production(' tools/archtest/*.go` |
+| 平台符号派生 vs 字面量 | `ARCHTEST-MODULE-PATH-FUNNEL-01` 已是 CI 守卫（非裸字面量 = 通过） |
+| allowlist 绑 isGoCellPlatformPkgPath | grep `isGoCellPlatformPkgPath` in allowlist/key derivation |
+| conformance enrollment | `grep 'checkSagaConformanceEnrollment\|conformance'` tools/archtest |
+
+---
+
+## 3. 现状 seed（引用已编码事实）
+
+### 3.1 已迁移外部安全集（StandardCellRules 当前 10 条）
+
+以下 ID 直接引自 `StandardCellRules()`（见 `external.go:284–334`），不复制判断：
+
+| # | Rule ID |
+|---|---|
+| 1 | `PANIC-REGISTERED-01` |
+| 2 | `ERRCODE-KIND-LITERAL-01` |
+| 3 | `MESSAGE-CONST-LITERAL-01` |
+| 4 | `EXPORTED-ERROR-NEW-01` |
+| 5 | `SCAFFOLD-DERIVED-FORCEOVERWRITE-01` |
+| 6 | `OUTBOX-RECONSTRUCTION-CALLER-01` |
+| 7 | `PROJECTION-APPLY-HOOK-FUNNEL-01` |
+| 8 | `OUTBOX-HANDLERESULT-FACTORY-PREFERRED-01` |
+| 9 | `SAGA-STEP-COMPENSATE-PURE-01` |
+| 10 | `PROD-MAIN-WIRING-NOOP-REJECT-01` |
+
+这 10 条已完成 M3 迁移（importable Check* + CellRule 注册），是 Epic #1878 的已交付基线。
+
+### 3.2 明确不注册的 gocell-internal 规则
+
+`external.go` godoc 已列出以下"明确不注册"条目及原因摘要（以 external.go 为权威，此处
+仅统计分类依据）：
+
+- **vacuous-green 类**：`ERROR-FIRST-API-01`、`ERROR-FIRST-TYPED-NIL-01`（硬编码 22-路径正向
+  allowlist，外部仓无对应路径）；`OUTBOX-TOPIC-FAILOPEN-01`（sealed entry → 消费仓 compile error
+  前置）；`SCAFFOLD-LISTENER-MARKER-TYPED-CONST-01`（扫 tools/codegen，消费仓无该路径）
+- **false-red + internal layout 类**：`DETAILS-SEALED-FIELD-FROZEN-01`（AST-parse
+  `pkg/errcode/details.go`，消费仓无该文件）；整个 `SAGA-*` 内部族（14 条，扫
+  GoCell runtime/saga layout 或 conformance enrollment）
+
+### 3.3 聚合规模估算
+
+通过路径域信号扫描 `tools/archtest/` 可得：
+
+- 引用 `corecells/` / `generated/` / `contracts/` 的 `.go` 文件（包含 test）约 **130 个**，
+  其中非 test 文件约 **33 个**——这 33 个文件内含规则均倾向 gocell-internal。
+- archtest 包总 Go 文件 **447 个**（含 test）；非 test 文件远小于此。
+- 初步估算：gocell-internal 规则占多数（>60%），external-safe 已迁移 10 条，conditional
+  桶约 10–20 条（主要是 cell-scan 类规则，scan dir 参数化后有意义）。
+
+精确按 rule-id 计数不是本文档目标——以 `StandardCellRules()` + 后续 `#2330` 注册表 API 为准。
+
+---
+
+## 4. 迁移 roadmap
+
+### 4.1 Batch-1（近期，~10–15 条，供 #2333 直接执行）
+
+**标准**：已有 importable Check*，allowlist 为 GoCell-internal 包（`isGoCellPlatformPkgPath`
+绑定），在消费仓内 allowlist 为空，故整规则是纯 ban，可直接注册无副作用。
+
+以下是从 signal 判定口径（§2）和已有规则源码派生出的候选 rule-id。这是 **短暂性工作列表**，
+由 #2333 消费后失去维护价值，以实际 PR 合并结果为准：
+
+| Rule ID | 当前状态 | 迁移阻力 | 备注 |
+|---|---|---|---|
+| `CLOCK-POSITIONAL-INJECTION-01` | importable，未注册 | 低 | allowlist = composition-root carve-outs（GoCell-internal）→ 外部仓无豁免位，纯 ban；godoc 注明"vacuous/false-red 外部"但实为 allowlist 全空 = 纯 ban 而非假通过，须复核 |
+| `BCRYPT-COST-FUNNEL-01` A1 臂 | importable，未注册 | 中 | A1 callee-location 绑 `credential/hasher.go`（GoCell-internal）→ 纯 ban；A2 allowlist 含 GoCell 测试路径，注册时考虑拆臂 |
+| `AUTHZ-MUTATION-APPLY-FUNNEL-01` | importable，未注册 | 中 | allowlist 绑 `PlatformCellsModulePath/accesscore/internal/...`（isGoCellPlatformPkgPath 派生），外部仓无豁免 → 纯 ban；须确认 scan target = 消费仓模块 |
+| `DOMAIN-AUTHZ-FIELD-PRIVATE-01` | importable，未注册 | 中 | 扫 domain.User 类型，allowlist 绑 accesscore internal，外部仓 → 消费仓如无同名 domain.User 则 vacuous-green，须标注此盲区 |
+| `AFTERCOMMIT-HOOK-PURE-TRANSIENT-01` | importable，未注册 | 中-高 | A3 drain-caller allowlist 含 GoCell-internal TxRunner 路径；注册前须支持 `ConfigForExternalCell.ExtraAllowlist` 或改为纯 ban（`RegisterAfterCommit` 调用即报，无豁免）—— 二选一 |
+| `ERRCODE-PREFIX-OWNERSHIP-01` | importable，未注册 | 高 | 扫 `pkg/errcode/testdata/prefix_set.golden`（GoCell-internal 文件），外部仓该文件不存在 → false-red；需 `RuntimeScopeConfig` 参数化 golden 路径才可迁移；归 conditional 桶或 batch-2 |
+| `DISTLOCK-LOCK-NOT-CONTEXT-01` | importable，未注册 | 低 | self-check：`runtime/distlock.Lock` 不 implement `context.Context`；scan scope = GoCell framework module，消费仓无该类型 → vacuous-green；不可迁移（应归 gocell-internal） |
+
+> **注**：上表为派生候选，不是冻结清单。`DISTLOCK-LOCK-NOT-CONTEXT-01` 经信号判定后
+> 归 gocell-internal，不应进入 batch-1，列出仅作对比说明口径正确性。`CLOCK-POSITIONAL-INJECTION-01`
+> 须在 #2333 中实证：若 carve-out allowlist 经 `isGoCellPlatformPkgPath` 绑定，则为纯 ban；
+> 若为路径字面量，则归 conditional 桶先行参数化。
+
+**真正适合 batch-1 的核心条件**：allowlist 要么为空（纯 ban），要么全部经 `isGoCellPlatformPkgPath`
+绑定（消费仓无对应包 → allowlist 运行时为空 → 等价纯 ban）。满足此条件的规则零改动可注册。
+
+### 4.2 Batch-2（signal-category，conditional 类，不逐一枚举）
+
+**信号品类**：scan dir 字面量硬编码（`"./corecells/..."` 等），但逻辑本身与消费仓 cells 目录结构兼容。
+
+**迁移路径**：将字面量替换为 `RuntimeScopeConfig.PlatformCellScanDirs()` 供给，外部消费仓
+通过 `ConfigForExternalCell`（或后续 `#2330` 扩展字段）覆盖扫描根。`DefaultScopeConfig()`
+的默认值锁测试保证 GoCell 自身不回归。
+
+**代表品类**（不枚举 ID）：`cell-scan 类`（扫 platform cells 的 layer/import/style 规则）、
+`composition-root 类`（扫 `cmd/` / `cellmodules/`，外部仓有类似 composition root 需参数化路径）。
+
+**前置条件**：#2329 `RuntimeScopeConfig` 落地（本 PR 分支已完成）；#2330 注册表 API 提供
+consumer scan-dir 覆盖扩展点（blocked-by #2330）。
+
+**风险**：双维护成本——GoCell 自身路径 + 消费仓路径均须在规则内正确派生，测试须覆盖两侧。
+
+### 4.3 Batch-3（gocell-internal，永不迁移）
+
+**信号品类**：conformance enrollment scan、reflect 平台类型 self-check、AST-parse 平台源文件、
+`Production` scope 下扫描写死 GoCell composition root。
+
+**处置**：永远留在 `tools/archtest/` in-repo，不注册进 `StandardCellRules()`。`external.go`
+godoc 已列出不注册理由，是这批规则的权威说明文本。
+
+**代表品类**（以 external.go 现有文本为真值源，不另列）：`SAGA-*` 内部族（~14 条）、
+`DETAILS-SEALED-FIELD-FROZEN-01`、`ERROR-FIRST-*`（正向 allowlist 硬锁平台路径）、
+`DISTLOCK-LOCK-NOT-CONTEXT-01`（self-check，消费仓无目标类型）。
+
+### 4.4 优先级与风险矩阵
+
+| Batch | 优先级 | 主要风险 | 缓解 |
+|---|---|---|---|
+| Batch-1 | 高（#2333 即期交付） | **vacuous-green 假安全信号**：allowlist 误判导致规则在消费仓静默通过但无真实覆盖 | 注册前用 `isGoCellPlatformPkgPath` 验证 allowlist 绑定；补外部仓 RED fixture |
+| Batch-1 | 高 | **forged-path bypass**：外部仓伪造 GoCell-internal 相对路径骗取豁免 | allowlist 必须经 `isGoCellPlatformPkgPath(pkgPath)` 绑定（package-identity，非 rel-path），见 `outbox_reconstruction_caller.go` §forged bypass 描述 |
+| Batch-2 | 中（blocked by #2329/#2330） | **双维护成本**：scan dir 参数化后每次 GoCell 内部布局调整须同步 consumer 文档 | `DefaultScopeConfig()` 锁测试保底；consumer 显式声明 scan dirs（opt-in） |
+| Batch-3 | 不迁移 | N/A | 永远 in-repo；external.go godoc 持续记录原因 |
+
+---
+
+## 5. #2333 验收口径
+
+一条规则迁移为 external-safe（进入 `StandardCellRules()`）须同时满足以下门禁：
+
+| # | 验收条件 | 验证方式 |
+|---|---|---|
+| G1 | 规则逻辑位于非 test `.go` 文件（`Check*` 函数可被外部 module 编译） | `go build ./tools/archtest/...` 在外部模块 `go get` 后成功 |
+| G2 | 所有平台符号路径从 `PlatformModulePath` / `PlatformFrameworkModulePath` 派生，无裸字符串字面量 | `ARCHTEST-MODULE-PATH-FUNNEL-01` CI 通过 |
+| G3 | 扫描目标 = running module（`Run(t, Typed(...))` 或 `Production(...)` 路径从 go.mod 推导，非硬编码 GoCell 路径） | 规则代码不含 `"./corecells/..."` 等路径字面量，或已参数化为 `RuntimeScopeConfig` 派生 |
+| G4 | allowlist 完全经 `isGoCellPlatformPkgPath(pkgPath)` 绑定：在消费仓（pkgPath ∉ `PlatformModulePath/*`）中运行时 allowlist 运行时为空，规则退化为**纯 ban** | 补一个外部仓 RED fixture（`testdata/` 下造违规文件），验证规则对消费仓代码真实报错 |
+| G5 | `CellRule` 注册 `{ID: ruleXxx, Run: CheckXxx}` 进 `StandardCellRules()` 返回切片 | `TestRunStandardCellRules` 在 CI 通过 |
+| G6 | 如规则依赖 `ConfigForExternalCell` 扩展字段（如 `BuildTags`/`ProductionMainPkgs`），文档注明 opt-in 语义且空值不产生 false-positive | `RunStandardCellRules` 的零值 cfg 场景覆盖 |
+| G7 | 无新增 Soft-grade enforcement（见 ai-robust.md §分级） | PR 内含 AI-robust 评级注释（archtest godoc 写 Hard/Medium/Soft） |

--- a/docs/plans/202606190832-049-archtest-portable-rule-classification.md
+++ b/docs/plans/202606190832-049-archtest-portable-rule-classification.md
@@ -124,12 +124,15 @@ scan dirs 四维合并为单一密封值，是规则迁移的运行时载体：
 | `DOMAIN-AUTHZ-FIELD-PRIVATE-01` | importable，未注册 | 中 | 扫 domain.User 类型，allowlist 绑 accesscore internal，外部仓 → 消费仓如无同名 domain.User 则 vacuous-green，须标注此盲区 |
 | `AFTERCOMMIT-HOOK-PURE-TRANSIENT-01` | importable，未注册 | 中-高 | A3 drain-caller allowlist 含 GoCell-internal TxRunner 路径；注册前须支持 `ConfigForExternalCell.ExtraAllowlist` 或改为纯 ban（`RegisterAfterCommit` 调用即报，无豁免）—— 二选一 |
 | `ERRCODE-PREFIX-OWNERSHIP-01` | importable，未注册 | 高 | 扫 `pkg/errcode/testdata/prefix_set.golden`（GoCell-internal 文件），外部仓该文件不存在 → false-red；需 `RuntimeScopeConfig` 参数化 golden 路径才可迁移；归 conditional 桶或 batch-2 |
-| `DISTLOCK-LOCK-NOT-CONTEXT-01` | importable，未注册 | 低 | self-check：`runtime/distlock.Lock` 不 implement `context.Context`；scan scope = GoCell framework module，消费仓无该类型 → vacuous-green；不可迁移（应归 gocell-internal） |
 
-> **注**：上表为派生候选，不是冻结清单。`DISTLOCK-LOCK-NOT-CONTEXT-01` 经信号判定后
-> 归 gocell-internal，不应进入 batch-1，列出仅作对比说明口径正确性。`CLOCK-POSITIONAL-INJECTION-01`
+> **注**：上表为派生候选，不是冻结清单。`CLOCK-POSITIONAL-INJECTION-01`
 > 须在 #2333 中实证：若 carve-out allowlist 经 `isGoCellPlatformPkgPath` 绑定，则为纯 ban；
 > 若为路径字面量，则归 conditional 桶先行参数化。
+>
+> **对比反例（不进 batch-1）**：`DISTLOCK-LOCK-NOT-CONTEXT-01` 经 §2 信号判定归 gocell-internal
+> ——self-check（`runtime/distlock.Lock` 不 implement `context.Context`），scan scope = GoCell
+> framework module，消费仓无该目标类型 → vacuous-green，不可迁移。列此仅示口径如何排除 self-check
+> 类规则，**不是** batch-1 工作项。
 
 **真正适合 batch-1 的核心条件**：allowlist 要么为空（纯 ban），要么全部经 `isGoCellPlatformPkgPath`
 绑定（消费仓无对应包 → allowlist 运行时为空 → 等价纯 ban）。满足此条件的规则零改动可注册。

--- a/tools/archtest/cell_scan_dirs.go
+++ b/tools/archtest/cell_scan_dirs.go
@@ -10,11 +10,16 @@ package archtest
 // a relayout touches one place, and PLATFORM-CELL-SCAN-COVERAGE-01 proves no
 // production platform-cell package escapes the scan set.
 
+// platformCellScanDirsDefault is the package-private single source for the
+// platform-cell scan directories, consumed by both the helper functions below
+// and by [RuntimeScopeConfig.PlatformCellScanDirs] (#2329).
+func platformCellScanDirsDefault() []string { return []string{PlatformCellsDir} }
+
 // platformCellScanDirs returns the on-disk scan root(s) holding GoCell's own
 // platform cells. Since #1560 that is the corecells module dir ([PlatformCellsDir]);
 // the repo root no longer has a cells/ directory.
 func platformCellScanDirs() []string {
-	return []string{PlatformCellsDir}
+	return platformCellScanDirsDefault()
 }
 
 // platformAndExampleCellScanDirs returns the platform-cell scan root plus the
@@ -22,5 +27,5 @@ func platformCellScanDirs() []string {
 // examples/<id>/cells/ on disk). Single source for the recurring
 // DirsScope(root, []string{"cells", "examples"}) pattern.
 func platformAndExampleCellScanDirs() []string {
-	return []string{PlatformCellsDir, "examples"}
+	return append(platformCellScanDirsDefault(), "examples")
 }

--- a/tools/archtest/module_root.go
+++ b/tools/archtest/module_root.go
@@ -17,6 +17,7 @@ const frameworkSubdir = "framework"
 // It delegates to [workspace.WorkspaceRoot] (go.work-first, single-module
 // go.mod fallback) and returns an error rather than calling t.Fatalf, so it is
 // safe to call from non-test contexts such as TestMain.
+// Composed by [RuntimeScopeConfig] (the runtime scope-config single source, #2329).
 //
 // go.work-first means the GoCell monorepo always anchors to the WORKSPACE root
 // — never to a nested module's go.mod when archtest runs from a subdirectory,
@@ -56,6 +57,7 @@ func findModuleRoot(t testing.TB) string {
 // symbol paths as <prefix>+"/framework/kernel/…" (post-#1565 split). The set of
 // ALL workspace modules (production scan / classification) comes from
 // [findWorkspaceModules], not this function.
+// Composed by [RuntimeScopeConfig] (the runtime scope-config single source, #2329).
 //
 // Resolution (never hardcoded, so a module rename / /v2 bump is caught by
 // TestPlatformModulePathMatchesGoMod):

--- a/tools/archtest/pass.go
+++ b/tools/archtest/pass.go
@@ -146,7 +146,7 @@ type RunScope interface {
 type astRunScope struct{ fs Scope }
 
 // typedRunScope dispatches [Run] in typed mode loading patterns from the main
-// module root (resolved via findModuleRoot).
+// module root (resolved via [defaultScopeConfig]).
 type typedRunScope struct {
 	opts     TypedOpts
 	patterns []string
@@ -414,7 +414,7 @@ func collectASTFiles(t testing.TB, scope Scope) (
 //
 // Precondition: root must be a non-empty absolute path. The caller is
 // responsible for this guarantee — the [Typed] / [Fixture] dispatch satisfies
-// it via findModuleRoot, and the [StandaloneModule] dispatch satisfies it via
+// it via [defaultScopeConfig], and the [StandaloneModule] dispatch satisfies it via
 // the filepath.IsAbs guard. No runtime check is performed here to avoid
 // duplicating caller-side enforcement.
 //

--- a/tools/archtest/pass.go
+++ b/tools/archtest/pass.go
@@ -284,14 +284,14 @@ func Run(t testing.TB, scope RunScope, rule Rule) []Diagnostic {
 	case astRunScope:
 		return runAST(t, s.fs, rule)
 	case typedRunScope:
-		return runTypedWithRoot(t, findModuleRoot(t), s.opts, s.patterns, rule)
+		return runTypedWithRoot(t, defaultScopeConfig(t).WorkspaceRoot(), s.opts, s.patterns, rule)
 	case dirRunScope:
 		if !filepath.IsAbs(s.dir) {
 			t.Fatalf("archtest.Run: StandaloneModule requires an absolute module root, got %q", s.dir)
 		}
 		return runStandaloneModuleWithRoot(t, s.dir, s.opts, s.patterns, rule)
 	case fixtureRunScope:
-		return runTypedWithRoot(t, findModuleRoot(t), TypedOpts{
+		return runTypedWithRoot(t, defaultScopeConfig(t).WorkspaceRoot(), TypedOpts{
 			Tests: s.opts.Tests,
 			Tags:  []string{fixtureBuildTag},
 		}, s.patterns, rule)
@@ -329,7 +329,7 @@ func runAST(t testing.TB, fs Scope, rule Rule) []Diagnostic {
 
 // runProduction executes rule in typed mode over the main module's production
 // package set ONLY (every <module>/generated/ package excluded). It resolves
-// the module root via [findModuleRoot], reads the module path from go.mod, and
+// the module root via [defaultScopeConfig], reads the module path from go.mod, and
 // delegates to [typeseval.LoadProductionPackages]; rule is invoked with one
 // Pass per production package (same dedup/ordering as the other typed scopes).
 //
@@ -340,7 +340,7 @@ func runAST(t testing.TB, fs Scope, rule Rule) []Diagnostic {
 //
 // ref: golang.org/x/tools/go/analysis Pass.Files driver-controlled scope
 func runProduction(t testing.TB, opts TypedOpts, rule Rule) []Diagnostic {
-	root := findModuleRoot(t)
+	root := defaultScopeConfig(t).WorkspaceRoot()
 	modules := findWorkspaceModules(t, root)
 	resolver, err := typeseval.LoadProductionPackages(root, modules, opts.Tests, opts.Tags)
 	if err != nil {

--- a/tools/archtest/scope_config.go
+++ b/tools/archtest/scope_config.go
@@ -1,6 +1,9 @@
 package archtest
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 // RuntimeScopeConfig is the resolved, per-run scope context that bundles the
 // workspace root, target module path, framework/platform module paths, and
@@ -8,9 +11,9 @@ import "testing"
 //
 // # Motivation and single-source guarantee
 //
-// Before #2329 these four values were resolved independently at each call site
-// (lookupModuleRoot, moduleImportPath, PlatformFrameworkModulePath, PlatformCellsDir)
-// and passed as separate arguments to runTypedWithRoot / runProduction /
+// Before #2329 these values were resolved independently at each call site
+// (lookupModuleRoot, moduleImportPath, and the Platform* consts) and passed as
+// separate arguments to runTypedWithRoot / runProduction /
 // platformCellScanDirs — making it easy for a site to diverge or forget one
 // of the values. RuntimeScopeConfig is the single construction point: callers
 // obtain it via [DefaultScopeConfig] or [defaultScopeConfig], and the defaults-
@@ -68,11 +71,11 @@ func (c RuntimeScopeConfig) TargetModulePath() string { return c.targetModulePat
 func (c RuntimeScopeConfig) FrameworkModulePath() string { return c.frameworkModulePath }
 
 // PlatformModulePath returns the GoCell org/repo prefix shared by every GoCell
-// module. Equals [PlatformModulePath].
+// module. Equals the [PlatformModulePath] constant.
 func (c RuntimeScopeConfig) PlatformModulePath() string { return c.platformModulePath }
 
 // PlatformCellsModulePath returns the Go module path of GoCell's platform-cells
-// module. Equals [PlatformCellsModulePath].
+// module. Equals the [PlatformCellsModulePath] constant.
 func (c RuntimeScopeConfig) PlatformCellsModulePath() string { return c.platformCellsModulePath }
 
 // PlatformCellScanDirs returns a defensive copy of the repo-relative on-disk
@@ -97,11 +100,11 @@ func (c RuntimeScopeConfig) PlatformCellScanDirs() []string {
 func DefaultScopeConfig() (RuntimeScopeConfig, error) {
 	root, err := lookupModuleRoot()
 	if err != nil {
-		return RuntimeScopeConfig{}, err
+		return RuntimeScopeConfig{}, fmt.Errorf("archtest.DefaultScopeConfig: %w", err)
 	}
 	target, err := moduleImportPath(root)
 	if err != nil {
-		return RuntimeScopeConfig{}, err
+		return RuntimeScopeConfig{}, fmt.Errorf("archtest.DefaultScopeConfig: %w", err)
 	}
 	return RuntimeScopeConfig{
 		workspaceRoot:           root,

--- a/tools/archtest/scope_config.go
+++ b/tools/archtest/scope_config.go
@@ -7,7 +7,8 @@ import (
 
 // RuntimeScopeConfig is the resolved, per-run scope context that bundles the
 // workspace root, target module path, framework/platform module paths, and
-// platform-cell scan directories into a single sealed value.
+// platform-cell scan directories into a single value whose fields are all
+// unexported.
 //
 // # Motivation and single-source guarantee
 //
@@ -20,12 +21,20 @@ import (
 // lock test (TestDefaultScopeConfig_ReproducesGoCellDefaults) pins each field
 // to its pre-#2329 value so behavior is byte-identical.
 //
-// # Sealed construction
+// # Construction (no out-of-package POPULATED value)
 //
-// All fields are unexported and the struct embeds the unexported [scopeConfigSeal]
-// marker field, which makes composite-literal construction outside this package a
-// compile error — the only legitimate mint site is the constructors in this file
-// (a Hard governance property per the ai-robust framework).
+// Every field is unexported, so an external package cannot populate a
+// RuntimeScopeConfig: both keyed (RuntimeScopeConfig{workspaceRoot: …}) and
+// positional composite literals fail to compile outside this package. The only
+// way to obtain a usable value is [DefaultScopeConfig] (the single mint site).
+// That closes the forgery threat — external code cannot fabricate a config with
+// an attacker-chosen targetModulePath.
+//
+// This is NOT an absolute construction ban: the zero value RuntimeScopeConfig{}
+// is still constructible anywhere (Go permits T{} for any struct), but it is
+// inert — every accessor returns ""/nil and it is never a valid config (see
+// TestRuntimeScopeConfig_ZeroValueIsInert). So the guarantee is "no forged
+// POPULATED value" (Hard, via the unexported fields), not "no value at all".
 //
 // # Relation to ConfigForExternalCell and future issues
 //
@@ -46,14 +55,7 @@ type RuntimeScopeConfig struct {
 	platformModulePath      string
 	platformCellsModulePath string
 	platformCellScanDirs    []string
-	_                       scopeConfigSeal
 }
-
-// scopeConfigSeal is the unexported marker that prevents package-external
-// composite-literal construction of [RuntimeScopeConfig]. Any attempt to
-// write archtest.RuntimeScopeConfig{…} outside this package produces a
-// compile error because the blank identifier field _ cannot be named.
-type scopeConfigSeal struct{}
 
 // WorkspaceRoot returns the resolved go.work workspace root (or the module
 // root for a single-module consumer repo). This is the same value returned by

--- a/tools/archtest/scope_config.go
+++ b/tools/archtest/scope_config.go
@@ -1,0 +1,126 @@
+package archtest
+
+import "testing"
+
+// RuntimeScopeConfig is the resolved, per-run scope context that bundles the
+// workspace root, target module path, framework/platform module paths, and
+// platform-cell scan directories into a single sealed value.
+//
+// # Motivation and single-source guarantee
+//
+// Before #2329 these four values were resolved independently at each call site
+// (lookupModuleRoot, moduleImportPath, PlatformFrameworkModulePath, PlatformCellsDir)
+// and passed as separate arguments to runTypedWithRoot / runProduction /
+// platformCellScanDirs — making it easy for a site to diverge or forget one
+// of the values. RuntimeScopeConfig is the single construction point: callers
+// obtain it via [DefaultScopeConfig] or [defaultScopeConfig], and the defaults-
+// lock test (TestDefaultScopeConfig_ReproducesGoCellDefaults) pins each field
+// to its pre-#2329 value so behavior is byte-identical.
+//
+// # Sealed construction
+//
+// All fields are unexported and the struct embeds the unexported [scopeConfigSeal]
+// marker field, which makes composite-literal construction outside this package a
+// compile error — the only legitimate mint site is the constructors in this file
+// (a Hard governance property per the ai-robust framework).
+//
+// # Relation to ConfigForExternalCell and future issues
+//
+// [ConfigForExternalCell] (external.go) is the consumer-supplied description of
+// the module to analyze — the "derive-not-supply" side. RuntimeScopeConfig is the
+// INTERNAL, fully-resolved runtime counterpart assembled from go.work / go.mod
+// discovery. External consumers never construct RuntimeScopeConfig directly; the
+// drivers call [defaultScopeConfig] on their behalf.
+//
+// The future Hard-ening funnel (forcing every helper and rule driver through this
+// config instead of calling [lookupModuleRoot] / [moduleImportPath] directly) is
+// tracked in #2333. The per-runner Scope/WorkspaceRoot wiring in the subprocess
+// runner ([cmd/gocell/internal/archtestrunner.Request]) is tracked in #2331.
+type RuntimeScopeConfig struct {
+	workspaceRoot           string
+	targetModulePath        string
+	frameworkModulePath     string
+	platformModulePath      string
+	platformCellsModulePath string
+	platformCellScanDirs    []string
+	_                       scopeConfigSeal
+}
+
+// scopeConfigSeal is the unexported marker that prevents package-external
+// composite-literal construction of [RuntimeScopeConfig]. Any attempt to
+// write archtest.RuntimeScopeConfig{…} outside this package produces a
+// compile error because the blank identifier field _ cannot be named.
+type scopeConfigSeal struct{}
+
+// WorkspaceRoot returns the resolved go.work workspace root (or the module
+// root for a single-module consumer repo). This is the same value returned by
+// [lookupModuleRoot] and used as the root argument to [runTypedWithRoot].
+func (c RuntimeScopeConfig) WorkspaceRoot() string { return c.workspaceRoot }
+
+// TargetModulePath returns the Go module import-path prefix of the module
+// under analysis (e.g. "github.com/ghbvf/gocell" in GoCell's own dogfood).
+// In GoCell this equals [PlatformModulePath]; in an external consumer repo it
+// equals the consumer's own module path.
+func (c RuntimeScopeConfig) TargetModulePath() string { return c.targetModulePath }
+
+// FrameworkModulePath returns the Go module path of the GoCell framework
+// module (kernel/runtime/pkg). Derived from [PlatformFrameworkModulePath].
+func (c RuntimeScopeConfig) FrameworkModulePath() string { return c.frameworkModulePath }
+
+// PlatformModulePath returns the GoCell org/repo prefix shared by every GoCell
+// module. Equals [PlatformModulePath].
+func (c RuntimeScopeConfig) PlatformModulePath() string { return c.platformModulePath }
+
+// PlatformCellsModulePath returns the Go module path of GoCell's platform-cells
+// module. Equals [PlatformCellsModulePath].
+func (c RuntimeScopeConfig) PlatformCellsModulePath() string { return c.platformCellsModulePath }
+
+// PlatformCellScanDirs returns a defensive copy of the repo-relative on-disk
+// scan roots that hold GoCell's own platform cells. The source is
+// [platformCellScanDirsDefault], shared with [platformCellScanDirs], so both
+// callers agree on the exact set (#2329 single-source requirement).
+func (c RuntimeScopeConfig) PlatformCellScanDirs() []string {
+	out := make([]string, len(c.platformCellScanDirs))
+	copy(out, c.platformCellScanDirs)
+	return out
+}
+
+// DefaultScopeConfig constructs a RuntimeScopeConfig from the running process's
+// go.work / go.mod environment. It resolves the workspace root via
+// [lookupModuleRoot] and the target module path via [moduleImportPath], then
+// assembles the remaining fields from the Platform* consts so that all paths
+// derive from [PlatformModulePath] (ARCHTEST-MODULE-PATH-FUNNEL-01).
+//
+// Returns a non-nil error if workspace root discovery or module-path derivation
+// fails (e.g. no go.work above the cwd and no go.mod found). On error the
+// returned RuntimeScopeConfig is the zero value and must not be used.
+func DefaultScopeConfig() (RuntimeScopeConfig, error) {
+	root, err := lookupModuleRoot()
+	if err != nil {
+		return RuntimeScopeConfig{}, err
+	}
+	target, err := moduleImportPath(root)
+	if err != nil {
+		return RuntimeScopeConfig{}, err
+	}
+	return RuntimeScopeConfig{
+		workspaceRoot:           root,
+		targetModulePath:        target,
+		frameworkModulePath:     PlatformFrameworkModulePath,
+		platformModulePath:      PlatformModulePath,
+		platformCellsModulePath: PlatformCellsModulePath,
+		platformCellScanDirs:    platformCellScanDirsDefault(),
+	}, nil
+}
+
+// defaultScopeConfig is the t.Fatalf wrapper around [DefaultScopeConfig] for
+// use inside test drivers that want fail-loud semantics (the same pattern as
+// [findModuleRoot] wrapping [lookupModuleRoot]).
+func defaultScopeConfig(t testing.TB) RuntimeScopeConfig {
+	t.Helper()
+	cfg, err := DefaultScopeConfig()
+	if err != nil {
+		t.Fatalf("archtest: defaultScopeConfig: %v", err)
+	}
+	return cfg
+}

--- a/tools/archtest/scope_config_test.go
+++ b/tools/archtest/scope_config_test.go
@@ -79,3 +79,21 @@ func TestScopeConfig_ScanDirsSingleSource(t *testing.T) {
 		t.Errorf("cfg.PlatformCellScanDirs() = %v, want %v (platformCellScanDirs)", got, want)
 	}
 }
+
+// TestScopeConfig_ScanDirsDefensiveCopy proves PlatformCellScanDirs() returns a
+// fresh copy each call: a caller that mutates the returned slice must not corrupt
+// the config's internal state (the accessor does make+copy, not an alias).
+func TestScopeConfig_ScanDirsDefensiveCopy(t *testing.T) {
+	cfg, err := DefaultScopeConfig()
+	if err != nil {
+		t.Fatalf("DefaultScopeConfig() error: %v", err)
+	}
+	got := cfg.PlatformCellScanDirs()
+	if len(got) == 0 {
+		t.Fatal("PlatformCellScanDirs() returned an empty slice; cannot test isolation")
+	}
+	got[0] = "MUTATED-BY-CALLER"
+	if again := cfg.PlatformCellScanDirs(); again[0] != PlatformCellsDir {
+		t.Errorf("PlatformCellScanDirs() is not a defensive copy: caller mutation leaked, got %q want %q", again[0], PlatformCellsDir)
+	}
+}

--- a/tools/archtest/scope_config_test.go
+++ b/tools/archtest/scope_config_test.go
@@ -1,0 +1,81 @@
+//go:build archtest
+
+package archtest
+
+// INVARIANT: ARCHTEST-SCOPE-CONFIG-UNIT-01
+//
+// scope_config_test.go is the defaults-lock unit-coverage anchor for the runtime
+// scope-config single source ([RuntimeScopeConfig] / [DefaultScopeConfig], #2329):
+// it pins each resolved field to its pre-#2329 path default so the helper-layer
+// convergence is byte-for-byte behavior-preserving for GoCell's own dogfood.
+// ARCHTEST-SCOPE-CONFIG-UNIT-01 is a unit-coverage anchor (same convention as
+// ARCHTEST-EXTERNAL-SURFACE-01 / ARCHTEST-PASS-DRIVER-UNIT-01), not a production
+// invariant gate.
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestDefaultScopeConfig_ReproducesGoCellDefaults locks the default values of
+// RuntimeScopeConfig to the legacy path defaults, satisfying #2329's
+// requirement: "用单测锁定旧路径默认值".
+//
+// This is the regression anchor: if any default path drifts, this test turns
+// red immediately, before the 370-rule suite has a chance to surface the gap.
+func TestDefaultScopeConfig_ReproducesGoCellDefaults(t *testing.T) {
+	cfg, err := DefaultScopeConfig()
+	if err != nil {
+		t.Fatalf("DefaultScopeConfig() error: %v", err)
+	}
+
+	root, err := lookupModuleRoot()
+	if err != nil {
+		t.Fatalf("lookupModuleRoot() error: %v", err)
+	}
+	if got := cfg.WorkspaceRoot(); got != root {
+		t.Errorf("WorkspaceRoot() = %q, want %q (lookupModuleRoot)", got, root)
+	}
+
+	want, err := moduleImportPath(root)
+	if err != nil {
+		t.Fatalf("moduleImportPath() error: %v", err)
+	}
+	if got := cfg.TargetModulePath(); got != want {
+		t.Errorf("TargetModulePath() = %q, want %q (moduleImportPath)", got, want)
+	}
+
+	// In GoCell's own dogfood the target module == the platform module.
+	if got := cfg.TargetModulePath(); got != PlatformModulePath {
+		t.Errorf("TargetModulePath() = %q, want PlatformModulePath %q", got, PlatformModulePath)
+	}
+
+	if got := cfg.FrameworkModulePath(); got != PlatformFrameworkModulePath {
+		t.Errorf("FrameworkModulePath() = %q, want PlatformFrameworkModulePath %q", got, PlatformFrameworkModulePath)
+	}
+
+	if got := cfg.PlatformModulePath(); got != PlatformModulePath {
+		t.Errorf("PlatformModulePath() = %q, want PlatformModulePath %q", got, PlatformModulePath)
+	}
+
+	if got := cfg.PlatformCellsModulePath(); got != PlatformCellsModulePath {
+		t.Errorf("PlatformCellsModulePath() = %q, want PlatformCellsModulePath %q", got, PlatformCellsModulePath)
+	}
+
+	if got := cfg.PlatformCellScanDirs(); !reflect.DeepEqual(got, []string{PlatformCellsDir}) {
+		t.Errorf("PlatformCellScanDirs() = %v, want %v", got, []string{PlatformCellsDir})
+	}
+}
+
+// TestScopeConfig_ScanDirsSingleSource asserts that RuntimeScopeConfig.PlatformCellScanDirs()
+// and the standalone platformCellScanDirs() helper return the same slice, proving
+// they share a single source (platformCellScanDirsDefault).
+func TestScopeConfig_ScanDirsSingleSource(t *testing.T) {
+	cfg, err := DefaultScopeConfig()
+	if err != nil {
+		t.Fatalf("DefaultScopeConfig() error: %v", err)
+	}
+	if got, want := cfg.PlatformCellScanDirs(), platformCellScanDirs(); !reflect.DeepEqual(got, want) {
+		t.Errorf("cfg.PlatformCellScanDirs() = %v, want %v (platformCellScanDirs)", got, want)
+	}
+}

--- a/tools/archtest/scope_config_test.go
+++ b/tools/archtest/scope_config_test.go
@@ -97,3 +97,33 @@ func TestScopeConfig_ScanDirsDefensiveCopy(t *testing.T) {
 		t.Errorf("PlatformCellScanDirs() is not a defensive copy: caller mutation leaked, got %q want %q", again[0], PlatformCellsDir)
 	}
 }
+
+// TestRuntimeScopeConfig_ZeroValueIsInert documents the construction guarantee
+// honestly: the zero value RuntimeScopeConfig{} IS constructible anywhere (Go
+// permits T{} for any struct, even with all-unexported fields), but it is inert —
+// every accessor returns its empty zero, so it is never a usable config. Only
+// DefaultScopeConfig mints a populated value. The forgery guarantee that DOES
+// hold — external code cannot POPULATE a RuntimeScopeConfig with chosen field
+// values — is a compile-time property of the unexported fields, not assertable
+// here at runtime.
+func TestRuntimeScopeConfig_ZeroValueIsInert(t *testing.T) {
+	var zero RuntimeScopeConfig
+	if got := zero.WorkspaceRoot(); got != "" {
+		t.Errorf("zero.WorkspaceRoot() = %q, want empty", got)
+	}
+	if got := zero.TargetModulePath(); got != "" {
+		t.Errorf("zero.TargetModulePath() = %q, want empty", got)
+	}
+	if got := zero.FrameworkModulePath(); got != "" {
+		t.Errorf("zero.FrameworkModulePath() = %q, want empty", got)
+	}
+	if got := zero.PlatformModulePath(); got != "" {
+		t.Errorf("zero.PlatformModulePath() = %q, want empty", got)
+	}
+	if got := zero.PlatformCellsModulePath(); got != "" {
+		t.Errorf("zero.PlatformCellsModulePath() = %q, want empty", got)
+	}
+	if got := zero.PlatformCellScanDirs(); len(got) != 0 {
+		t.Errorf("zero.PlatformCellScanDirs() = %v, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

引入 archtest **运行时 scope 配置单源** `RuntimeScopeConfig`（#2329）+ **规则可移植性分类口径**文档（#2328），Epic #1878 可移植化 Wave 1。

## Why / 背景

Epic #1878 要让外部独立 cell 仓对**自己的代码**跑同一套 archtest 架构规则。两个前置缺口：

- **#2329**：archtest 的 `{workspace root, target module path, framework/platform module path, platform-cell scan dirs}` 当前散落在 helper 层各 callsite 临时 re-derive（`moduleImportPath(findModuleRoot(t))` / `platformCellScanDirs()`），缺一个统一的运行时配置单源——#2330（external-safe registry/API）与 #2333（规则迁移）无 seam 可建。
- **#2328**：无机读/可审阅的规则分层口径——哪些规则 external-safe、哪些依赖 GoCell 内部 `corecells/`/`generated/`/`contracts/` 布局、哪些可参数化迁移。

本 PR 把四维收敛进 sealed `RuntimeScopeConfig`（helper 层收敛、保持本仓行为字节不变），并产出三桶分类口径 + 迁移 roadmap。

## Refs

- Closes #2328
- Closes #2329
- Epic #1878；后续 #2330（registry/API）/ #2331（`--scope` flag）/ #2333（规则迁移 batch）
- ref: golang.org/x/tools/go/analysis（external surface 对标）；ADR `docs/architecture/202606041600-1555-adr-archtest-workspace-root-model.md`

## Risk / 兼容性

- **行为保持**：GoCell 本仓 archtest 行为字节不变——`RuntimeScopeConfig` 的默认构造逐字段复现旧路径默认值，由新 `TestDefaultScopeConfig_ReproducesGoCellDefaults` + 既有 ~370 规则套 + archtestrunner 三测锁定（`cfg.WorkspaceRoot()` 与 `findModuleRoot(t)` 值恒等）。
- helper 签名**不变**、不碰 ~370 规则与 ~50 callers（批量迁移归 #2333）；runner 仅 `Request.Scope`/`WorkspaceRoot` godoc 对齐（`--scope=framework|workspace` flag 归 #2331）。
- 无 wire 契约 / DB migration / 消费方影响。
- 治理：`RuntimeScopeConfig` sealed 构造（unexported 字段 + marker，包外伪造编译错 = Hard）；复用既有 `ARCHTEST-MODULE-PATH-FUNNEL-01` + `PLATFORM-CELL-SCAN-COVERAGE-01`，无新 funnel；新 `ARCHTEST-SCOPE-CONFIG-UNIT-01` 单元覆盖锚。
- **⚠️ 预存（与本 PR 无关）**：`origin/develop` 夜间 archtest lane 已有 8 个 pre-existing 失败（registrycore #2383 新增 cell 未同步 probename/coverage golden 与 allowlist）。archtest 套件**不门禁 PR CI**（夜间 16-shard，`archtest-nightly.yml`）。本 PR 经全套对拍**零新增失败**（base 8 == 本分支 8），建议另开 issue 给 registrycore 收口。

## Test plan

- [x] `go -C tools build ./...`（default / `-tags=integration` / `-tags=archtest`）+ `go -C cmd/gocell build ./...` 通过
- [x] `go -C tools test -tags=archtest ./archtest/`：新增 `TestDefaultScopeConfig_*` / `TestScopeConfig_ScanDirsSingleSource` 通过；全套对拍 base 零新增失败
- [x] `go -C cmd/gocell test ./internal/archtestrunner/...` 通过
- [x] `golangci-lint run --build-tags=archtest ./archtest/...` 0 issues
