### PR TITLE
refactor(tlsutiltest): #2287 抽取共享 mTLS cert-gen test helper + TLS-TEST-MATERIAL-FUNNEL-01 收口守卫

### DIFF
--- a/adapters/grpc/cert_test.go
+++ b/adapters/grpc/cert_test.go
@@ -1,25 +1,12 @@
 package grpc_test
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
-	"math/big"
 	"net"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/require"
-)
-
-const (
-	// testCertValidity is the validity window for self-signed test certificates.
-	// TEST-TIME-LITERAL-01: file-local const prevents bare time.Duration literals in test bodies.
-	testCertValidity = time.Hour
+	"github.com/ghbvf/gocell/framework/runtime/http/tlsutil/tlsutiltest"
 )
 
 // integTestChain holds PEM-encoded server materials and a ready-to-use client
@@ -32,77 +19,33 @@ type integTestChain struct {
 	clientLeaf    *x509.Certificate
 }
 
-// genIntegChain produces a self-signed CA + server leaf (SAN: 127.0.0.1 + localhost)
-// + client leaf (ExtKeyUsageClientAuth). Uses ECDSA P-256.
+// genIntegChain produces a self-signed CA + server leaf (SAN: 127.0.0.1 + ::1 +
+// localhost) + client leaf (ExtKeyUsageClientAuth). Uses ECDSA P-256.
 //
 // The server SAN must include 127.0.0.1 and localhost so the gRPC client's TLS
 // handshake verification succeeds when dialing those addresses.
 func genIntegChain(t *testing.T) integTestChain {
 	t.Helper()
 
-	// Root CA.
-	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	rootTmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "grpc-test-root"},
-		NotBefore:             time.Now().Add(-testCertValidity),
-		NotAfter:              time.Now().Add(testCertValidity),
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
-	}
-	rootDER, err := x509.CreateCertificate(rand.Reader, rootTmpl, rootTmpl, &rootKey.PublicKey, rootKey)
-	require.NoError(t, err)
-	rootCert, err := x509.ParseCertificate(rootDER)
-	require.NoError(t, err)
-	rootCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootDER})
+	ca := tlsutiltest.NewCA(t)
 
-	// Server leaf — SAN must include 127.0.0.1 + localhost for TLS dial verification.
-	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	serverTmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(2),
-		Subject:      pkix.Name{CommonName: "grpc-test-server"},
-		DNSNames:     []string{"localhost"},
-		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
-		NotBefore:    time.Now().Add(-testCertValidity),
-		NotAfter:     time.Now().Add(testCertValidity),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-	}
-	serverDER, err := x509.CreateCertificate(rand.Reader, serverTmpl, rootCert, &serverKey.PublicKey, rootKey)
-	require.NoError(t, err)
-	serverCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER})
-	serverKeyDER, err := x509.MarshalECPrivateKey(serverKey)
-	require.NoError(t, err)
-	serverKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: serverKeyDER})
+	server := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		DNSNames: []string{"localhost"},
+		IPs:      []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		EKU:      []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
 
 	// Client leaf — ExtKeyUsageClientAuth required for mTLS peer verification.
-	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	clientTmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(3),
-		Subject:      pkix.Name{CommonName: "grpc-test-client"},
-		NotBefore:    time.Now().Add(-testCertValidity),
-		NotAfter:     time.Now().Add(testCertValidity),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-	}
-	clientDER, err := x509.CreateCertificate(rand.Reader, clientTmpl, rootCert, &clientKey.PublicKey, rootKey)
-	require.NoError(t, err)
-	clientLeaf, err := x509.ParseCertificate(clientDER)
-	require.NoError(t, err)
+	// No SPIFFE URI: this is a plain mTLS client, not a workload identity principal.
+	client := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		EKU: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
 
 	return integTestChain{
-		rootCertPEM:   rootCertPEM,
-		serverCertPEM: serverCertPEM,
-		serverKeyPEM:  serverKeyPEM,
-		clientCert: tls.Certificate{
-			Certificate: [][]byte{clientDER},
-			PrivateKey:  clientKey,
-			Leaf:        clientLeaf,
-		},
-		clientLeaf: clientLeaf,
+		rootCertPEM:   ca.CertPEM,
+		serverCertPEM: server.CertPEM,
+		serverKeyPEM:  server.KeyPEM,
+		clientCert:    client.TLSCert,
+		clientLeaf:    client.Cert,
 	}
 }

--- a/adapters/mqtt/config_test.go
+++ b/adapters/mqtt/config_test.go
@@ -1,15 +1,10 @@
 package mqtt
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"errors"
 	"fmt"
-	"math/big"
 	"testing"
 	"time"
 
@@ -18,6 +13,7 @@ import (
 
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/framework/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/framework/runtime/http/tlsutil/tlsutiltest"
 )
 
 // configNegTimeout is used in validation tests that assert negative ConnectTimeout
@@ -550,29 +546,6 @@ func TestNewConfig_DefensivelyClonesTLS(t *testing.T) {
 		"MinVersion must not reflect caller mutation after construction")
 }
 
-// newTestCACert returns a minimal self-signed CA certificate for the cert-pool
-// defensive-copy test. serial distinguishes certs so x509.CertPool.Equal can
-// tell two pools apart.
-func newTestCACert(t *testing.T, serial int64) *x509.Certificate {
-	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	tmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(serial),
-		Subject:               pkix.Name{CommonName: "mqtt-test-ca"},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
-		IsCA:                  true,
-		KeyUsage:              x509.KeyUsageCertSign,
-		BasicConstraintsValid: true,
-	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	require.NoError(t, err)
-	cert, err := x509.ParseCertificate(der)
-	require.NoError(t, err)
-	return cert
-}
-
 // TestNewConfig_DefensivelyClonesTLSPools verifies that post-construction
 // mutation of the caller's RootCAs / ClientCAs *x509.CertPool cannot widen the
 // sealed Config's trust roots. tls.Config.Clone copies the pools by pointer, so
@@ -581,7 +554,7 @@ func newTestCACert(t *testing.T, serial int64) *x509.Certificate {
 // Config trusts — beyond the trust roots validateBrokers verified.
 func TestNewConfig_DefensivelyClonesTLSPools(t *testing.T) {
 	t.Parallel()
-	ca1 := newTestCACert(t, 1)
+	ca1 := tlsutiltest.NewCA(t).Cert
 	rootPool := x509.NewCertPool()
 	rootPool.AddCert(ca1)
 	clientPool := x509.NewCertPool()
@@ -600,7 +573,7 @@ func TestNewConfig_DefensivelyClonesTLSPools(t *testing.T) {
 	pristine.AddCert(ca1)
 
 	// Mutate the caller's pools after construction.
-	ca2 := newTestCACert(t, 2)
+	ca2 := tlsutiltest.NewCA(t).Cert
 	rootPool.AddCert(ca2)
 	clientPool.AddCert(ca2)
 

--- a/adapters/mqtt/integration_tls_test.go
+++ b/adapters/mqtt/integration_tls_test.go
@@ -5,20 +5,13 @@ package mqtt
 import (
 	"bytes"
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"errors"
 	"fmt"
-	"math/big"
 	"net"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/testcontainers/testcontainers-go"
@@ -27,11 +20,9 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/clock"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/framework/pkg/testutil/testtime"
+	"github.com/ghbvf/gocell/framework/runtime/http/tlsutil/tlsutiltest"
 	"github.com/ghbvf/gocell/tests/testutil"
 )
-
-// TEST-TIME-LITERAL-01: file-local const prevents bare time.Duration literals in test bodies.
-const tlsTestCertValidity = time.Hour
 
 // mqttTLSChain holds PEM-encoded server materials and a ready-to-use client
 // tls.Certificate for a full mTLS round-trip test against a mosquitto broker.
@@ -44,93 +35,28 @@ type mqttTLSChain struct {
 
 // genMQTTTLSChain produces a self-signed CA + server leaf (SAN: 127.0.0.1 +
 // localhost) + client leaf (ExtKeyUsageClientAuth). Uses ECDSA P-256.
-//
-// Ported from adapters/grpc/cert_test.go::genIntegChain with naming adapted
-// for the MQTT TLS context.
 func genMQTTTLSChain(t *testing.T) mqttTLSChain {
 	t.Helper()
 
-	// Root CA.
-	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("genMQTTTLSChain: root CA key: %v", err)
-	}
-	rootTmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "mqtt-test-root"},
-		NotBefore:             time.Now().Add(-tlsTestCertValidity),
-		NotAfter:              time.Now().Add(tlsTestCertValidity),
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
-	}
-	rootDER, err := x509.CreateCertificate(rand.Reader, rootTmpl, rootTmpl, &rootKey.PublicKey, rootKey)
-	if err != nil {
-		t.Fatalf("genMQTTTLSChain: root CA cert: %v", err)
-	}
-	rootCert, err := x509.ParseCertificate(rootDER)
-	if err != nil {
-		t.Fatalf("genMQTTTLSChain: parse root CA: %v", err)
-	}
-	caCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootDER})
+	ca := tlsutiltest.NewCA(t)
 
 	// Server leaf — SAN includes 127.0.0.1 + localhost for TLS dial verification.
-	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("genMQTTTLSChain: server key: %v", err)
-	}
-	serverTmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(2),
-		Subject:      pkix.Name{CommonName: "mqtt-test-server"},
-		DNSNames:     []string{"localhost"},
-		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
-		NotBefore:    time.Now().Add(-tlsTestCertValidity),
-		NotAfter:     time.Now().Add(tlsTestCertValidity),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-	}
-	serverDER, err := x509.CreateCertificate(rand.Reader, serverTmpl, rootCert, &serverKey.PublicKey, rootKey)
-	if err != nil {
-		t.Fatalf("genMQTTTLSChain: server cert: %v", err)
-	}
-	serverCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER})
-	serverKeyDER, err := x509.MarshalECPrivateKey(serverKey)
-	if err != nil {
-		t.Fatalf("genMQTTTLSChain: marshal server key: %v", err)
-	}
-	serverKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: serverKeyDER})
+	server := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		DNSNames: []string{"localhost"},
+		IPs:      []net.IP{net.ParseIP("127.0.0.1")},
+		EKU:      []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
 
 	// Client leaf — ExtKeyUsageClientAuth required for mTLS peer verification.
-	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("genMQTTTLSChain: client key: %v", err)
-	}
-	clientTmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(3),
-		Subject:      pkix.Name{CommonName: "mqtt-test-client"},
-		NotBefore:    time.Now().Add(-tlsTestCertValidity),
-		NotAfter:     time.Now().Add(tlsTestCertValidity),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-	}
-	clientDER, err := x509.CreateCertificate(rand.Reader, clientTmpl, rootCert, &clientKey.PublicKey, rootKey)
-	if err != nil {
-		t.Fatalf("genMQTTTLSChain: client cert: %v", err)
-	}
-	clientLeaf, err := x509.ParseCertificate(clientDER)
-	if err != nil {
-		t.Fatalf("genMQTTTLSChain: parse client cert: %v", err)
-	}
+	client := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		EKU: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
 
 	return mqttTLSChain{
-		caCertPEM:     caCertPEM,
-		serverCertPEM: serverCertPEM,
-		serverKeyPEM:  serverKeyPEM,
-		clientCert: tls.Certificate{
-			Certificate: [][]byte{clientDER},
-			PrivateKey:  clientKey,
-			Leaf:        clientLeaf,
-		},
+		caCertPEM:     ca.CertPEM,
+		serverCertPEM: server.CertPEM,
+		serverKeyPEM:  server.KeyPEM,
+		clientCert:    client.TLSCert,
 	}
 }
 

--- a/cellmodules/celltls/celltls_test.go
+++ b/cellmodules/celltls/celltls_test.go
@@ -1,19 +1,9 @@
 package celltls_test
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
-	"math/big"
 	"net/url"
-	"os"
-	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,58 +11,18 @@ import (
 	"github.com/ghbvf/gocell/cellmodules/celltls"
 	kauth "github.com/ghbvf/gocell/framework/kernel/auth"
 	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
+	"github.com/ghbvf/gocell/framework/runtime/http/tlsutil/tlsutiltest"
 )
-
-// testCAValidity is the validity window for test CA certs (TEST-TIME-LITERAL-01:
-// site-specific test deadline as a file-local const, not an inline literal).
-const testCAValidity = 2 * time.Hour
 
 // writeCellMaterial generates a CA + a cell leaf (with a SPIFFE URI SAN) and
 // writes cert/key/ca PEM files into a temp dir, returning their paths.
 func writeCellMaterial(t *testing.T) (certFile, keyFile, caFile string) {
 	t.Helper()
-	dir := t.TempDir()
-
-	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	caTmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "test-ca"},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(testCAValidity),
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign,
-	}
-	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
-	require.NoError(t, err)
-	caCert, err := x509.ParseCertificate(caDER)
-	require.NoError(t, err)
-
-	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	uri, _ := url.Parse("spiffe://example.org/cell/accesscore")
-	leafTmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(2),
-		Subject:      pkix.Name{CommonName: "accesscore"},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
-		URIs:         []*url.URL{uri},
-	}
-	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
-	require.NoError(t, err)
-	leafKeyDER, err := x509.MarshalPKCS8PrivateKey(leafKey)
-	require.NoError(t, err)
-
-	certFile = filepath.Join(dir, "cell.crt")
-	keyFile = filepath.Join(dir, "cell.key")
-	caFile = filepath.Join(dir, "ca.crt")
-	require.NoError(t, os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER}), 0o600))
-	require.NoError(t, os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: leafKeyDER}), 0o600))
-	require.NoError(t, os.WriteFile(caFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}), 0o600))
-	return certFile, keyFile, caFile
+	ca := tlsutiltest.NewCA(t)
+	leaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		URIs: []*url.URL{tlsutiltest.SPIFFEURI(t, "spiffe://example.org/cell/accesscore")},
+	})
+	return leaf.WriteFiles(t, t.TempDir(), ca)
 }
 
 func topo(t *testing.T, remotes ...bootstrap.RemoteCellEndpoint) bootstrap.DeploymentTopology {

--- a/cellmodules/celltransport/resolve_test.go
+++ b/cellmodules/celltransport/resolve_test.go
@@ -2,15 +2,8 @@ package celltransport_test
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"errors"
-	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -25,6 +18,7 @@ import (
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
 	"github.com/ghbvf/gocell/framework/runtime/http/tlsutil"
+	"github.com/ghbvf/gocell/framework/runtime/http/tlsutil/tlsutiltest"
 	"github.com/ghbvf/gocell/framework/runtime/transport"
 )
 
@@ -32,7 +26,6 @@ import (
 // test deadlines, not inline literals).
 const (
 	testReadinessProbeDeadline = 200 * time.Millisecond // short ctx so a silent peer handshake fails fast
-	testCAValidity             = 2 * time.Hour          // test CA cert validity window
 	testSNICaptureWait         = 2 * time.Second        // upper bound waiting for the captured ClientHello SNI
 )
 
@@ -452,47 +445,14 @@ func TestResolve_MTLSReadiness_CompletesHandshake(t *testing.T) {
 // resulting client mTLS identity for trust domain "example.org".
 func genClientIdentity(t *testing.T) tlsutil.ClientIdentity {
 	t.Helper()
-	must := func(err error) {
-		t.Helper()
-		if err != nil {
-			t.Fatal(err)
-		}
+	ca := tlsutiltest.NewCA(t)
+	leaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		URIs: []*url.URL{tlsutiltest.SPIFFEURI(t, "spiffe://example.org/cell/accesscore")},
+	})
+	id, err := tlsutil.NewClientIdentity(leaf.CertPEM, leaf.KeyPEM, ca.Pool, "example.org")
+	if err != nil {
+		t.Fatal(err)
 	}
-	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	must(err)
-	caTmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "ca"},
-		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(testCAValidity),
-		IsCA: true, BasicConstraintsValid: true, KeyUsage: x509.KeyUsageCertSign,
-	}
-	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
-	must(err)
-	caCert, err := x509.ParseCertificate(caDER)
-	must(err)
-
-	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	must(err)
-	uri, err := url.Parse("spiffe://example.org/cell/accesscore")
-	must(err)
-	leafTmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(2), Subject: pkix.Name{CommonName: "accesscore"},
-		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour),
-		KeyUsage:    x509.KeyUsageDigitalSignature,
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
-		URIs:        []*url.URL{uri},
-	}
-	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
-	must(err)
-	leafKeyDER, err := x509.MarshalPKCS8PrivateKey(leafKey)
-	must(err)
-
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER})
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: leafKeyDER})
-	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
-	pool, err := tlsutil.NewClientCAPool(caPEM)
-	must(err)
-	id, err := tlsutil.NewClientIdentity(certPEM, keyPEM, pool, "example.org")
-	must(err)
 	return id
 }
 

--- a/framework/runtime/certlifecycle/testsupport_test.go
+++ b/framework/runtime/certlifecycle/testsupport_test.go
@@ -84,6 +84,10 @@ func (s *fakeSigner) Sign(_ context.Context, req cs.AuthorizedCertRequest) (cs.I
 		NotBefore:    s.notBefore,
 		NotAfter:     s.notAfter,
 	}
+	// x509.CreateCertificate here is intentional and sanctioned by
+	// TLS-TEST-MATERIAL-FUNNEL-01: this is the cert-issuance pipeline under test,
+	// so the cert is system-under-test input, not a reusable cell-identity
+	// fixture — do NOT migrate to tlsutiltest (that would be circular).
 	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &s.key.PublicKey, s.key)
 	if err != nil {
 		return cs.IssuedCert{}, fmt.Errorf("fake sign: create cert: %w", err)

--- a/framework/runtime/certsigning/request_test.go
+++ b/framework/runtime/certsigning/request_test.go
@@ -56,6 +56,10 @@ func testCertDER(t *testing.T, serial *big.Int, notAfter time.Time) []byte {
 		NotBefore:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		NotAfter:     notAfter,
 	}
+	// x509.CreateCertificate here is intentional and sanctioned by
+	// TLS-TEST-MATERIAL-FUNNEL-01: this is the cert-signing pipeline under test,
+	// so the cert is system-under-test input, not a reusable cell-identity
+	// fixture — do NOT migrate to tlsutiltest (that would be circular).
 	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
 	if err != nil {
 		t.Fatalf("create cert: %v", err)

--- a/framework/runtime/http/middleware/mtls_test.go
+++ b/framework/runtime/http/middleware/mtls_test.go
@@ -1,28 +1,23 @@
 package middleware
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/json"
-	"encoding/pem"
 	"io"
-	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/framework/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/framework/runtime/http/tlsutil"
+	"github.com/ghbvf/gocell/framework/runtime/http/tlsutil/tlsutiltest"
 )
 
 func mustURL(t *testing.T, raw string) *url.URL {
@@ -234,97 +229,23 @@ func TestMTLS_PeerIdentityIsolatedFromCert(t *testing.T) {
 
 // ─── Integration: end-to-end handshake via httptest.NewUnstartedServer ───────
 
-// integTestChain holds server + client materials for a full mTLS round-trip.
-type integTestChain struct {
-	rootCertPEM   []byte
-	serverCertPEM []byte
-	serverKeyPEM  []byte
-	clientCert    tls.Certificate
-	clientLeaf    *x509.Certificate
-}
-
-func genIntegChain(t *testing.T) integTestChain {
-	t.Helper()
-
-	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	rootTmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "integ-root"},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
-	}
-	rootDER, err := x509.CreateCertificate(rand.Reader, rootTmpl, rootTmpl, &rootKey.PublicKey, rootKey)
-	require.NoError(t, err)
-	rootCert, err := x509.ParseCertificate(rootDER)
-	require.NoError(t, err)
-	rootCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootDER})
-
-	// Server leaf — must include 127.0.0.1 / localhost in SAN for httptest.
-	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	serverTmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(2),
-		Subject:      pkix.Name{CommonName: "integ-server"},
-		DNSNames:     []string{"localhost"},
-		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-	}
-	serverDER, err := x509.CreateCertificate(rand.Reader, serverTmpl, rootCert, &serverKey.PublicKey, rootKey)
-	require.NoError(t, err)
-	serverCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER})
-	serverKeyDER, err := x509.MarshalECPrivateKey(serverKey)
-	require.NoError(t, err)
-	serverKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: serverKeyDER})
-
-	// Client leaf — CN + DNS SAN + URI SAN so the test asserts a non-trivial PeerIdentity.
-	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	spiffeURI, err := url.Parse("spiffe://example.org/ns/edge/sa/integ-client")
-	require.NoError(t, err)
-	clientTmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(3),
-		Subject: pkix.Name{
-			CommonName:   "integ-client",
-			Organization: []string{"acme"},
-		},
-		DNSNames:    []string{"integ-client.example.com"},
-		URIs:        []*url.URL{spiffeURI},
-		NotBefore:   time.Now().Add(-time.Hour),
-		NotAfter:    time.Now().Add(time.Hour),
-		KeyUsage:    x509.KeyUsageDigitalSignature,
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-	}
-	clientDER, err := x509.CreateCertificate(rand.Reader, clientTmpl, rootCert, &clientKey.PublicKey, rootKey)
-	require.NoError(t, err)
-	clientLeaf, err := x509.ParseCertificate(clientDER)
-	require.NoError(t, err)
-
-	return integTestChain{
-		rootCertPEM:   rootCertPEM,
-		serverCertPEM: serverCertPEM,
-		serverKeyPEM:  serverKeyPEM,
-		clientCert: tls.Certificate{
-			Certificate: [][]byte{clientDER},
-			PrivateKey:  clientKey,
-			Leaf:        clientLeaf,
-		},
-		clientLeaf: clientLeaf,
-	}
-}
-
 func TestMTLS_IntegrationRoundTripViaHTTPTestServer(t *testing.T) {
-	chain := genIntegChain(t)
+	ca := tlsutiltest.NewCA(t)
 
-	caPool, err := tlsutil.NewClientCAPool(chain.rootCertPEM)
+	server := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		DNSNames: []string{"localhost"},
+		IPs:      []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		EKU:      []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	client := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		URIs:     []*url.URL{tlsutiltest.SPIFFEURI(t, "spiffe://example.org/ns/edge/sa/integ-client")},
+		DNSNames: []string{"integ-client.example.com"},
+		EKU:      []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+
+	caPool, err := tlsutil.NewClientCAPool(ca.CertPEM)
 	require.NoError(t, err)
-	serverCfg, err := tlsutil.NewServerMTLSConfig(chain.serverCertPEM, chain.serverKeyPEM, caPool)
+	serverCfg, err := tlsutil.NewServerMTLSConfig(server.CertPEM, server.KeyPEM, caPool)
 	require.NoError(t, err)
 
 	var seenIdentity ctxkeys.PeerIdentity
@@ -341,25 +262,24 @@ func TestMTLS_IntegrationRoundTripViaHTTPTestServer(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	clientCAs := x509.NewCertPool()
-	require.True(t, clientCAs.AppendCertsFromPEM(chain.rootCertPEM))
-	client := &http.Client{
+	require.True(t, clientCAs.AppendCertsFromPEM(ca.CertPEM))
+	httpClient := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				RootCAs:      clientCAs,
-				Certificates: []tls.Certificate{chain.clientCert},
+				Certificates: []tls.Certificate{client.TLSCert},
 				MinVersion:   tls.VersionTLS13,
 			},
 		},
 	}
 
-	resp, err := client.Get(srv.URL + "/")
+	resp, err := httpClient.Get(srv.URL + "/")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = resp.Body.Close() })
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.True(t, seenOK)
-	assert.Equal(t, "integ-client", seenIdentity.Subject.CommonName)
-	assert.Equal(t, []string{"acme"}, seenIdentity.Subject.Organization)
+	assert.Equal(t, "tlsutiltest-leaf", seenIdentity.Subject.CommonName)
 	assert.Equal(t, []string{"integ-client.example.com"}, seenIdentity.DNSNames)
 	require.Len(t, seenIdentity.URIs, 1)
 	assert.Equal(t, "spiffe://example.org/ns/edge/sa/integ-client", seenIdentity.URIs[0].String())

--- a/framework/runtime/http/middleware/mtls_test.go
+++ b/framework/runtime/http/middleware/mtls_test.go
@@ -241,6 +241,7 @@ func TestMTLS_IntegrationRoundTripViaHTTPTestServer(t *testing.T) {
 		URIs:     []*url.URL{tlsutiltest.SPIFFEURI(t, "spiffe://example.org/ns/edge/sa/integ-client")},
 		DNSNames: []string{"integ-client.example.com"},
 		EKU:      []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		Subject:  pkix.Name{CommonName: "integ-client", Organization: []string{"acme"}},
 	})
 
 	caPool, err := tlsutil.NewClientCAPool(ca.CertPEM)
@@ -279,7 +280,8 @@ func TestMTLS_IntegrationRoundTripViaHTTPTestServer(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.True(t, seenOK)
-	assert.Equal(t, "tlsutiltest-leaf", seenIdentity.Subject.CommonName)
+	assert.Equal(t, "integ-client", seenIdentity.Subject.CommonName)
+	assert.Equal(t, []string{"acme"}, seenIdentity.Subject.Organization)
 	assert.Equal(t, []string{"integ-client.example.com"}, seenIdentity.DNSNames)
 	require.Len(t, seenIdentity.URIs, 1)
 	assert.Equal(t, "spiffe://example.org/ns/edge/sa/integ-client", seenIdentity.URIs[0].String())

--- a/framework/runtime/http/tlsutil/client_test.go
+++ b/framework/runtime/http/tlsutil/client_test.go
@@ -1,14 +1,8 @@
 package tlsutil
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
-	"math/big"
 	"net/url"
 	"testing"
 	"time"
@@ -17,79 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/framework/pkg/spiffeid"
+	"github.com/ghbvf/gocell/framework/runtime/http/tlsutil/tlsutiltest"
 )
 
-// testRootCAValidity is the validity window for test root CA certs (TEST-TIME-LITERAL-01:
-// site-specific test deadline as a file-local const, not an inline literal).
-const testRootCAValidity = 2 * time.Hour
-
-// cellChain holds a self-signed root + a cell leaf carrying a SPIFFE URI SAN.
-type cellChain struct {
-	rootCertPEM []byte
-	rootPool    *x509.CertPool
-	leafCertPEM []byte
-	leafKeyPEM  []byte
-	leaf        *x509.Certificate
-}
-
-// genCellChain builds a root CA and a leaf whose URI SANs are `uris`, signed by
-// the root, with the given ExtKeyUsages and validity window. ECDSA P-256.
-func genCellChain(t *testing.T, uris []*url.URL, eku []x509.ExtKeyUsage, notAfter time.Time) cellChain {
-	t.Helper()
-
-	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	rootTmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "test-root"},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(testRootCAValidity),
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign,
-	}
-	rootDER, err := x509.CreateCertificate(rand.Reader, rootTmpl, rootTmpl, &rootKey.PublicKey, rootKey)
-	require.NoError(t, err)
-	rootCert, err := x509.ParseCertificate(rootDER)
-	require.NoError(t, err)
-
-	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	leafTmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(2),
-		Subject:      pkix.Name{CommonName: "test-cell"},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     notAfter,
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  eku,
-		URIs:         uris,
-	}
-	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, rootCert, &leafKey.PublicKey, rootKey)
-	require.NoError(t, err)
-	leaf, err := x509.ParseCertificate(leafDER)
-	require.NoError(t, err)
-
-	leafKeyDER, err := x509.MarshalPKCS8PrivateKey(leafKey)
-	require.NoError(t, err)
-
-	rootPool := x509.NewCertPool()
-	rootPool.AddCert(rootCert)
-
-	return cellChain{
-		rootCertPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootDER}),
-		rootPool:    rootPool,
-		leafCertPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER}),
-		leafKeyPEM:  pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: leafKeyDER}),
-		leaf:        leaf,
-	}
-}
-
-func mustURI(t *testing.T, raw string) *url.URL {
-	t.Helper()
-	u, err := url.Parse(raw)
-	require.NoError(t, err)
-	return u
-}
+// expiredLeafOffset is the offset used to produce an already-expired leaf cert
+// (TEST-TIME-LITERAL-01: site-specific test deadline as a file-local const, not an inline literal).
+const expiredLeafOffset = -time.Minute
 
 func bothAuth() []x509.ExtKeyUsage {
 	return []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
@@ -104,11 +31,13 @@ func mustCellID(t *testing.T, td, cell string) spiffeid.CellID {
 
 func TestNewClientMTLSConfig_PinsFailClosedDefaults(t *testing.T) {
 	t.Parallel()
-	ch := genCellChain(t,
-		[]*url.URL{mustURI(t, "spiffe://example.org/cell/configcore")},
-		bothAuth(), time.Now().Add(time.Hour))
+	ca := tlsutiltest.NewCA(t)
+	leaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		URIs: []*url.URL{tlsutiltest.SPIFFEURI(t, "spiffe://example.org/cell/configcore")},
+		EKU:  bothAuth(),
+	})
 
-	cfg, err := NewClientMTLSConfig(ch.leafCertPEM, ch.leafKeyPEM, ch.rootPool, mustCellID(t, "example.org", "configcore"))
+	cfg, err := NewClientMTLSConfig(leaf.CertPEM, leaf.KeyPEM, ca.Pool, mustCellID(t, "example.org", "configcore"))
 	require.NoError(t, err)
 	assert.Equal(t, uint16(tls.VersionTLS13), cfg.MinVersion, "MinVersion must be pinned to TLS 1.3")
 	assert.True(t, cfg.InsecureSkipVerify, "InsecureSkipVerify must be true (hostname check replaced by SPIFFE-ID verify)")
@@ -118,10 +47,16 @@ func TestNewClientMTLSConfig_PinsFailClosedDefaults(t *testing.T) {
 
 func TestNewClientMTLSConfig_ErrorPaths(t *testing.T) {
 	t.Parallel()
-	ch := genCellChain(t,
-		[]*url.URL{mustURI(t, "spiffe://example.org/cell/configcore")},
-		bothAuth(), time.Now().Add(time.Hour))
+	ca := tlsutiltest.NewCA(t)
+	leaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		URIs: []*url.URL{tlsutiltest.SPIFFEURI(t, "spiffe://example.org/cell/configcore")},
+		EKU:  bothAuth(),
+	})
 	id := mustCellID(t, "example.org", "configcore")
+
+	// A mismatched key: issue a second leaf from the same CA so we have a valid PEM
+	// key that doesn't correspond to leaf.CertPEM.
+	otherLeaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{EKU: bothAuth()})
 
 	tests := []struct {
 		name    string
@@ -131,15 +66,15 @@ func TestNewClientMTLSConfig_ErrorPaths(t *testing.T) {
 		peer    spiffeid.CellID
 		wantErr bool
 	}{
-		{name: "ok", cert: ch.leafCertPEM, key: ch.leafKeyPEM, pool: ch.rootPool, peer: id, wantErr: false},
-		{name: "empty cert", cert: nil, key: ch.leafKeyPEM, pool: ch.rootPool, peer: id, wantErr: true},
-		{name: "empty key", cert: ch.leafCertPEM, key: nil, pool: ch.rootPool, peer: id, wantErr: true},
-		{name: "nil rootCAs", cert: ch.leafCertPEM, key: ch.leafKeyPEM, pool: nil, peer: id, wantErr: true},
-		{name: "zero expected peer id", cert: ch.leafCertPEM, key: ch.leafKeyPEM, pool: ch.rootPool, peer: spiffeid.CellID{}, wantErr: true},
+		{name: "ok", cert: leaf.CertPEM, key: leaf.KeyPEM, pool: ca.Pool, peer: id, wantErr: false},
+		{name: "empty cert", cert: nil, key: leaf.KeyPEM, pool: ca.Pool, peer: id, wantErr: true},
+		{name: "empty key", cert: leaf.CertPEM, key: nil, pool: ca.Pool, peer: id, wantErr: true},
+		{name: "nil rootCAs", cert: leaf.CertPEM, key: leaf.KeyPEM, pool: nil, peer: id, wantErr: true},
+		{name: "zero expected peer id", cert: leaf.CertPEM, key: leaf.KeyPEM, pool: ca.Pool, peer: spiffeid.CellID{}, wantErr: true},
 		{
-			name: "mismatched cert/key", cert: ch.leafCertPEM,
-			key:  genCellChain(t, nil, bothAuth(), time.Now().Add(time.Hour)).leafKeyPEM,
-			pool: ch.rootPool, peer: id, wantErr: true,
+			name: "mismatched cert/key", cert: leaf.CertPEM,
+			key:  otherLeaf.KeyPEM,
+			pool: ca.Pool, peer: id, wantErr: true,
 		},
 	}
 	for _, tc := range tests {
@@ -164,59 +99,68 @@ func TestVerifyConnection(t *testing.T) {
 
 	// Build the config once against a server peer whose cert chains to `serverCA`
 	// and asserts identity == expected.
-	server := genCellChain(t,
-		[]*url.URL{mustURI(t, "spiffe://example.org/cell/configcore")},
-		bothAuth(), time.Now().Add(time.Hour))
+	serverCA := tlsutiltest.NewCA(t)
+	server := serverCA.IssueLeaf(t, tlsutiltest.LeafOptions{
+		URIs: []*url.URL{tlsutiltest.SPIFFEURI(t, "spiffe://example.org/cell/configcore")},
+		EKU:  bothAuth(),
+	})
 	// A client cert/key just to satisfy the config builder; not used by verify.
-	client := genCellChain(t,
-		[]*url.URL{mustURI(t, "spiffe://example.org/cell/accesscore")},
-		bothAuth(), time.Now().Add(time.Hour))
+	clientCA := tlsutiltest.NewCA(t)
+	client := clientCA.IssueLeaf(t, tlsutiltest.LeafOptions{
+		URIs: []*url.URL{tlsutiltest.SPIFFEURI(t, "spiffe://example.org/cell/accesscore")},
+		EKU:  bothAuth(),
+	})
 
 	build := func(peerCAPool *x509.CertPool, peer spiffeid.CellID) *tls.Config {
-		cfg, err := NewClientMTLSConfig(client.leafCertPEM, client.leafKeyPEM, peerCAPool, peer)
+		cfg, err := NewClientMTLSConfig(client.CertPEM, client.KeyPEM, peerCAPool, peer)
 		require.NoError(t, err)
 		return cfg
 	}
 
 	t.Run("valid: chained + matching SPIFFE id", func(t *testing.T) {
 		t.Parallel()
-		cfg := build(server.rootPool, expected)
-		err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{server.leaf}})
+		cfg := build(serverCA.Pool, expected)
+		err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{server.Cert}})
 		assert.NoError(t, err)
 	})
 
 	t.Run("reject: no peer certificate", func(t *testing.T) {
 		t.Parallel()
-		cfg := build(server.rootPool, expected)
+		cfg := build(serverCA.Pool, expected)
 		err := cfg.VerifyConnection(tls.ConnectionState{})
 		assert.Error(t, err)
 	})
 
 	t.Run("reject: wrong cell SPIFFE id", func(t *testing.T) {
 		t.Parallel()
-		wrong := genCellChain(t,
-			[]*url.URL{mustURI(t, "spiffe://example.org/cell/auditcore")},
-			bothAuth(), time.Now().Add(time.Hour))
-		cfg := build(wrong.rootPool, expected) // expects configcore, peer is auditcore
-		err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{wrong.leaf}})
+		wrongCA := tlsutiltest.NewCA(t)
+		wrong := wrongCA.IssueLeaf(t, tlsutiltest.LeafOptions{
+			URIs: []*url.URL{tlsutiltest.SPIFFEURI(t, "spiffe://example.org/cell/auditcore")},
+			EKU:  bothAuth(),
+		})
+		cfg := build(wrongCA.Pool, expected) // expects configcore, peer is auditcore
+		err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{wrong.Cert}})
 		assert.Error(t, err)
 	})
 
 	t.Run("reject: wrong trust domain", func(t *testing.T) {
 		t.Parallel()
-		other := genCellChain(t,
-			[]*url.URL{mustURI(t, "spiffe://other.org/cell/configcore")},
-			bothAuth(), time.Now().Add(time.Hour))
-		cfg := build(other.rootPool, expected) // expects example.org, peer is other.org
-		err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{other.leaf}})
+		otherCA := tlsutiltest.NewCA(t)
+		other := otherCA.IssueLeaf(t, tlsutiltest.LeafOptions{
+			URIs: []*url.URL{tlsutiltest.SPIFFEURI(t, "spiffe://other.org/cell/configcore")},
+			EKU:  bothAuth(),
+		})
+		cfg := build(otherCA.Pool, expected) // expects example.org, peer is other.org
+		err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{other.Cert}})
 		assert.Error(t, err)
 	})
 
 	t.Run("reject: no SPIFFE SAN", func(t *testing.T) {
 		t.Parallel()
-		bare := genCellChain(t, nil, bothAuth(), time.Now().Add(time.Hour))
-		cfg := build(bare.rootPool, expected)
-		err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{bare.leaf}})
+		bareCA := tlsutiltest.NewCA(t)
+		bare := bareCA.IssueLeaf(t, tlsutiltest.LeafOptions{EKU: bothAuth()})
+		cfg := build(bareCA.Pool, expected)
+		err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{bare.Cert}})
 		assert.Error(t, err)
 	})
 
@@ -224,29 +168,36 @@ func TestVerifyConnection(t *testing.T) {
 		t.Parallel()
 		// Verify against an unrelated CA pool: chain build must fail even though
 		// the SPIFFE id matches — proves we are NOT fail-open on chain.
-		unrelated := genCellChain(t, nil, bothAuth(), time.Now().Add(time.Hour))
-		cfg := build(unrelated.rootPool, expected)
-		err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{server.leaf}})
+		unrelatedCA := tlsutiltest.NewCA(t)
+		unrelated := unrelatedCA.IssueLeaf(t, tlsutiltest.LeafOptions{EKU: bothAuth()})
+		_ = unrelated
+		cfg := build(unrelatedCA.Pool, expected)
+		err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{server.Cert}})
 		assert.Error(t, err)
 	})
 
 	t.Run("reject: expired leaf", func(t *testing.T) {
 		t.Parallel()
-		expired := genCellChain(t,
-			[]*url.URL{mustURI(t, "spiffe://example.org/cell/configcore")},
-			bothAuth(), time.Now().Add(-time.Minute))
-		cfg := build(expired.rootPool, expected)
-		err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{expired.leaf}})
+		expiredCA := tlsutiltest.NewCA(t)
+		expired := expiredCA.IssueLeaf(t, tlsutiltest.LeafOptions{
+			URIs:     []*url.URL{tlsutiltest.SPIFFEURI(t, "spiffe://example.org/cell/configcore")},
+			EKU:      bothAuth(),
+			NotAfter: time.Now().Add(expiredLeafOffset),
+		})
+		cfg := build(expiredCA.Pool, expected)
+		err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{expired.Cert}})
 		assert.Error(t, err)
 	})
 
 	t.Run("reject: peer lacks ServerAuth EKU", func(t *testing.T) {
 		t.Parallel()
-		clientOnly := genCellChain(t,
-			[]*url.URL{mustURI(t, "spiffe://example.org/cell/configcore")},
-			[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, time.Now().Add(time.Hour))
-		cfg := build(clientOnly.rootPool, expected)
-		err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{clientOnly.leaf}})
+		clientOnlyCA := tlsutiltest.NewCA(t)
+		clientOnly := clientOnlyCA.IssueLeaf(t, tlsutiltest.LeafOptions{
+			URIs: []*url.URL{tlsutiltest.SPIFFEURI(t, "spiffe://example.org/cell/configcore")},
+			EKU:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		})
+		cfg := build(clientOnlyCA.Pool, expected)
+		err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{clientOnly.Cert}})
 		assert.Error(t, err)
 	})
 
@@ -255,26 +206,30 @@ func TestVerifyConnection(t *testing.T) {
 	// must reject it regardless of whether either URI matches the expected peer.
 	t.Run("reject: ambiguous cell SPIFFE id (two distinct cell URIs)", func(t *testing.T) {
 		t.Parallel()
-		ambiguous := genCellChain(t,
-			[]*url.URL{
-				mustURI(t, "spiffe://example.org/cell/accesscore"),
-				mustURI(t, "spiffe://example.org/cell/auditcore"),
+		ambiguousCA := tlsutiltest.NewCA(t)
+		ambiguous := ambiguousCA.IssueLeaf(t, tlsutiltest.LeafOptions{
+			URIs: []*url.URL{
+				tlsutiltest.SPIFFEURI(t, "spiffe://example.org/cell/accesscore"),
+				tlsutiltest.SPIFFEURI(t, "spiffe://example.org/cell/auditcore"),
 			},
-			bothAuth(), time.Now().Add(time.Hour))
+			EKU: bothAuth(),
+		})
 		// Use the outer `expected` (configcore) as the expected peer identity: the
 		// ambiguity check fires before the identity comparison, so the expected peer
 		// does not matter for the error path.
-		cfg := build(ambiguous.rootPool, expected)
-		err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{ambiguous.leaf}})
+		cfg := build(ambiguousCA.Pool, expected)
+		err := cfg.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{ambiguous.Cert}})
 		assert.Error(t, err, "ambiguous SPIFFE id must be rejected")
 	})
 }
 
 func TestClientIdentity(t *testing.T) {
 	t.Parallel()
-	ch := genCellChain(t,
-		[]*url.URL{mustURI(t, "spiffe://example.org/cell/accesscore")},
-		bothAuth(), time.Now().Add(time.Hour))
+	ca := tlsutiltest.NewCA(t)
+	leaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		URIs: []*url.URL{tlsutiltest.SPIFFEURI(t, "spiffe://example.org/cell/accesscore")},
+		EKU:  bothAuth(),
+	})
 
 	t.Run("zero value IsZero", func(t *testing.T) {
 		t.Parallel()
@@ -286,7 +241,7 @@ func TestClientIdentity(t *testing.T) {
 
 	t.Run("constructed + ConfigForPeer binds expected id", func(t *testing.T) {
 		t.Parallel()
-		ci, err := NewClientIdentity(ch.leafCertPEM, ch.leafKeyPEM, ch.rootPool, "example.org")
+		ci, err := NewClientIdentity(leaf.CertPEM, leaf.KeyPEM, ca.Pool, "example.org")
 		require.NoError(t, err)
 		assert.False(t, ci.IsZero())
 
@@ -295,31 +250,39 @@ func TestClientIdentity(t *testing.T) {
 		require.NotNil(t, cfg.VerifyConnection)
 
 		// The minted config must accept a configcore peer and reject an auditcore peer.
-		good := genCellChain(t, []*url.URL{mustURI(t, "spiffe://example.org/cell/configcore")}, bothAuth(), time.Now().Add(time.Hour))
+		goodCA := tlsutiltest.NewCA(t)
+		good := goodCA.IssueLeaf(t, tlsutiltest.LeafOptions{
+			URIs: []*url.URL{tlsutiltest.SPIFFEURI(t, "spiffe://example.org/cell/configcore")},
+			EKU:  bothAuth(),
+		})
 		// Re-issue the good peer under the SAME root as ci so the chain verifies.
-		ciSameRoot, err := NewClientIdentity(ch.leafCertPEM, ch.leafKeyPEM, good.rootPool, "example.org")
+		ciSameRoot, err := NewClientIdentity(leaf.CertPEM, leaf.KeyPEM, goodCA.Pool, "example.org")
 		require.NoError(t, err)
 		cfg2, err := ciSameRoot.ConfigForPeer("configcore")
 		require.NoError(t, err)
-		assert.NoError(t, cfg2.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{good.leaf}}))
+		assert.NoError(t, cfg2.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{good.Cert}}))
 
-		bad := genCellChain(t, []*url.URL{mustURI(t, "spiffe://example.org/cell/auditcore")}, bothAuth(), time.Now().Add(time.Hour))
-		ciBadRoot, err := NewClientIdentity(ch.leafCertPEM, ch.leafKeyPEM, bad.rootPool, "example.org")
+		badCA := tlsutiltest.NewCA(t)
+		bad := badCA.IssueLeaf(t, tlsutiltest.LeafOptions{
+			URIs: []*url.URL{tlsutiltest.SPIFFEURI(t, "spiffe://example.org/cell/auditcore")},
+			EKU:  bothAuth(),
+		})
+		ciBadRoot, err := NewClientIdentity(leaf.CertPEM, leaf.KeyPEM, badCA.Pool, "example.org")
 		require.NoError(t, err)
 		cfg3, err := ciBadRoot.ConfigForPeer("configcore")
 		require.NoError(t, err)
-		assert.Error(t, cfg3.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{bad.leaf}}))
+		assert.Error(t, cfg3.VerifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{bad.Cert}}))
 	})
 
 	t.Run("error paths", func(t *testing.T) {
 		t.Parallel()
-		_, err := NewClientIdentity(nil, ch.leafKeyPEM, ch.rootPool, "example.org")
+		_, err := NewClientIdentity(nil, leaf.KeyPEM, ca.Pool, "example.org")
 		assert.Error(t, err, "empty cert")
-		_, err = NewClientIdentity(ch.leafCertPEM, ch.leafKeyPEM, nil, "example.org")
+		_, err = NewClientIdentity(leaf.CertPEM, leaf.KeyPEM, nil, "example.org")
 		assert.Error(t, err, "nil rootCAs")
-		_, err = NewClientIdentity(ch.leafCertPEM, ch.leafKeyPEM, ch.rootPool, "")
+		_, err = NewClientIdentity(leaf.CertPEM, leaf.KeyPEM, ca.Pool, "")
 		assert.Error(t, err, "empty trust domain")
-		_, err = NewClientIdentity(ch.leafCertPEM, ch.leafKeyPEM, ch.rootPool, "Example.ORG")
+		_, err = NewClientIdentity(leaf.CertPEM, leaf.KeyPEM, ca.Pool, "Example.ORG")
 		assert.Error(t, err, "invalid (uppercase) trust domain")
 	})
 }

--- a/framework/runtime/http/tlsutil/server_test.go
+++ b/framework/runtime/http/tlsutil/server_test.go
@@ -1,85 +1,26 @@
 package tlsutil
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
-	"math/big"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/framework/runtime/http/tlsutil/tlsutiltest"
 )
 
-// testChain holds PEM-encoded materials produced by genTestChain.
-type testChain struct {
-	rootCertPEM   []byte
-	serverCertPEM []byte
-	serverKeyPEM  []byte
-}
-
-// genTestChain produces a self-signed root CA + a server leaf signed by the
-// root, all in PEM form. Uses ECDSA P-256 (fast, ~1ms total). The test only
-// needs material that tls.X509KeyPair will accept and x509.AppendCertsFromPEM
-// will parse — no real handshake is performed at the tlsutil package level.
-func genTestChain(t *testing.T) testChain {
-	t.Helper()
-
-	// Root CA.
-	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	rootTmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "test-root"},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
-	}
-	rootDER, err := x509.CreateCertificate(rand.Reader, rootTmpl, rootTmpl, &rootKey.PublicKey, rootKey)
-	require.NoError(t, err)
-	rootCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootDER})
-
-	// Server leaf.
-	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	serverTmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(2),
-		Subject:      pkix.Name{CommonName: "test-server"},
-		DNSNames:     []string{"localhost"},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-	}
-	rootCert, err := x509.ParseCertificate(rootDER)
-	require.NoError(t, err)
-	serverDER, err := x509.CreateCertificate(rand.Reader, serverTmpl, rootCert, &serverKey.PublicKey, rootKey)
-	require.NoError(t, err)
-	serverCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER})
-	serverKeyDER, err := x509.MarshalECPrivateKey(serverKey)
-	require.NoError(t, err)
-	serverKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: serverKeyDER})
-
-	return testChain{
-		rootCertPEM:   rootCertPEM,
-		serverCertPEM: serverCertPEM,
-		serverKeyPEM:  serverKeyPEM,
-	}
-}
-
 func TestNewServerMTLSConfig_ValidSetsTLS13RequireAndCAs(t *testing.T) {
-	chain := genTestChain(t)
-	pool, err := NewClientCAPool(chain.rootCertPEM)
+	ca := tlsutiltest.NewCA(t)
+	leaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		DNSNames: []string{"localhost"},
+		EKU:      []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	pool, err := NewClientCAPool(ca.CertPEM)
 	require.NoError(t, err)
 
-	cfg, err := NewServerMTLSConfig(chain.serverCertPEM, chain.serverKeyPEM, pool)
+	cfg, err := NewServerMTLSConfig(leaf.CertPEM, leaf.KeyPEM, pool)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
@@ -90,63 +31,70 @@ func TestNewServerMTLSConfig_ValidSetsTLS13RequireAndCAs(t *testing.T) {
 }
 
 func TestNewServerMTLSConfig_ErrorPaths(t *testing.T) {
-	chain := genTestChain(t)
-	pool, err := NewClientCAPool(chain.rootCertPEM)
+	ca := tlsutiltest.NewCA(t)
+	leaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		DNSNames: []string{"localhost"},
+		EKU:      []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	pool, err := NewClientCAPool(ca.CertPEM)
 	require.NoError(t, err)
 
 	t.Run("empty_cert_PEM_returns_error", func(t *testing.T) {
-		cfg, err := NewServerMTLSConfig(nil, chain.serverKeyPEM, pool)
+		cfg, err := NewServerMTLSConfig(nil, leaf.KeyPEM, pool)
 		assert.Error(t, err)
 		assert.Nil(t, cfg)
 	})
 
 	t.Run("empty_key_PEM_returns_error", func(t *testing.T) {
-		cfg, err := NewServerMTLSConfig(chain.serverCertPEM, nil, pool)
+		cfg, err := NewServerMTLSConfig(leaf.CertPEM, nil, pool)
 		assert.Error(t, err)
 		assert.Nil(t, cfg)
 	})
 
 	t.Run("malformed_cert_PEM_returns_error", func(t *testing.T) {
-		cfg, err := NewServerMTLSConfig([]byte("not a pem"), chain.serverKeyPEM, pool)
+		cfg, err := NewServerMTLSConfig([]byte("not a pem"), leaf.KeyPEM, pool)
 		assert.Error(t, err)
 		assert.Nil(t, cfg)
 	})
 
 	t.Run("mismatched_cert_key_returns_error", func(t *testing.T) {
-		other := genTestChain(t)
-		cfg, err := NewServerMTLSConfig(chain.serverCertPEM, other.serverKeyPEM, pool)
+		otherLeaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+			DNSNames: []string{"localhost"},
+			EKU:      []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		})
+		cfg, err := NewServerMTLSConfig(leaf.CertPEM, otherLeaf.KeyPEM, pool)
 		assert.Error(t, err)
 		assert.Nil(t, cfg)
 	})
 
 	t.Run("nil_ClientCAs_returns_error", func(t *testing.T) {
-		cfg, err := NewServerMTLSConfig(chain.serverCertPEM, chain.serverKeyPEM, nil)
+		cfg, err := NewServerMTLSConfig(leaf.CertPEM, leaf.KeyPEM, nil)
 		assert.Error(t, err)
 		assert.Nil(t, cfg)
 	})
 }
 
 func TestNewClientCAPool_SingleAndMultipleBundles(t *testing.T) {
-	a := genTestChain(t)
-	b := genTestChain(t)
+	caA := tlsutiltest.NewCA(t)
+	caB := tlsutiltest.NewCA(t)
 
 	t.Run("single_PEM_block", func(t *testing.T) {
-		pool, err := NewClientCAPool(a.rootCertPEM)
+		pool, err := NewClientCAPool(caA.CertPEM)
 		require.NoError(t, err)
 		require.NotNil(t, pool)
 		assert.Len(t, pool.Subjects(), 1) //nolint:staticcheck // Subjects() simplest count; alternatives require typed-cert reflection
 	})
 
 	t.Run("multiple_PEM_blocks_merged", func(t *testing.T) {
-		pool, err := NewClientCAPool(a.rootCertPEM, b.rootCertPEM)
+		pool, err := NewClientCAPool(caA.CertPEM, caB.CertPEM)
 		require.NoError(t, err)
 		require.NotNil(t, pool)
 		assert.Len(t, pool.Subjects(), 2) //nolint:staticcheck // Subjects() simplest count; alternatives require typed-cert reflection
 	})
 
 	t.Run("concatenated_PEM_blocks_merged", func(t *testing.T) {
-		joined := append([]byte{}, a.rootCertPEM...)
-		joined = append(joined, b.rootCertPEM...)
+		joined := append([]byte{}, caA.CertPEM...)
+		joined = append(joined, caB.CertPEM...)
 		pool, err := NewClientCAPool(joined)
 		require.NoError(t, err)
 		require.NotNil(t, pool)
@@ -177,9 +125,13 @@ func TestNewClientCAPool_NoValidCertReturnsError(t *testing.T) {
 // ─── NewServerTLSConfig ───────────────────────────────────────────────────────
 
 func TestNewServerTLSConfig_Valid(t *testing.T) {
-	chain := genTestChain(t)
+	ca := tlsutiltest.NewCA(t)
+	leaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		DNSNames: []string{"localhost"},
+		EKU:      []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
 
-	cfg, err := NewServerTLSConfig(chain.serverCertPEM, chain.serverKeyPEM)
+	cfg, err := NewServerTLSConfig(leaf.CertPEM, leaf.KeyPEM)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
@@ -189,29 +141,36 @@ func TestNewServerTLSConfig_Valid(t *testing.T) {
 }
 
 func TestNewServerTLSConfig_ErrorPaths(t *testing.T) {
-	chain := genTestChain(t)
+	ca := tlsutiltest.NewCA(t)
+	leaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		DNSNames: []string{"localhost"},
+		EKU:      []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
 
 	t.Run("empty_cert_PEM_returns_error", func(t *testing.T) {
-		cfg, err := NewServerTLSConfig(nil, chain.serverKeyPEM)
+		cfg, err := NewServerTLSConfig(nil, leaf.KeyPEM)
 		assert.Error(t, err)
 		assert.Nil(t, cfg)
 	})
 
 	t.Run("empty_key_PEM_returns_error", func(t *testing.T) {
-		cfg, err := NewServerTLSConfig(chain.serverCertPEM, nil)
+		cfg, err := NewServerTLSConfig(leaf.CertPEM, nil)
 		assert.Error(t, err)
 		assert.Nil(t, cfg)
 	})
 
 	t.Run("cert_key_parse_error_returns_error", func(t *testing.T) {
-		cfg, err := NewServerTLSConfig([]byte("not a pem"), chain.serverKeyPEM)
+		cfg, err := NewServerTLSConfig([]byte("not a pem"), leaf.KeyPEM)
 		assert.Error(t, err)
 		assert.Nil(t, cfg)
 	})
 
 	t.Run("mismatched_cert_key_returns_error", func(t *testing.T) {
-		other := genTestChain(t)
-		cfg, err := NewServerTLSConfig(chain.serverCertPEM, other.serverKeyPEM)
+		otherLeaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+			DNSNames: []string{"localhost"},
+			EKU:      []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		})
+		cfg, err := NewServerTLSConfig(leaf.CertPEM, otherLeaf.KeyPEM)
 		assert.Error(t, err)
 		assert.Nil(t, cfg)
 	})
@@ -223,22 +182,22 @@ func TestNewServerTLSConfig_ErrorPaths(t *testing.T) {
 // when another bundle is valid. The pre-fix code returned a pool that
 // silently omitted the bad bundle's intended anchors.
 func TestNewClientCAPool_FailsClosedOnBadBundleInMix(t *testing.T) {
-	valid := genTestChain(t)
+	ca := tlsutiltest.NewCA(t)
 
 	t.Run("valid_then_garbage_returns_error", func(t *testing.T) {
-		pool, err := NewClientCAPool(valid.rootCertPEM, []byte("not a cert"))
+		pool, err := NewClientCAPool(ca.CertPEM, []byte("not a cert"))
 		assert.Error(t, err)
 		assert.Nil(t, pool)
 	})
 
 	t.Run("valid_then_empty_returns_error", func(t *testing.T) {
-		pool, err := NewClientCAPool(valid.rootCertPEM, []byte{})
+		pool, err := NewClientCAPool(ca.CertPEM, []byte{})
 		assert.Error(t, err)
 		assert.Nil(t, pool)
 	})
 
 	t.Run("garbage_then_valid_returns_error", func(t *testing.T) {
-		pool, err := NewClientCAPool([]byte("not a cert"), valid.rootCertPEM)
+		pool, err := NewClientCAPool([]byte("not a cert"), ca.CertPEM)
 		assert.Error(t, err)
 		assert.Nil(t, pool)
 	})

--- a/framework/runtime/http/tlsutil/tlsutiltest/doc.go
+++ b/framework/runtime/http/tlsutil/tlsutiltest/doc.go
@@ -9,16 +9,21 @@
 //
 // # Why it exists (issue #2287, F13)
 //
-// Before this package ~8 near-equivalent "self-signed CA + cell leaf" cert-gen
-// helpers were copy-pasted across the test tree (tlsutil, middleware,
-// transport, celltls, celltransport, adapters/grpc, adapters/mqtt). cert-gen
-// detail — curve, validity window, EKU set, SAN shape — is sensitive to mTLS
-// correctness: a bug in any one copy is invisible to the others and a change
-// must be synced N ways. Centralizing the minting here makes the cert shape a
-// single source. The TLS-TEST-MATERIAL-FUNNEL-01 archtest keeps it that way by
-// banning x509.CreateCertificate in the test tree outside this package (plus
-// the cert-issuance-pipeline tests that fabricate certs as system-under-test
-// input — certsigning / certlifecycle).
+// Before this package, 9 near-equivalent cert-gen helpers were copy-pasted
+// across the test tree — 8 "self-signed CA + cell leaf" chain helpers (tlsutil
+// client + server, middleware, transport, celltls, celltransport, adapters/grpc,
+// adapters/mqtt) plus a CA-only cert-pool fixture (adapters/mqtt config_test).
+// cert-gen detail — curve, validity window, EKU set, SAN shape — is sensitive to
+// mTLS correctness: a bug in any one copy is invisible to the others and a
+// change must be synced N ways. Centralizing the minting here makes the cert
+// shape a single source. The TLS-TEST-MATERIAL-FUNNEL-01 archtest keeps it that
+// way by banning x509.CreateCertificate in the test tree outside this package
+// (plus the cert-issuance-pipeline tests that fabricate certs as
+// system-under-test input — certsigning / certlifecycle).
+//
+// Framework consumers (including examples/* projects) write their mTLS tests by
+// importing this package directly — it is the sanctioned source, so no
+// allowlist exemption is needed.
 //
 // # Funnel boundary — material only, no provisioning
 //

--- a/framework/runtime/http/tlsutil/tlsutiltest/doc.go
+++ b/framework/runtime/http/tlsutil/tlsutiltest/doc.go
@@ -1,0 +1,34 @@
+// Package tlsutiltest is the single sanctioned source of self-signed mTLS cert
+// material for GoCell tests: a self-signed ECDSA P-256 root CA and the cell /
+// transport leaves it issues (SPIFFE-URI / DNS / IP SANs, ServerAuth /
+// ClientAuth EKU).
+//
+// It is an exported test-support package (imports testing, takes *testing.T),
+// mirroring framework/kernel/reconcile/reconciletest and the broader
+// {pkg}test convention. ref: net/http → net/http/httptest.
+//
+// # Why it exists (issue #2287, F13)
+//
+// Before this package ~8 near-equivalent "self-signed CA + cell leaf" cert-gen
+// helpers were copy-pasted across the test tree (tlsutil, middleware,
+// transport, celltls, celltransport, adapters/grpc, adapters/mqtt). cert-gen
+// detail — curve, validity window, EKU set, SAN shape — is sensitive to mTLS
+// correctness: a bug in any one copy is invisible to the others and a change
+// must be synced N ways. Centralizing the minting here makes the cert shape a
+// single source. The TLS-TEST-MATERIAL-FUNNEL-01 archtest keeps it that way by
+// banning x509.CreateCertificate in the test tree outside this package (plus
+// the cert-issuance-pipeline tests that fabricate certs as system-under-test
+// input — certsigning / certlifecycle).
+//
+// # Funnel boundary — material only, no provisioning
+//
+// This package emits raw PEM material (CertPEM / KeyPEM / a *x509.CertPool /
+// a ready tls.Certificate) and never calls the provisioning constructors
+// tlsutil.NewClientIdentity / tlsutil.NewServerMTLSConfig. Those are
+// restricted by CELLTLS-MATERIAL-FUNNEL-01 to cellmodules/celltls and
+// adapters/grpc production code; its scanner exempts _test.go files but not a
+// non-test importable package like this one. So callers that need a
+// ClientIdentity or a server *tls.Config wrap this package's PEM output in
+// their own _test.go (the funnel-exempt site). Keeping the boundary here means
+// adding this package required zero change to the CELLTLS allowlist.
+package tlsutiltest

--- a/framework/runtime/http/tlsutil/tlsutiltest/tlsutiltest.go
+++ b/framework/runtime/http/tlsutil/tlsutiltest/tlsutiltest.go
@@ -107,6 +107,11 @@ type LeafOptions struct {
 	DNSNames []string
 	// IPs are IP SANs.
 	IPs []net.IP
+	// Subject is the leaf's X.509 subject (CommonName, Organization, …). The
+	// zero value yields CommonName "tlsutiltest-leaf"; set it to preserve a
+	// test's specific cert-subject assertions (CN / Organization). When set with
+	// an empty CommonName, the default CommonName is still filled in.
+	Subject pkix.Name
 	// EKU is the ExtKeyUsage set; when nil it defaults to BOTH ServerAuth and
 	// ClientAuth — a dual-purpose leaf usable as server or client, the shape the
 	// original per-file helpers used. Set it explicitly to narrow the usage.
@@ -147,9 +152,13 @@ func (ca *CA) IssueLeaf(t *testing.T, opts LeafOptions) Leaf {
 		notAfter = time.Now().Add(defaultLeafValidity)
 	}
 
+	subject := opts.Subject
+	if subject.CommonName == "" {
+		subject.CommonName = "tlsutiltest-leaf"
+	}
 	tmpl := &x509.Certificate{
 		SerialNumber: big.NewInt(ca.serial.Add(1)),
-		Subject:      pkix.Name{CommonName: "tlsutiltest-leaf"},
+		Subject:      subject,
 		NotBefore:    time.Now().Add(-certBackdate),
 		NotAfter:     notAfter,
 		KeyUsage:     x509.KeyUsageDigitalSignature,
@@ -197,7 +206,8 @@ func SPIFFEURI(t *testing.T, raw string) *url.URL {
 }
 
 // WriteFiles writes the leaf cert, leaf key, and CA cert as PEM files under dir
-// (0o600) and returns their paths — for consumers configured by file path.
+// (leaf key 0o600; leaf cert and CA cert 0o644) and returns their paths — for
+// consumers configured by file path. ca must be the issuer of l.
 func (l Leaf) WriteFiles(t *testing.T, dir string, ca *CA) (certFile, keyFile, caFile string) {
 	t.Helper()
 	certFile = filepath.Join(dir, "cert.pem")
@@ -210,10 +220,16 @@ func (l Leaf) WriteFiles(t *testing.T, dir string, ca *CA) (certFile, keyFile, c
 	return certFile, keyFile, caFile
 }
 
-// writeFile writes data to path with mode, failing the test on error.
+// writeFile writes data to path with mode, failing the test on error. It Chmods
+// after writing because os.WriteFile leaves an EXISTING file's mode unchanged
+// (it only truncates) — without the Chmod a pre-existing wide-mode key.pem would
+// keep its permissions and leak the private key.
 func writeFile(t *testing.T, path string, data []byte, mode os.FileMode) {
 	t.Helper()
 	if err := os.WriteFile(path, data, mode); err != nil {
 		t.Fatalf("tlsutiltest: write %s: %v", path, err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("tlsutiltest: chmod %s: %v", path, err)
 	}
 }

--- a/framework/runtime/http/tlsutil/tlsutiltest/tlsutiltest.go
+++ b/framework/runtime/http/tlsutil/tlsutiltest/tlsutiltest.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -31,12 +32,19 @@ const (
 	defaultLeafValidity = time.Hour
 )
 
-// pemFileMode is the permission for PEM files written by WriteFiles — private
-// key material, so owner-only.
-const pemFileMode os.FileMode = 0o600
+// File permissions for WriteFiles: the leaf private key is owner-only; the leaf
+// cert and CA cert are public material (world-readable), matching the
+// adapters/softca convention (key 0o600, cert 0o644).
+const (
+	keyFileMode  os.FileMode = 0o600
+	certFileMode os.FileMode = 0o644
+)
 
 // CA is a self-signed ECDSA P-256 root CA for tests. It can issue any number of
-// leaves via IssueLeaf; each gets a distinct serial. Construct it with NewCA.
+// leaves via IssueLeaf; each gets a distinct, monotonically increasing serial
+// (root = 1, leaves = 2,3,…). Construct it with NewCA. A *CA is safe for
+// concurrent IssueLeaf calls from multiple goroutines — the serial counter is
+// atomic and the rest of issuance (key-gen, signing) is local.
 type CA struct {
 	// Cert is the parsed root certificate.
 	Cert *x509.Certificate
@@ -46,8 +54,8 @@ type CA struct {
 	// trust root to NewClientCAPool consumers or tls verification.
 	Pool *x509.CertPool
 
-	key        *ecdsa.PrivateKey
-	nextSerial int64
+	key    *ecdsa.PrivateKey
+	serial atomic.Int64 // last issued serial; root = 1, leaves start at 2
 }
 
 // NewCA generates a self-signed ECDSA P-256 root CA with a generous validity
@@ -79,13 +87,14 @@ func NewCA(t *testing.T) *CA {
 	pool := x509.NewCertPool()
 	pool.AddCert(cert)
 
-	return &CA{
-		Cert:       cert,
-		CertPEM:    pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
-		Pool:       pool,
-		key:        key,
-		nextSerial: 2, // root is 1
+	ca := &CA{
+		Cert:    cert,
+		CertPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		Pool:    pool,
+		key:     key,
 	}
+	ca.serial.Store(1) // root cert used serial 1; leaves start at 2
+	return ca
 }
 
 // LeafOptions configures a leaf cert issued by IssueLeaf. The zero value yields
@@ -98,7 +107,9 @@ type LeafOptions struct {
 	DNSNames []string
 	// IPs are IP SANs.
 	IPs []net.IP
-	// EKU is the ExtKeyUsage set; when nil it defaults to ServerAuth+ClientAuth.
+	// EKU is the ExtKeyUsage set; when nil it defaults to BOTH ServerAuth and
+	// ClientAuth — a dual-purpose leaf usable as server or client, the shape the
+	// original per-file helpers used. Set it explicitly to narrow the usage.
 	EKU []x509.ExtKeyUsage
 	// NotAfter overrides the leaf expiry. The zero value means
 	// now+defaultLeafValidity; a past time produces an already-expired leaf
@@ -110,9 +121,10 @@ type LeafOptions struct {
 type Leaf struct {
 	// Cert is the parsed leaf certificate.
 	Cert *x509.Certificate
-	// CertPEM / KeyPEM are the PEM-encoded leaf cert and PKCS#8 private key.
+	// CertPEM is the PEM-encoded leaf certificate.
 	CertPEM []byte
-	KeyPEM  []byte
+	// KeyPEM is the PEM-encoded PKCS#8 leaf private key.
+	KeyPEM []byte
 	// TLSCert is a ready-to-use tls.Certificate (Leaf field populated).
 	TLSCert tls.Certificate
 }
@@ -136,7 +148,7 @@ func (ca *CA) IssueLeaf(t *testing.T, opts LeafOptions) Leaf {
 	}
 
 	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(ca.nextSerial),
+		SerialNumber: big.NewInt(ca.serial.Add(1)),
 		Subject:      pkix.Name{CommonName: "tlsutiltest-leaf"},
 		NotBefore:    time.Now().Add(-certBackdate),
 		NotAfter:     notAfter,
@@ -146,7 +158,6 @@ func (ca *CA) IssueLeaf(t *testing.T, opts LeafOptions) Leaf {
 		DNSNames:     opts.DNSNames,
 		IPAddresses:  opts.IPs,
 	}
-	ca.nextSerial++
 
 	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.Cert, &key.PublicKey, ca.key)
 	if err != nil {
@@ -172,8 +183,10 @@ func (ca *CA) IssueLeaf(t *testing.T, opts LeafOptions) Leaf {
 	return Leaf{Cert: cert, CertPEM: certPEM, KeyPEM: keyPEM, TLSCert: tlsCert}
 }
 
-// SPIFFEURI parses a SPIFFE (or any) URI for use as a URI SAN, failing the test
-// on a parse error.
+// SPIFFEURI parses raw into a *url.URL for use as a SPIFFE URI SAN — the cell-
+// identity use case this package serves — failing the test on a parse error.
+// It does NOT validate SPIFFE-ID format: raw is passed verbatim to url.Parse,
+// so any parseable URI is accepted and the caller owns the scheme.
 func SPIFFEURI(t *testing.T, raw string) *url.URL {
 	t.Helper()
 	u, err := url.Parse(raw)
@@ -190,10 +203,17 @@ func (l Leaf) WriteFiles(t *testing.T, dir string, ca *CA) (certFile, keyFile, c
 	certFile = filepath.Join(dir, "cert.pem")
 	keyFile = filepath.Join(dir, "key.pem")
 	caFile = filepath.Join(dir, "ca.pem")
-	for path, data := range map[string][]byte{certFile: l.CertPEM, keyFile: l.KeyPEM, caFile: ca.CertPEM} {
-		if err := os.WriteFile(path, data, pemFileMode); err != nil {
-			t.Fatalf("tlsutiltest: write %s: %v", path, err)
-		}
-	}
+	// Fixed order; key owner-only (0o600), cert + CA public (0o644).
+	writeFile(t, certFile, l.CertPEM, certFileMode)
+	writeFile(t, keyFile, l.KeyPEM, keyFileMode)
+	writeFile(t, caFile, ca.CertPEM, certFileMode)
 	return certFile, keyFile, caFile
+}
+
+// writeFile writes data to path with mode, failing the test on error.
+func writeFile(t *testing.T, path string, data []byte, mode os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(path, data, mode); err != nil {
+		t.Fatalf("tlsutiltest: write %s: %v", path, err)
+	}
 }

--- a/framework/runtime/http/tlsutil/tlsutiltest/tlsutiltest.go
+++ b/framework/runtime/http/tlsutil/tlsutiltest/tlsutiltest.go
@@ -1,0 +1,199 @@
+package tlsutiltest
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Validity windows for generated test certs. TEST-TIME-LITERAL-01: site-specific
+// test deadlines as file-local consts, not inline literals.
+const (
+	// certBackdate moves NotBefore into the past so a freshly generated cert is
+	// already valid (no clock-skew flakiness).
+	certBackdate = time.Hour
+	// caValidity is the (generous) validity window of a test root CA — wide
+	// enough that no test's leaf outlives it.
+	caValidity = 24 * time.Hour
+	// defaultLeafValidity is the leaf window used when LeafOptions.NotAfter is
+	// the zero value.
+	defaultLeafValidity = time.Hour
+)
+
+// pemFileMode is the permission for PEM files written by WriteFiles — private
+// key material, so owner-only.
+const pemFileMode os.FileMode = 0o600
+
+// CA is a self-signed ECDSA P-256 root CA for tests. It can issue any number of
+// leaves via IssueLeaf; each gets a distinct serial. Construct it with NewCA.
+type CA struct {
+	// Cert is the parsed root certificate.
+	Cert *x509.Certificate
+	// CertPEM is the PEM-encoded root certificate.
+	CertPEM []byte
+	// Pool is a *x509.CertPool containing only this root — ready to pass as the
+	// trust root to NewClientCAPool consumers or tls verification.
+	Pool *x509.CertPool
+
+	key        *ecdsa.PrivateKey
+	nextSerial int64
+}
+
+// NewCA generates a self-signed ECDSA P-256 root CA with a generous validity
+// window.
+func NewCA(t *testing.T) *CA {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("tlsutiltest: generate CA key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "tlsutiltest-root"},
+		NotBefore:             time.Now().Add(-certBackdate),
+		NotAfter:              time.Now().Add(caValidity),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("tlsutiltest: create CA cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("tlsutiltest: parse CA cert: %v", err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(cert)
+
+	return &CA{
+		Cert:       cert,
+		CertPEM:    pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		Pool:       pool,
+		key:        key,
+		nextSerial: 2, // root is 1
+	}
+}
+
+// LeafOptions configures a leaf cert issued by IssueLeaf. The zero value yields
+// a Server+Client-auth leaf with no SANs valid for defaultLeafValidity — set
+// the fields the test needs.
+type LeafOptions struct {
+	// URIs are URI SANs, typically SPIFFE IDs (see SPIFFEURI).
+	URIs []*url.URL
+	// DNSNames are DNS SANs.
+	DNSNames []string
+	// IPs are IP SANs.
+	IPs []net.IP
+	// EKU is the ExtKeyUsage set; when nil it defaults to ServerAuth+ClientAuth.
+	EKU []x509.ExtKeyUsage
+	// NotAfter overrides the leaf expiry. The zero value means
+	// now+defaultLeafValidity; a past time produces an already-expired leaf
+	// (for testing expiry handling).
+	NotAfter time.Time
+}
+
+// Leaf is an issued leaf cert + key in the forms tests consume.
+type Leaf struct {
+	// Cert is the parsed leaf certificate.
+	Cert *x509.Certificate
+	// CertPEM / KeyPEM are the PEM-encoded leaf cert and PKCS#8 private key.
+	CertPEM []byte
+	KeyPEM  []byte
+	// TLSCert is a ready-to-use tls.Certificate (Leaf field populated).
+	TLSCert tls.Certificate
+}
+
+// IssueLeaf issues an ECDSA P-256 leaf signed by the CA per opts.
+func (ca *CA) IssueLeaf(t *testing.T, opts LeafOptions) Leaf {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("tlsutiltest: generate leaf key: %v", err)
+	}
+
+	eku := opts.EKU
+	if eku == nil {
+		eku = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
+	}
+	notAfter := opts.NotAfter
+	if notAfter.IsZero() {
+		notAfter = time.Now().Add(defaultLeafValidity)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(ca.nextSerial),
+		Subject:      pkix.Name{CommonName: "tlsutiltest-leaf"},
+		NotBefore:    time.Now().Add(-certBackdate),
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  eku,
+		URIs:         opts.URIs,
+		DNSNames:     opts.DNSNames,
+		IPAddresses:  opts.IPs,
+	}
+	ca.nextSerial++
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.Cert, &key.PublicKey, ca.key)
+	if err != nil {
+		t.Fatalf("tlsutiltest: create leaf cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("tlsutiltest: parse leaf cert: %v", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("tlsutiltest: marshal leaf key: %v", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("tlsutiltest: build tls.Certificate: %v", err)
+	}
+	tlsCert.Leaf = cert
+
+	return Leaf{Cert: cert, CertPEM: certPEM, KeyPEM: keyPEM, TLSCert: tlsCert}
+}
+
+// SPIFFEURI parses a SPIFFE (or any) URI for use as a URI SAN, failing the test
+// on a parse error.
+func SPIFFEURI(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("tlsutiltest: parse URI %q: %v", raw, err)
+	}
+	return u
+}
+
+// WriteFiles writes the leaf cert, leaf key, and CA cert as PEM files under dir
+// (0o600) and returns their paths — for consumers configured by file path.
+func (l Leaf) WriteFiles(t *testing.T, dir string, ca *CA) (certFile, keyFile, caFile string) {
+	t.Helper()
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+	caFile = filepath.Join(dir, "ca.pem")
+	for path, data := range map[string][]byte{certFile: l.CertPEM, keyFile: l.KeyPEM, caFile: ca.CertPEM} {
+		if err := os.WriteFile(path, data, pemFileMode); err != nil {
+			t.Fatalf("tlsutiltest: write %s: %v", path, err)
+		}
+	}
+	return certFile, keyFile, caFile
+}

--- a/framework/runtime/http/tlsutil/tlsutiltest/tlsutiltest_test.go
+++ b/framework/runtime/http/tlsutil/tlsutiltest/tlsutiltest_test.go
@@ -3,9 +3,11 @@ package tlsutiltest_test
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"net"
 	"net/url"
 	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 	"time"
@@ -144,6 +146,47 @@ func TestNewCA_DistinctCertsAcrossInstances(t *testing.T) {
 	b := tlsutiltest.NewCA(t)
 	if a.Cert.Equal(b.Cert) {
 		t.Fatal("independent CAs must yield distinct certs")
+	}
+}
+
+func TestIssueLeaf_SubjectPassthrough(t *testing.T) {
+	t.Parallel()
+	ca := tlsutiltest.NewCA(t)
+	// An explicit Subject (CN + Organization) must be preserved verbatim.
+	leaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		Subject: pkix.Name{CommonName: "integ-client", Organization: []string{"acme"}},
+	})
+	if leaf.Cert.Subject.CommonName != "integ-client" {
+		t.Errorf("CommonName = %q, want integ-client", leaf.Cert.Subject.CommonName)
+	}
+	if !slices.Contains(leaf.Cert.Subject.Organization, "acme") {
+		t.Errorf("Organization = %v, want to contain acme", leaf.Cert.Subject.Organization)
+	}
+	// Zero-value Subject defaults the CommonName.
+	def := ca.IssueLeaf(t, tlsutiltest.LeafOptions{})
+	if def.Cert.Subject.CommonName != "tlsutiltest-leaf" {
+		t.Errorf("default CommonName = %q, want tlsutiltest-leaf", def.Cert.Subject.CommonName)
+	}
+}
+
+func TestLeaf_WriteFilesTightensPreexistingKeyMode(t *testing.T) {
+	t.Parallel()
+	ca := tlsutiltest.NewCA(t)
+	leaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{})
+	dir := t.TempDir()
+	// Pre-create key.pem with a wide mode. os.WriteFile alone would leave the
+	// existing mode (it only truncates); WriteFiles must tighten it to 0600.
+	stalePath := filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(stalePath, []byte("stale"), 0o644); err != nil {
+		t.Fatalf("pre-create key.pem: %v", err)
+	}
+	_, keyFile, _ := leaf.WriteFiles(t, dir, ca)
+	info, err := os.Stat(keyFile)
+	if err != nil {
+		t.Fatalf("stat key file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("WriteFiles must tighten pre-existing key.pem to 0600, got %o", got)
 	}
 }
 

--- a/framework/runtime/http/tlsutil/tlsutiltest/tlsutiltest_test.go
+++ b/framework/runtime/http/tlsutil/tlsutiltest/tlsutiltest_test.go
@@ -29,6 +29,10 @@ func TestIssueLeaf_VerifiesAgainstCAPool(t *testing.T) {
 	if _, err := leaf.Cert.Verify(x509.VerifyOptions{Roots: ca.Pool, KeyUsages: anyEKU}); err != nil {
 		t.Fatalf("leaf must verify against CA pool: %v", err)
 	}
+	// Zero-value LeafOptions.NotAfter must default to a future expiry.
+	if !leaf.Cert.NotAfter.After(time.Now()) {
+		t.Fatalf("default-NotAfter leaf must be valid into the future, got NotAfter=%s", leaf.Cert.NotAfter)
+	}
 }
 
 func TestIssueLeaf_SANsLandInCert(t *testing.T) {
@@ -112,6 +116,15 @@ func TestLeaf_WriteFilesReadable(t *testing.T) {
 	if _, err := tlsutil.NewClientCAPool(caPEM); err != nil {
 		t.Fatalf("written CA must parse into a pool: %v", err)
 	}
+	// The private key file must be owner-only (0o600). umask only clears bits,
+	// and 0o600 has no group/other bits to clear, so this is umask-robust.
+	info, err := os.Stat(keyFile)
+	if err != nil {
+		t.Fatalf("stat key file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("key file mode = %o, want 0600 (owner-only private key)", got)
+	}
 }
 
 func TestIssueLeaf_CurveIsECDSA(t *testing.T) {
@@ -131,5 +144,20 @@ func TestNewCA_DistinctCertsAcrossInstances(t *testing.T) {
 	b := tlsutiltest.NewCA(t)
 	if a.Cert.Equal(b.Cert) {
 		t.Fatal("independent CAs must yield distinct certs")
+	}
+}
+
+func TestIssueLeaf_DistinctSerialsWithinCA(t *testing.T) {
+	t.Parallel()
+	// One CA issuing multiple leaves must give each a distinct serial (RFC 5280
+	// §4.1.2.2) and none may collide with the root's serial.
+	ca := tlsutiltest.NewCA(t)
+	a := ca.IssueLeaf(t, tlsutiltest.LeafOptions{})
+	b := ca.IssueLeaf(t, tlsutiltest.LeafOptions{})
+	if a.Cert.SerialNumber.Cmp(b.Cert.SerialNumber) == 0 {
+		t.Fatalf("leaves from the same CA must have distinct serials, both = %s", a.Cert.SerialNumber)
+	}
+	if a.Cert.SerialNumber.Cmp(ca.Cert.SerialNumber) == 0 || b.Cert.SerialNumber.Cmp(ca.Cert.SerialNumber) == 0 {
+		t.Fatalf("leaf serial must differ from the root serial %s", ca.Cert.SerialNumber)
 	}
 }

--- a/framework/runtime/http/tlsutil/tlsutiltest/tlsutiltest_test.go
+++ b/framework/runtime/http/tlsutil/tlsutiltest/tlsutiltest_test.go
@@ -1,0 +1,135 @@
+package tlsutiltest_test
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"net/url"
+	"os"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/ghbvf/gocell/framework/runtime/http/tlsutil"
+	"github.com/ghbvf/gocell/framework/runtime/http/tlsutil/tlsutiltest"
+)
+
+const testSPIFFE = "spiffe://example.org/cell/configcore"
+
+// anyEKU lets Verify ignore EKU chaining so these tests assert SAN/expiry/curve
+// without coupling to EKU verification semantics.
+var anyEKU = []x509.ExtKeyUsage{x509.ExtKeyUsageAny}
+
+func TestIssueLeaf_VerifiesAgainstCAPool(t *testing.T) {
+	t.Parallel()
+	ca := tlsutiltest.NewCA(t)
+	leaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		URIs: []*url.URL{tlsutiltest.SPIFFEURI(t, testSPIFFE)},
+	})
+	if _, err := leaf.Cert.Verify(x509.VerifyOptions{Roots: ca.Pool, KeyUsages: anyEKU}); err != nil {
+		t.Fatalf("leaf must verify against CA pool: %v", err)
+	}
+}
+
+func TestIssueLeaf_SANsLandInCert(t *testing.T) {
+	t.Parallel()
+	ca := tlsutiltest.NewCA(t)
+	leaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		URIs:     []*url.URL{tlsutiltest.SPIFFEURI(t, testSPIFFE)},
+		DNSNames: []string{"localhost"},
+		IPs:      []net.IP{net.ParseIP("127.0.0.1")},
+	})
+	if len(leaf.Cert.URIs) != 1 || leaf.Cert.URIs[0].String() != testSPIFFE {
+		t.Fatalf("SPIFFE URI SAN missing: got %v", leaf.Cert.URIs)
+	}
+	if !slices.Contains(leaf.Cert.DNSNames, "localhost") {
+		t.Fatalf("DNS SAN missing: got %v", leaf.Cert.DNSNames)
+	}
+	if len(leaf.Cert.IPAddresses) != 1 || !leaf.Cert.IPAddresses[0].Equal(net.ParseIP("127.0.0.1")) {
+		t.Fatalf("IP SAN missing: got %v", leaf.Cert.IPAddresses)
+	}
+}
+
+func TestIssueLeaf_EKUDefaultAndExplicit(t *testing.T) {
+	t.Parallel()
+	ca := tlsutiltest.NewCA(t)
+
+	def := ca.IssueLeaf(t, tlsutiltest.LeafOptions{})
+	if !slices.Equal(def.Cert.ExtKeyUsage,
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}) {
+		t.Fatalf("default EKU must be Server+Client, got %v", def.Cert.ExtKeyUsage)
+	}
+
+	explicit := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		EKU: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	if !slices.Equal(explicit.Cert.ExtKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}) {
+		t.Fatalf("explicit EKU must be exactly ClientAuth, got %v", explicit.Cert.ExtKeyUsage)
+	}
+}
+
+func TestIssueLeaf_NotAfterPastIsExpired(t *testing.T) {
+	t.Parallel()
+	ca := tlsutiltest.NewCA(t)
+	leaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		NotAfter: time.Now().Add(-time.Minute),
+	})
+	_, err := leaf.Cert.Verify(x509.VerifyOptions{Roots: ca.Pool, KeyUsages: anyEKU})
+	if err == nil {
+		t.Fatal("expired leaf must fail verification")
+	}
+}
+
+func TestIssueLeaf_TLSCertUsable(t *testing.T) {
+	t.Parallel()
+	ca := tlsutiltest.NewCA(t)
+	leaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{DNSNames: []string{"localhost"}})
+	if leaf.TLSCert.Leaf == nil {
+		t.Fatal("TLSCert.Leaf must be populated")
+	}
+	if len(leaf.TLSCert.Certificate) != 1 {
+		t.Fatalf("TLSCert must carry one cert, got %d", len(leaf.TLSCert.Certificate))
+	}
+	// Must be loadable into a tls.Config without error.
+	_ = &tls.Config{Certificates: []tls.Certificate{leaf.TLSCert}, MinVersion: tls.VersionTLS13}
+}
+
+func TestLeaf_WriteFilesReadable(t *testing.T) {
+	t.Parallel()
+	ca := tlsutiltest.NewCA(t)
+	leaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		URIs: []*url.URL{tlsutiltest.SPIFFEURI(t, testSPIFFE)},
+	})
+	certFile, keyFile, caFile := leaf.WriteFiles(t, t.TempDir(), ca)
+
+	if _, err := tls.LoadX509KeyPair(certFile, keyFile); err != nil {
+		t.Fatalf("written cert/key must load: %v", err)
+	}
+	caPEM, err := os.ReadFile(caFile) //nolint:gosec // G304: caFile is a t.TempDir() path produced by WriteFiles in this test
+	if err != nil {
+		t.Fatalf("read ca file: %v", err)
+	}
+	if _, err := tlsutil.NewClientCAPool(caPEM); err != nil {
+		t.Fatalf("written CA must parse into a pool: %v", err)
+	}
+}
+
+func TestIssueLeaf_CurveIsECDSA(t *testing.T) {
+	t.Parallel()
+	ca := tlsutiltest.NewCA(t)
+	leaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{})
+	if leaf.Cert.PublicKeyAlgorithm != x509.ECDSA {
+		t.Fatalf("leaf must be ECDSA, got %v", leaf.Cert.PublicKeyAlgorithm)
+	}
+}
+
+func TestNewCA_DistinctCertsAcrossInstances(t *testing.T) {
+	t.Parallel()
+	// Two CAs must produce distinct certs so x509.CertPool.Equal can tell pools
+	// apart (the adapters/mqtt config_test pool-defensive-copy use case).
+	a := tlsutiltest.NewCA(t)
+	b := tlsutiltest.NewCA(t)
+	if a.Cert.Equal(b.Cert) {
+		t.Fatal("independent CAs must yield distinct certs")
+	}
+}

--- a/framework/runtime/transport/remote_mtls_integration_test.go
+++ b/framework/runtime/transport/remote_mtls_integration_test.go
@@ -16,103 +16,39 @@ package transport_test
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"io"
-	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
-	"time"
 
 	"github.com/ghbvf/gocell/framework/kernel/clock"
 	"github.com/ghbvf/gocell/framework/pkg/spiffeid"
 	"github.com/ghbvf/gocell/framework/runtime/auth"
 	"github.com/ghbvf/gocell/framework/runtime/http/middleware"
 	"github.com/ghbvf/gocell/framework/runtime/http/tlsutil"
+	"github.com/ghbvf/gocell/framework/runtime/http/tlsutil/tlsutiltest"
 	"github.com/ghbvf/gocell/framework/runtime/transport"
 )
 
 const mtlsTrustDomain = "example.org"
 
-// testMTLSCAValidity is the validity window for the test CA/leaf certs
-// (TEST-TIME-LITERAL-01: site-specific test deadline as a const, not inline).
-const testMTLSCAValidity = 2 * time.Hour
-
-// mtlsCA holds a self-signed CA and the pool that verifies certs it signs.
-type mtlsCA struct {
-	cert   *x509.Certificate
-	key    *ecdsa.PrivateKey
-	pemPEM []byte
-	pool   *x509.CertPool
+// cellSPIFFEURI returns the SPIFFE URI for a cell in the test trust domain.
+func cellSPIFFEURI(t *testing.T, cell string) *url.URL {
+	t.Helper()
+	return tlsutiltest.SPIFFEURI(t, "spiffe://"+mtlsTrustDomain+"/cell/"+cell)
 }
 
-func newMTLSCA(t *testing.T) mtlsCA {
+// newMTLSClientCAPool parses the CA cert and returns a pool for use as server ClientCAs.
+func newMTLSClientCAPool(t *testing.T, ca *tlsutiltest.CA) *x509.CertPool {
 	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	p, err := tlsutil.NewClientCAPool(ca.CertPEM)
 	if err != nil {
-		t.Fatalf("CA key: %v", err)
+		t.Fatalf("NewClientCAPool: %v", err)
 	}
-	tmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "mtls-test-ca"},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(testMTLSCAValidity),
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign,
-	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	if err != nil {
-		t.Fatalf("CA cert: %v", err)
-	}
-	cert, err := x509.ParseCertificate(der)
-	if err != nil {
-		t.Fatalf("parse CA: %v", err)
-	}
-	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
-	pool := x509.NewCertPool()
-	pool.AddCert(cert)
-	return mtlsCA{cert: cert, key: key, pemPEM: caPEM, pool: pool}
-}
-
-// issueCellLeaf signs a leaf cert for cell (URI SAN spiffe://example.org/cell/<cell>,
-// both ServerAuth + ClientAuth EKUs) and returns its PEM cert/key.
-func (ca mtlsCA) issueCellLeaf(t *testing.T, cell string) (certPEM, keyPEM []byte) {
-	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("leaf key: %v", err)
-	}
-	uri, err := url.Parse("spiffe://" + mtlsTrustDomain + "/cell/" + cell)
-	if err != nil {
-		t.Fatalf("spiffe uri: %v", err)
-	}
-	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(2),
-		Subject:      pkix.Name{CommonName: cell},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
-		URIs:         []*url.URL{uri},
-	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, &key.PublicKey, ca.key)
-	if err != nil {
-		t.Fatalf("leaf cert: %v", err)
-	}
-	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
-	if err != nil {
-		t.Fatalf("marshal key: %v", err)
-	}
-	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
-		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	return p
 }
 
 // startMTLSServer starts an httptest TLS server for cell "configcore" behind the
@@ -120,10 +56,12 @@ func (ca mtlsCA) issueCellLeaf(t *testing.T, cell string) (certPEM, keyPEM []byt
 // (caller principal) → PeerCellCrossBindMiddleware (cert↔caller bind) → biz 200.
 // RequireCallerCell is intentionally omitted so the cross-bind is the sole
 // caller-cell check under test.
-func startMTLSServer(t *testing.T, ca mtlsCA, ring *auth.HMACKeyRing, ns auth.NonceStore) *httptest.Server {
+func startMTLSServer(t *testing.T, ca *tlsutiltest.CA, ring *auth.HMACKeyRing, ns auth.NonceStore) *httptest.Server {
 	t.Helper()
-	serverCertPEM, serverKeyPEM := ca.issueCellLeaf(t, "configcore")
-	serverCfg, err := tlsutil.NewServerMTLSConfig(serverCertPEM, serverKeyPEM, ca.pool)
+	serverLeaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		URIs: []*url.URL{cellSPIFFEURI(t, "configcore")},
+	})
+	serverCfg, err := tlsutil.NewServerMTLSConfig(serverLeaf.CertPEM, serverLeaf.KeyPEM, newMTLSClientCAPool(t, ca))
 	if err != nil {
 		t.Fatalf("NewServerMTLSConfig: %v", err)
 	}
@@ -147,14 +85,16 @@ func startMTLSServer(t *testing.T, ca mtlsCA, ring *auth.HMACKeyRing, ns auth.No
 
 // mtlsClientTransport builds a RemoteHTTPTransport whose http.Client presents the
 // given client cell cert and authorizes the server as expectedPeerCell (SPIFFE).
-func mtlsClientTransport(t *testing.T, ca mtlsCA, clientCell, expectedPeerCell, serverURL string) *transport.RemoteHTTPTransport {
+func mtlsClientTransport(t *testing.T, ca *tlsutiltest.CA, clientCell, expectedPeerCell, serverURL string) *transport.RemoteHTTPTransport {
 	t.Helper()
-	clientCertPEM, clientKeyPEM := ca.issueCellLeaf(t, clientCell)
+	clientLeaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		URIs: []*url.URL{cellSPIFFEURI(t, clientCell)},
+	})
 	expected, err := spiffeid.ForCell(mtlsTrustDomain, expectedPeerCell)
 	if err != nil {
 		t.Fatalf("ForCell: %v", err)
 	}
-	clientCfg, err := tlsutil.NewClientMTLSConfig(clientCertPEM, clientKeyPEM, ca.pool, expected)
+	clientCfg, err := tlsutil.NewClientMTLSConfig(clientLeaf.CertPEM, clientLeaf.KeyPEM, ca.Pool, expected)
 	if err != nil {
 		t.Fatalf("NewClientMTLSConfig: %v", err)
 	}
@@ -175,14 +115,16 @@ func transportFromTLSConfig(serverURL string, clientCfg *tls.Config) *transport.
 // clientConfigFor builds a SPIFFE-verifying client *tls.Config (via tlsutil, so
 // no bare InsecureSkipVerify in this test file) presenting the given cell's cert
 // issued by `ca`, authorizing the server as configcore.
-func clientConfigFor(t *testing.T, ca mtlsCA, clientCell string) *tls.Config {
+func clientConfigFor(t *testing.T, ca *tlsutiltest.CA, clientCell string) *tls.Config {
 	t.Helper()
-	certPEM, keyPEM := ca.issueCellLeaf(t, clientCell)
+	clientLeaf := ca.IssueLeaf(t, tlsutiltest.LeafOptions{
+		URIs: []*url.URL{cellSPIFFEURI(t, clientCell)},
+	})
 	expected, err := spiffeid.ForCell(mtlsTrustDomain, "configcore")
 	if err != nil {
 		t.Fatalf("ForCell: %v", err)
 	}
-	cfg, err := tlsutil.NewClientMTLSConfig(certPEM, keyPEM, ca.pool, expected)
+	cfg, err := tlsutil.NewClientMTLSConfig(clientLeaf.CertPEM, clientLeaf.KeyPEM, ca.Pool, expected)
 	if err != nil {
 		t.Fatalf("NewClientMTLSConfig: %v", err)
 	}
@@ -195,7 +137,7 @@ func clientConfigFor(t *testing.T, ca mtlsCA, clientCell string) *tls.Config {
 // handler never runs (DoContract returns a transport error). (F5)
 func TestRemoteMTLS_NoClientCert_ServerRejects(t *testing.T) {
 	t.Parallel()
-	ca := newMTLSCA(t)
+	ca := tlsutiltest.NewCA(t)
 	srv := startMTLSServer(t, ca, mustRing(t), mustNonceStore(t))
 
 	cfg := clientConfigFor(t, ca, "accesscore")
@@ -215,18 +157,20 @@ func TestRemoteMTLS_NoClientCert_ServerRejects(t *testing.T) {
 // only failure cause is the server-side client-cert CA enforcement. (F5)
 func TestRemoteMTLS_WrongCAClientCert_ServerRejects(t *testing.T) {
 	t.Parallel()
-	serverCA := newMTLSCA(t)
+	serverCA := tlsutiltest.NewCA(t)
 	srv := startMTLSServer(t, serverCA, mustRing(t), mustNonceStore(t))
 
-	wrongCA := newMTLSCA(t) // independent CA, not in the server's ClientCAs
-	wrongCertPEM, wrongKeyPEM := wrongCA.issueCellLeaf(t, "accesscore")
+	wrongCA := tlsutiltest.NewCA(t) // independent CA, not in the server's ClientCAs
+	wrongLeaf := wrongCA.IssueLeaf(t, tlsutiltest.LeafOptions{
+		URIs: []*url.URL{cellSPIFFEURI(t, "accesscore")},
+	})
 	expected, err := spiffeid.ForCell(mtlsTrustDomain, "configcore")
 	if err != nil {
 		t.Fatalf("ForCell: %v", err)
 	}
 	// RootCAs = serverCA so the client still verifies the trusted server; the
 	// client cert is wrongCA-signed so the server's ClientCAs rejects it.
-	cfg, err := tlsutil.NewClientMTLSConfig(wrongCertPEM, wrongKeyPEM, serverCA.pool, expected)
+	cfg, err := tlsutil.NewClientMTLSConfig(wrongLeaf.CertPEM, wrongLeaf.KeyPEM, serverCA.Pool, expected)
 	if err != nil {
 		t.Fatalf("NewClientMTLSConfig: %v", err)
 	}
@@ -242,7 +186,7 @@ func TestRemoteMTLS_WrongCAClientCert_ServerRejects(t *testing.T) {
 // accesscore. Full handshake + SPIFFE verify + cross-bind all pass → 200.
 func TestRemoteMTLS_Happy(t *testing.T) {
 	t.Parallel()
-	ca := newMTLSCA(t)
+	ca := tlsutiltest.NewCA(t)
 	ring := mustRing(t)
 	ns := mustNonceStore(t)
 	tid := mustTenantID(t)
@@ -266,7 +210,7 @@ func TestRemoteMTLS_Happy(t *testing.T) {
 // VerifyConnection rejects the handshake → DoContract returns a transport error.
 func TestRemoteMTLS_ServerSPIFFEMismatch(t *testing.T) {
 	t.Parallel()
-	ca := newMTLSCA(t)
+	ca := tlsutiltest.NewCA(t)
 	ring := mustRing(t)
 	ns := mustNonceStore(t)
 	tid := mustTenantID(t)
@@ -289,7 +233,7 @@ func TestRemoteMTLS_ServerSPIFFEMismatch(t *testing.T) {
 // mismatch → 403.
 func TestRemoteMTLS_CrossBindMismatch(t *testing.T) {
 	t.Parallel()
-	ca := newMTLSCA(t)
+	ca := tlsutiltest.NewCA(t)
 	ring := mustRing(t)
 	ns := mustNonceStore(t)
 	tid := mustTenantID(t)

--- a/tools/archtest/internal/tlsmaterialfixture/redfixture.go
+++ b/tools/archtest/internal/tlsmaterialfixture/redfixture.go
@@ -1,0 +1,39 @@
+//go:build archtest_fixture
+
+// Package tlsmaterialfixture contains intentionally-violating call sites against
+// crypto/x509.CreateCertificate, banned outside the sanctioned packages by
+// TLS-TEST-MATERIAL-FUNNEL-01 (see tls_test_material_funnel_test.go).
+//
+// Gated by the archtest_fixture build tag; production builds (and the dogfood
+// scan, whose tag union deliberately omits archtest_fixture) never see this
+// file. Loaded by TestTLSTestMaterialFunnel_RedFixtureDetected via
+// Run(t, archtest.Fixture(...)).
+//
+// # Forms covered
+//
+// crypto/x509.CreateCertificate is called in qualified-import form (1 hit) plus
+// aliased-import form (1 hit, verifying ResolvePackageRef is alias-safe), for 2
+// total violations.
+package tlsmaterialfixture
+
+import (
+	"crypto/rand"
+	"crypto/x509"
+	x509alias "crypto/x509"
+)
+
+// violateCreateCertificate calls x509.CreateCertificate outside any sanctioned
+// package (1 qualified hit).
+//
+//nolint:all // intentional violation for archtest RED fixture
+func violateCreateCertificate(tmpl, parent *x509.Certificate, pub, priv any) {
+	_, _ = x509.CreateCertificate(rand.Reader, tmpl, parent, pub, priv)
+}
+
+// violateAliasedCreateCertificate calls x509.CreateCertificate via an import
+// alias (1 aliased hit).
+//
+//nolint:all // intentional violation for archtest RED fixture
+func violateAliasedCreateCertificate(tmpl, parent *x509alias.Certificate, pub, priv any) {
+	_, _ = x509alias.CreateCertificate(rand.Reader, tmpl, parent, pub, priv)
+}

--- a/tools/archtest/tls_test_material_funnel.go
+++ b/tools/archtest/tls_test_material_funnel.go
@@ -1,0 +1,176 @@
+// Importable rule body for TLS-TEST-MATERIAL-FUNNEL-01. Non-test .go file so
+// the dogfood + RED-fixture precision gate (tls_test_material_funnel_test.go)
+// share a single scanner — no parallel rule body. The sanctioned set is matched
+// by workspace-relative directory prefix (not import path), which is robust
+// against go/packages test-variant path mangling (foo / foo_test / foo.test)
+// and needs no module-path literal.
+//
+// # TLS-TEST-MATERIAL-FUNNEL-01
+//
+// crypto/x509.CreateCertificate — the act of minting an X.509 certificate — may
+// only be called from a closed set of sanctioned packages:
+//
+//   - framework/runtime/http/tlsutil/tlsutiltest — the single sanctioned source
+//     of self-signed mTLS cert material for tests (issue #2287). Before it, ~8
+//     near-equivalent "self-signed CA + cell leaf" cert-gen helpers were copy-
+//     pasted across the test tree (the mqtt copy even carried a "Ported from
+//     adapters/grpc/cert_test.go" comment). cert-gen detail — curve, validity,
+//     EKU, SAN — is sensitive to mTLS correctness, so a bug in one copy is
+//     invisible to the others; centralizing the mint makes the shape a single
+//     source and this funnel keeps it centralized.
+//   - framework/runtime/certsigning, framework/runtime/certlifecycle — the
+//     CSR→certificate issuance pipeline tests. They fabricate certificates as
+//     system-under-test INPUT (the cert is what the signing/lifecycle code
+//     consumes), not reusable cell-identity fixtures, so routing them through
+//     tlsutiltest would be circular. Allowlisted with this rationale.
+//   - adapters/softca — the production soft-CA implementation. It is the real
+//     certificate authority (not test material); the scan covers production
+//     packages too, so it is allowlisted here.
+//
+// Every other caller — production or test — is a violation.
+//
+// # AI-robust: Medium (downstream type-aware scan; no Hard ceiling)
+//
+// This is a Medium funnel, NOT Hard, and there is no low-cost Hard path:
+// crypto/x509.CreateCertificate is a stdlib free function, so there is no
+// sealed type or unexported field that could make an unsanctioned call
+// unrepresentable at compile time (contrast CELLTLS-MATERIAL-FUNNEL-01, whose
+// upstream is Hard because tlsutil.ClientIdentity is sealed). The downstream
+// scan is type-aware: ResolvePackageRef resolves each callee to its owning
+// package via go/types, so import aliases (x509alias.CreateCertificate) do not
+// defeat it.
+//
+// Not registered in StandardCellRules: the sanctioned packages are GoCell-
+// internal; an external Cell repo has no such files, so the allowlist would
+// never match and the rule would degrade to a pure ban that false-reds any
+// repo legitimately minting test certs from its own helper. Same disposition as
+// CELLTLS-MATERIAL-FUNNEL-01.
+//
+// # Scope
+//
+// Scanned via Production(Tests:true) under both the default build context and
+// FlatNonDefaultTags() (so integration / mqtt_tls-gated test files are covered),
+// union-deduped. generated/ is excluded by Production; the archtest_fixture tag
+// is deliberately absent from FlatNonDefaultTags (#944), so the RED fixture is
+// never compiled into the dogfood.
+//
+// # Blind spots (BS)
+//
+//   - BS-1 Reverse build constraints (//go:build !tag): files excluded from a
+//     -tags=...,tag,... union load are not scanned. No such cert-gen file
+//     exists today; the nil-tags companion pass covers the default context.
+//   - BS-2 CreateCertificateRequest (CSR creation) is intentionally NOT banned —
+//     it is a distinct concern used legitimately by the pipeline tests and is
+//     not cell mTLS cert material.
+//   - BS-3 Function-value indirection (var f = x509.CreateCertificate; f(...))
+//     resolves to *types.Var (ok=false) and is not flagged. Accepted: no
+//     sanctioned or migrated caller does this.
+//   - BS-4 Reflection construction: out of scope per ai-robust.md §3.
+package archtest
+
+import (
+	"fmt"
+	"go/ast"
+	"strings"
+	"testing"
+)
+
+const (
+	tlsTestMaterialRuleID = "TLS-TEST-MATERIAL-FUNNEL-01"
+
+	// tlsTestMaterialBannedPkg / tlsTestMaterialBannedCtor identify the minting
+	// call this funnel governs: crypto/x509.CreateCertificate.
+	tlsTestMaterialBannedPkg  = "crypto/x509"
+	tlsTestMaterialBannedCtor = "CreateCertificate"
+)
+
+// tlsTestMaterialSanctionedDirs is the closed set of Pass.Rel directory prefixes
+// whose files may call crypto/x509.CreateCertificate. See the package godoc for
+// the per-entry rationale. Trailing slash makes each a true directory prefix (so
+// "…/certsigning/" never matches "…/certsigningfoo/").
+//
+// Pass.Rel strips the core framework module's leading "framework/" segment (the
+// #1565 split normalization in newPackageRel/stripFrameworkPrefix), so framework
+// packages appear as "runtime/…" here, NOT "framework/runtime/…". Non-framework
+// modules (adapters/, cellmodules/, tools/) are not stripped.
+var tlsTestMaterialSanctionedDirs = []string{
+	"runtime/http/tlsutil/tlsutiltest/",
+	"runtime/certsigning/",
+	"runtime/certlifecycle/",
+	"adapters/softca/",
+}
+
+// CheckTLSTestMaterialFunnel enforces TLS-TEST-MATERIAL-FUNNEL-01 over the whole
+// workspace. It scans the production tree with test variants under both the
+// default build context and FlatNonDefaultTags() (integration / mqtt_tls etc.)
+// and returns the union of diagnostics; GoCell's TestTLSTestMaterialFunnel calls
+// it directly — single source, no parallel rule body.
+func CheckTLSTestMaterialFunnel(t *testing.T) []Diagnostic {
+	t.Helper()
+	seen := map[string]struct{}{}
+	var out []Diagnostic
+	for _, tags := range [][]string{nil, FlatNonDefaultTags()} {
+		for _, d := range Run(t, Production(TypedOpts{Tests: true, Tags: tags}), scanTLSTestMaterialViolations) {
+			key := fmt.Sprintf("%s:%d", d.Rel, d.Line)
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// scanTLSTestMaterialViolations walks every CallExpr in pass.Files, resolves the
+// callee to its (pkgPath, name) tuple via ResolvePackageRef, and flags calls to
+// crypto/x509.CreateCertificate whose file is not under a sanctioned directory.
+func scanTLSTestMaterialViolations(p *Pass) []Diagnostic {
+	var out []Diagnostic
+	for _, file := range p.Files {
+		rel := p.Rel(file)
+		if isTLSTestMaterialSanctioned(rel) {
+			continue
+		}
+		EachInSubtree[ast.CallExpr](file, func(call *ast.CallExpr) {
+			if d, ok := tlsTestMaterialCallViolation(p, rel, call); ok {
+				out = append(out, d)
+			}
+		})
+	}
+	return out
+}
+
+// tlsTestMaterialCallViolation returns the diagnostic for a single CallExpr if it
+// is an unsanctioned call to crypto/x509.CreateCertificate — ok=false otherwise.
+func tlsTestMaterialCallViolation(p *Pass, rel string, call *ast.CallExpr) (Diagnostic, bool) {
+	calleePkg, name, ok := ResolvePackageRef(p.TypesInfo, call.Fun)
+	if !ok || calleePkg != tlsTestMaterialBannedPkg || name != tlsTestMaterialBannedCtor {
+		return Diagnostic{}, false
+	}
+	return Diagnostic{
+		Rel:  rel,
+		Line: p.Fset.Position(call.Pos()).Line,
+		Message: fmt.Sprintf(
+			"crypto/x509.CreateCertificate mints an X.509 certificate; "+
+				"callers are restricted to the sanctioned packages "+
+				"(tlsutiltest for test mTLS material, certsigning/certlifecycle "+
+				"pipeline tests, adapters/softca production CA) (%s). "+
+				"For test mTLS cert material use "+
+				"framework/runtime/http/tlsutil/tlsutiltest",
+			tlsTestMaterialRuleID,
+		),
+	}, true
+}
+
+// isTLSTestMaterialSanctioned reports whether the workspace-relative file path
+// rel is under one of the sanctioned directories. Pure function for unit
+// testability (TestIsTLSTestMaterialSanctioned).
+func isTLSTestMaterialSanctioned(rel string) bool {
+	for _, dir := range tlsTestMaterialSanctionedDirs {
+		if strings.HasPrefix(rel, dir) {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/archtest/tls_test_material_funnel.go
+++ b/tools/archtest/tls_test_material_funnel.go
@@ -19,11 +19,14 @@
 //     EKU, SAN — is sensitive to mTLS correctness, so a bug in one copy is
 //     invisible to the others; centralizing the mint makes the shape a single
 //     source and this funnel keeps it centralized.
-//   - framework/runtime/certsigning, framework/runtime/certlifecycle — the
-//     CSR→certificate issuance pipeline tests. They fabricate certificates as
-//     system-under-test INPUT (the cert is what the signing/lifecycle code
-//     consumes), not reusable cell-identity fixtures, so routing them through
-//     tlsutiltest would be circular. Allowlisted with this rationale.
+//   - framework/runtime/certsigning/request_test.go,
+//     framework/runtime/certlifecycle/testsupport_test.go — the CSR→certificate
+//     issuance pipeline tests. They fabricate certificates as system-under-test
+//     INPUT (the cert is what the signing/lifecycle code consumes), not reusable
+//     cell-identity fixtures, so routing them through tlsutiltest would be
+//     circular. These are sanctioned as EXACT FILES (not whole package): the
+//     production code in those packages does not mint, so a whole-package
+//     allowlist would fail-open a future production CreateCertificate (#2414 F1).
 //   - adapters/softca — the production soft-CA implementation. It is the real
 //     certificate authority (not test material); the scan covers production
 //     packages too, so it is allowlisted here.
@@ -110,16 +113,25 @@ const (
 // #1565 split normalization in newPackageRel/stripFrameworkPrefix), so framework
 // packages appear as "runtime/…" here, NOT "framework/runtime/…". Non-framework
 // modules (adapters/, cellmodules/, tools/) are not stripped.
+// tlsTestMaterialSanctionedDirs are WHOLE-PACKAGE minters: every file under them
+// may call x509.CreateCertificate because minting is the package's purpose.
 var tlsTestMaterialSanctionedDirs = []string{
 	// framework module: Pass.Rel strips the leading "framework/" (#1565), so
 	// these appear as "runtime/…", NOT "framework/runtime/…".
 	"runtime/http/tlsutil/tlsutiltest/", // the sanctioned test mTLS-material minter (#2287)
-	"runtime/certsigning/",              // CSR→cert pipeline test: cert is SUT input, not a fixture
-	"runtime/certlifecycle/",            // cert renewal/lifecycle test: cert is SUT input, not a fixture
 	// non-framework modules: rel path is module-prefixed as-is (no strip).
-	"adapters/softca/", // production soft-CA implementation (the real authority, not test material)
+	"adapters/softca/", // production soft-CA implementation (the real authority, mints across files)
 	// NOTE: tlsutil/ itself (client_test/server_test) is deliberately NOT here —
 	// those callers were migrated to tlsutiltest and must route through it.
+}
+
+// tlsTestMaterialSanctionedFiles are EXACT files (not whole package): only the
+// CSR→cert pipeline TEST files fabricate a cert as system-under-test input. The
+// production code in those packages does NOT mint, so a whole-package prefix
+// would fail-open a future production x509.CreateCertificate there (#2414 F1).
+var tlsTestMaterialSanctionedFiles = []string{
+	"runtime/certsigning/request_test.go",       // cert-signing pipeline test: cert is SUT input
+	"runtime/certlifecycle/testsupport_test.go", // cert-lifecycle pipeline test: cert is SUT input
 }
 
 // CheckTLSTestMaterialFunnel enforces TLS-TEST-MATERIAL-FUNNEL-01 over the whole
@@ -186,11 +198,17 @@ func tlsTestMaterialCallViolation(p *Pass, rel string, call *ast.CallExpr) (Diag
 }
 
 // isTLSTestMaterialSanctioned reports whether the workspace-relative file path
-// rel is under one of the sanctioned directories. Pure function for unit
-// testability (TestIsTLSTestMaterialSanctioned).
+// rel is under a sanctioned whole-package directory OR is one of the sanctioned
+// exact files (the CSR-pipeline test files). Pure function for unit testability
+// (TestIsTLSTestMaterialSanctioned).
 func isTLSTestMaterialSanctioned(rel string) bool {
 	for _, dir := range tlsTestMaterialSanctionedDirs {
 		if strings.HasPrefix(rel, dir) {
+			return true
+		}
+	}
+	for _, f := range tlsTestMaterialSanctionedFiles {
+		if rel == f {
 			return true
 		}
 	}

--- a/tools/archtest/tls_test_material_funnel.go
+++ b/tools/archtest/tls_test_material_funnel.go
@@ -11,10 +11,11 @@
 // only be called from a closed set of sanctioned packages:
 //
 //   - framework/runtime/http/tlsutil/tlsutiltest — the single sanctioned source
-//     of self-signed mTLS cert material for tests (issue #2287). Before it, ~8
-//     near-equivalent "self-signed CA + cell leaf" cert-gen helpers were copy-
-//     pasted across the test tree (the mqtt copy even carried a "Ported from
-//     adapters/grpc/cert_test.go" comment). cert-gen detail — curve, validity,
+//     of self-signed mTLS cert material for tests (issue #2287). Before it, 9
+//     near-equivalent cert-gen helpers (8 "self-signed CA + cell leaf" chains +
+//     1 CA-only pool fixture) were copy-pasted across the test tree (the mqtt
+//     copy even carried a "Ported from adapters/grpc/cert_test.go" comment).
+//     cert-gen detail — curve, validity,
 //     EKU, SAN — is sensitive to mTLS correctness, so a bug in one copy is
 //     invisible to the others; centralizing the mint makes the shape a single
 //     source and this funnel keeps it centralized.
@@ -54,6 +55,15 @@
 // is deliberately absent from FlatNonDefaultTags (#944), so the RED fixture is
 // never compiled into the dogfood.
 //
+// # CI lane (nightly-only, like CELLTLS-MATERIAL-FUNNEL-01)
+//
+// This rule runs Production(Tests:true) + FlatNonDefaultTags() — a heavy
+// whole-tree packages.Load (two passes) — so it belongs to the nightly archtest
+// bucket (verify-archtest.sh / `go test -tags=archtest ./tools/archtest/...`),
+// NOT the cheap PR-time fast lane (hack/verify-archtest-invariants.sh, reserved
+// for non-packages.Load invariants). Same disposition + cost class as
+// CELLTLS-MATERIAL-FUNNEL-01.
+//
 // # Blind spots (BS)
 //
 //   - BS-1 Reverse build constraints (//go:build !tag): files excluded from a
@@ -66,6 +76,13 @@
 //     resolves to *types.Var (ok=false) and is not flagged. Accepted: no
 //     sanctioned or migrated caller does this.
 //   - BS-4 Reflection construction: out of scope per ai-robust.md §3.
+//   - BS-5 Rel-prefix coupling: tlsTestMaterialSanctionedDirs matches Pass.Rel's
+//     framework-stripped, module-relative form (runtime/… for the framework
+//     module, <module>/… otherwise). If newPackageRel / stripFrameworkPrefix
+//     changes, this list AND TestIsTLSTestMaterialSanctioned (which feeds
+//     pre-stripped literals) must be updated together. A strip-behavior change
+//     would silently false-RED (a sanctioned caller stops matching) — fail-safe,
+//     not fail-open, so it surfaces as CI red rather than a missed violation.
 package archtest
 
 import (
@@ -94,10 +111,15 @@ const (
 // packages appear as "runtime/…" here, NOT "framework/runtime/…". Non-framework
 // modules (adapters/, cellmodules/, tools/) are not stripped.
 var tlsTestMaterialSanctionedDirs = []string{
-	"runtime/http/tlsutil/tlsutiltest/",
-	"runtime/certsigning/",
-	"runtime/certlifecycle/",
-	"adapters/softca/",
+	// framework module: Pass.Rel strips the leading "framework/" (#1565), so
+	// these appear as "runtime/…", NOT "framework/runtime/…".
+	"runtime/http/tlsutil/tlsutiltest/", // the sanctioned test mTLS-material minter (#2287)
+	"runtime/certsigning/",              // CSR→cert pipeline test: cert is SUT input, not a fixture
+	"runtime/certlifecycle/",            // cert renewal/lifecycle test: cert is SUT input, not a fixture
+	// non-framework modules: rel path is module-prefixed as-is (no strip).
+	"adapters/softca/", // production soft-CA implementation (the real authority, not test material)
+	// NOTE: tlsutil/ itself (client_test/server_test) is deliberately NOT here —
+	// those callers were migrated to tlsutiltest and must route through it.
 }
 
 // CheckTLSTestMaterialFunnel enforces TLS-TEST-MATERIAL-FUNNEL-01 over the whole

--- a/tools/archtest/tls_test_material_funnel_test.go
+++ b/tools/archtest/tls_test_material_funnel_test.go
@@ -1,0 +1,80 @@
+//go:build archtest
+
+// INVARIANT: TLS-TEST-MATERIAL-FUNNEL-01
+//
+// This _test.go only dogfoods + precision-gates the rule. The importable rule
+// body (CheckTLSTestMaterialFunnel + scanTLSTestMaterialViolations +
+// isTLSTestMaterialSanctioned + the full package godoc) lives in the non-test
+// companion tls_test_material_funnel.go so it is a single source — no parallel
+// rule body.
+package archtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTLSTestMaterialFunnel dogfoods TLS-TEST-MATERIAL-FUNNEL-01 against GoCell
+// itself: every crypto/x509.CreateCertificate caller must live in a sanctioned
+// package, so the workspace scan must return ZERO violations.
+func TestTLSTestMaterialFunnel(t *testing.T) {
+	Report(t, tlsTestMaterialRuleID, CheckTLSTestMaterialFunnel(t))
+}
+
+// TestTLSTestMaterialFunnel_RedFixtureDetected asserts the production scanner
+// catches every banned call shape (qualified + aliased) in the RED fixture,
+// gated by //go:build archtest_fixture. It runs the same
+// scanTLSTestMaterialViolations the production Check uses (single source)
+// against the synthetic fixture package — anti-vacuity proof the rule is not
+// trivially green.
+//
+// Coverage: 1 qualified hit + 1 aliased hit (via x509alias) = 2 total.
+func TestTLSTestMaterialFunnel_RedFixtureDetected(t *testing.T) {
+	diags := Run(t, Fixture(
+		FixtureOpts{Tests: false},
+		[]string{"./tools/archtest/internal/tlsmaterialfixture/..."},
+	), scanTLSTestMaterialViolations)
+
+	for _, d := range diags {
+		t.Logf("RED fixture hit: %s:%d %s", d.Rel, d.Line, d.Message)
+	}
+	// Equality (not >=) so the fixture cannot drift silently — any change to the
+	// fixture files must update this count.
+	assert.Len(t, diags, 2,
+		"fixture must yield exactly 2 TLS-TEST-MATERIAL-FUNNEL-01 hits "+
+			"(1 qualified + 1 aliased crypto/x509.CreateCertificate); "+
+			"if the fixture changes intentionally, update the expected count")
+}
+
+// TestIsTLSTestMaterialSanctioned locks the sanctioned-directory predicate: each
+// sanctioned prefix is exempt, a sibling directory sharing a name prefix is NOT
+// (trailing-slash boundary), and an arbitrary test path is NOT.
+func TestIsTLSTestMaterialSanctioned(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		rel  string
+		want bool
+	}{
+		// Pass.Rel strips the framework module's "framework/" prefix → "runtime/…".
+		{name: "tlsutiltest file", rel: "runtime/http/tlsutil/tlsutiltest/tlsutiltest.go", want: true},
+		{name: "certsigning test", rel: "runtime/certsigning/request_test.go", want: true},
+		{name: "certlifecycle test", rel: "runtime/certlifecycle/testsupport_test.go", want: true},
+		{name: "softca production", rel: "adapters/softca/ca.go", want: true},
+		{name: "tlsutil (non-test-helper) is NOT sanctioned", rel: "runtime/http/tlsutil/client_test.go", want: false},
+		{name: "name-prefix sibling is NOT sanctioned", rel: "runtime/certsigningfoo/x_test.go", want: false},
+		{name: "arbitrary cell test is NOT sanctioned", rel: "cellmodules/celltls/celltls_test.go", want: false},
+		{name: "the RED fixture is NOT sanctioned", rel: "tools/archtest/internal/tlsmaterialfixture/redfixture.go", want: false},
+		{name: "empty path", rel: "", want: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isTLSTestMaterialSanctioned(tc.rel); got != tc.want {
+				t.Errorf("isTLSTestMaterialSanctioned(%q) = %v, want %v", tc.rel, got, tc.want)
+			}
+		})
+	}
+}

--- a/tools/archtest/tls_test_material_funnel_test.go
+++ b/tools/archtest/tls_test_material_funnel_test.go
@@ -64,6 +64,11 @@ func TestIsTLSTestMaterialSanctioned(t *testing.T) {
 		{name: "softca production", rel: "adapters/softca/ca.go", want: true},
 		{name: "tlsutil (non-test-helper) is NOT sanctioned", rel: "runtime/http/tlsutil/client_test.go", want: false},
 		{name: "name-prefix sibling is NOT sanctioned", rel: "runtime/certsigningfoo/x_test.go", want: false},
+		// F1 negative controls: certsigning/certlifecycle are sanctioned as EXACT
+		// files, NOT whole package — production code there must NOT be exempt.
+		{name: "certsigning PRODUCTION file is NOT sanctioned", rel: "runtime/certsigning/request.go", want: false},
+		{name: "certlifecycle PRODUCTION file is NOT sanctioned", rel: "runtime/certlifecycle/manager.go", want: false},
+		{name: "certsigning OTHER test file is NOT sanctioned (exact-file only)", rel: "runtime/certsigning/signer_test.go", want: false},
 		{name: "arbitrary cell test is NOT sanctioned", rel: "cellmodules/celltls/celltls_test.go", want: false},
 		{name: "the RED fixture is NOT sanctioned", rel: "tools/archtest/internal/tlsmaterialfixture/redfixture.go", want: false},
 		{name: "empty path", rel: "", want: false},

--- a/tools/internal/fileroles/fileroles.go
+++ b/tools/internal/fileroles/fileroles.go
@@ -9,7 +9,8 @@
 // non-shipping: *_test.go (the canonical Go test convention), every
 // **/conformance.go (driver-conformance suites that exercise an adapter
 // under test), and every file under a recognized test-helper package
-// (locktest, outboxtest, storetest, healthtest, contracttest, commandtest).
+// (locktest, outboxtest, storetest, healthtest, contracttest, commandtest,
+// tlsutiltest).
 //
 // "Production code" is the strict complement within the gate scope: any
 // file under a top-level Go directory (cmd/, kernel/, runtime/, adapters/,
@@ -60,6 +61,7 @@ var testHelperSubpaths = []string{
 	"/accesscoretest/",
 	"/configcoretest/",
 	"/idempotencytest/",
+	"/tlsutiltest/",
 }
 
 // IsTestCode reports whether the given module-relative path is test code

--- a/tools/internal/fileroles/fileroles_test.go
+++ b/tools/internal/fileroles/fileroles_test.go
@@ -74,6 +74,7 @@ func TestIsTestCode(t *testing.T) {
 		{"auditcoretest builders", "corecells/auditcore/auditcoretest/builders.go", true},
 		{"accesscoretest builders", "corecells/accesscore/accesscoretest/builders.go", true},
 		{"accesscoretest fixture", "corecells/accesscore/accesscoretest/fixture.go", true},
+		{"tlsutiltest helper", "runtime/http/tlsutil/tlsutiltest/tlsutiltest.go", true},
 
 		{"production main", "cmd/corebundle/main.go", false},
 		{"production code", "kernel/outbox/consumer_base.go", false},


### PR DESCRIPTION
## Summary

将 8 处近乎等价的 mTLS cert-gen 测试 helper 去重到共享 exported test-support 包
`framework/runtime/http/tlsutil/tlsutiltest`，并加 `TLS-TEST-MATERIAL-FUNNEL-01` 收口守卫防回潮。

## Why / 背景

#2263 split topology mTLS 落地后，测试树散落约 8 份「自签 CA + cell leaf（SPIFFE/DNS/IP SAN +
Server/ClientAuth EKU）」ECDSA-P256 cert-gen helper。cert-gen 细节（曲线 / 有效期 / EKU / SAN）对
mTLS 正确性敏感：任一处 bug 不被其他测试感知，改动要多处同步。issue 列了 5 处，repo 全量 scan 发现
真实 Family-A = **8 处 / 4 module**——issue 漏列 `tlsutil/server_test.go`（同包孪生）、`adapters/grpc`、
`adapters/mqtt`（后者注释自承 "Ported from adapters/grpc/cert_test.go"，复制已在扩散）。根因是
「cert 材料铸造点无收口、会持续裂变」，故纯 dedup（L1）不够，**同 PR 落静态守卫**（彻底 + AI-robust）。

## Refs

Closes #2287
ref: net/http/httptest；`framework/kernel/reconcile/reconciletest`（exported test-support 约定）；
`tools/archtest/celltls_material_funnel.go`（funnel 守卫结构对标）

## Risk / 兼容性

无 wire / 契约 / 生产代码行为变更——纯测试基建去重 + 新增 archtest 规则 + fileroles 分类。

- helper 只产 PEM 材料；`tlsutil.NewClientIdentity` / `tls.Config` 组装留各 caller 的 `_test.go`
  （`CELLTLS-MATERIAL-FUNNEL-01` 对 `_test.go` funnel-exempt）→ **零 CELLTLS allowlist 改动**。
- 新守卫 `TLS-TEST-MATERIAL-FUNNEL-01` 评级 **Medium**（downstream type-aware AST scan；
  `x509.CreateCertificate` 是 stdlib，无 sealed type 可达 Hard 上限——如实标注，不虚报）。
  sanctioned 集精确到 `tlsutiltest` / `certsigning` / `certlifecycle` / `softca`，异域 cert-gen 不误伤。
- `fileroles` 增 `/tlsutiltest/` 归类为 test-support（修正 `PROD-CLOCK-INJECTION-01` 对 fixture 的误判）。

## Test plan

- [x] build 通过（逐 go.work 模块：framework / cellmodules / adapters/grpc / adapters/mqtt / tools；
      根 `./...` 在多模块 go.work 不适用）
- [x] 迁移包单测 + 新 `tlsutiltest` 单测通过
- [x] integration-tag 编译通过（`-tags=integration` transport / `-tags="integration mqtt_tls"` mqtt）
- [x] golangci-lint 全 5 模块 **0 issues**
- [x] archtest：`TLS-TEST-MATERIAL-FUNNEL-01` dogfood GREEN + RED fixture（2 hits）+ 精度门；
      `CELLTLS-MATERIAL-FUNNEL-01` 未回归；fast invariants lane GREEN；`fileroles` 单测 GREEN

> 注：本地 `hack/githooks/pre-push` 因预存 bug（#1565 模块拆分后根 `go build ./...` 失效，干净主仓同样复现）
> 阻断，经 owner 授权本次 `--no-verify`；其意图（build/vet/lint 全绿）已用逐模块命令（即 CI 实际跑的形态）覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
