### PR TITLE
test(authz): #1985 mergeObligations 穷尽合并矩阵 + only-tighten property 守卫

### DIFF
--- a/corecells/accesscore/slices/authorizationdecide/service_test.go
+++ b/corecells/accesscore/slices/authorizationdecide/service_test.go
@@ -668,7 +668,7 @@ func TestMergeObligations(t *testing.T) {
 		// sourced in framework/pkg/tenant, not re-enumerated here.
 		{"pair tenant+self → self", []authz.Obligations{obl(ten, "a"), obl(self, "b")}, self, []string{"a", "b"}},
 		{"pair device+all → device", []authz.Obligations{obl(dev, "x"), obl(all, "y")}, dev, []string{"x", "y"}},
-		{"three ordered → self", []authz.Obligations{obl(all), obl(ten), obl(self)}, self, nil},
+		{"three ordered → self (scope+fields)", []authz.Obligations{obl(all, "a"), obl(ten, "b"), obl(self, "c")}, self, []string{"a", "b", "c"}},
 		{"three reordered → self (order-independent)", []authz.Obligations{obl(self), obl(all), obl(ten)}, self, nil},
 
 		// same-value folds.
@@ -710,10 +710,14 @@ func TestMergeObligations(t *testing.T) {
 //
 // It pairs with the enumerated wantScope/wantFields above: the property catches
 // under-tightening (the security failure), the enumerated values catch over- or
-// wrong-tightening (a correctness failure the property alone cannot see).
+// wrong-tightening (a correctness failure the property alone cannot see). For an
+// empty/nil `in` the property is a vacuous no-op — that case's correctness rests
+// entirely on the caller's wantScope/wantFields.
 func assertObligationsOnlyTighten(t *testing.T, merged authz.Obligations, in []authz.Obligations) {
 	t.Helper()
 	for _, o := range in {
+		// Skip zero-scope inputs: 0 is "no row constraint" (the fold seed), so
+		// "merged no wider than 0" is vacuously true and carries no signal.
 		if o.RowScope != 0 {
 			// Narrowing an already-narrowest scope by any input is a no-op; if
 			// merged were wider than o, Narrower would return o instead.

--- a/corecells/accesscore/slices/authorizationdecide/service_test.go
+++ b/corecells/accesscore/slices/authorizationdecide/service_test.go
@@ -635,16 +635,102 @@ func TestMatchCondition_UnknownOperator_FailsClosed(t *testing.T) {
 	assert.False(t, matchCondition(c, r), "unknown operator must be fail-closed (condition unsatisfied)")
 }
 
-// TestMergeObligations_SkipsZeroRowScope_UnionsFieldMask covers the zero-RowScope
-// skip + FieldMask union/dedup in mergeObligations.
-func TestMergeObligations_SkipsZeroRowScope_UnionsFieldMask(t *testing.T) {
-	merged := mergeObligations([]authz.Obligations{
-		{RowScope: 0, FieldMask: authz.FieldMask{Fields: []string{"a"}}},
-		{RowScope: tenant.RowScopeTenant, FieldMask: authz.FieldMask{Fields: []string{"b", "a"}}},
-		{RowScope: tenant.RowScopeSelf},
-	})
-	assert.Equal(t, tenant.RowScopeSelf, merged.RowScope, "zero RowScope skipped; narrowest non-zero wins")
-	assert.ElementsMatch(t, []string{"a", "b"}, merged.FieldMask.Fields, "FieldMask is the deduped union")
+// TestMergeObligations is the exhaustive table for the fail-safe obligation
+// merge (mergeObligations): the security invariant is that combining multiple
+// permits can only TIGHTEN, never loosen, what the PEP enforces — RowScope
+// folds to the narrowest input (via tenant.RowScope's Narrower, whose pairwise
+// lattice self<device<tenant<all is owned and exhaustively tested by
+// framework/pkg/tenant's TestRowScope_Narrower / TestRowScope_StrictnessOrdering)
+// and FieldMask folds to the deduped union. This pins mergeObligations' OWN
+// logic — the N-ary fold, zero-scope seeding, and FieldMask union/dedup —
+// without re-enumerating the pairwise Narrower lattice. Every case is also
+// checked against the generic only-tighten invariant
+// (assertObligationsOnlyTighten), so a loosening regression is caught even for
+// input shapes this table omits.
+func TestMergeObligations(t *testing.T) {
+	obl := func(rs tenant.RowScope, fields ...string) authz.Obligations {
+		return authz.Obligations{RowScope: rs, FieldMask: authz.FieldMask{Fields: fields}}
+	}
+	// Local lattice aliases keep the cases on one readable line each.
+	self, dev, ten, all := tenant.RowScopeSelf, tenant.RowScopeDevice, tenant.RowScopeTenant, tenant.RowScopeAll
+
+	cases := []struct {
+		name       string
+		in         []authz.Obligations
+		wantScope  tenant.RowScope
+		wantFields []string
+	}{
+		// single permit: identity (the weak baseline the issue calls out).
+		{"single permit is identity", []authz.Obligations{obl(self, "a")}, self, []string{"a"}},
+
+		// N-ary fold: narrowest non-zero RowScope wins. Two representative pairs
+		// prove the fold delegates to Narrower; the lattice itself is single-
+		// sourced in framework/pkg/tenant, not re-enumerated here.
+		{"pair tenant+self → self", []authz.Obligations{obl(ten, "a"), obl(self, "b")}, self, []string{"a", "b"}},
+		{"pair device+all → device", []authz.Obligations{obl(dev, "x"), obl(all, "y")}, dev, []string{"x", "y"}},
+		{"three ordered → self", []authz.Obligations{obl(all), obl(ten), obl(self)}, self, nil},
+		{"three reordered → self (order-independent)", []authz.Obligations{obl(self), obl(all), obl(ten)}, self, nil},
+
+		// same-value folds.
+		{"same self+self → self", []authz.Obligations{obl(self, "a"), obl(self, "b")}, self, []string{"a", "b"}},
+		{"same all+all → all", []authz.Obligations{obl(all, "a"), obl(all, "b")}, all, []string{"a", "b"}},
+
+		// zero-scope seeding: 0 means "no row constraint", skipped in the fold.
+		{"zero scope alone stays zero, keeps fields", []authz.Obligations{obl(0, "a")}, 0, []string{"a"}},
+		{"zero+self → self", []authz.Obligations{obl(0, "a"), obl(self, "b")}, self, []string{"a", "b"}},
+		{"self+zero → self", []authz.Obligations{obl(self, "a"), obl(0, "b")}, self, []string{"a", "b"}},
+		{"zero+tenant → tenant", []authz.Obligations{obl(0), obl(ten)}, ten, nil},
+		{"all zero → zero", []authz.Obligations{obl(0), obl(0)}, 0, nil},
+		{"nil input → zero, empty", nil, 0, nil},
+
+		// FieldMask union / dedup.
+		{"disjoint union (same scope)", []authz.Obligations{obl(ten, "a"), obl(ten, "b")}, ten, []string{"a", "b"}},
+		{"overlapping union dedups", []authz.Obligations{obl(0, "a"), obl(ten, "b", "a"), obl(self)}, self, []string{"a", "b"}},
+		{"empty + non-empty mask", []authz.Obligations{obl(self), obl(self, "a")}, self, []string{"a"}},
+		{"three-way union with dups", []authz.Obligations{obl(ten, "a", "b"), obl(ten, "b", "c"), obl(ten, "a")}, ten, []string{"a", "b", "c"}},
+		{"all empty masks → empty", []authz.Obligations{obl(self), obl(ten)}, self, nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			merged := mergeObligations(tc.in)
+			assert.Equal(t, tc.wantScope, merged.RowScope, "RowScope folds to the narrowest non-zero input")
+			assert.ElementsMatch(t, tc.wantFields, merged.FieldMask.Fields, "FieldMask is the deduped union (set, order-agnostic)")
+			assertObligationsOnlyTighten(t, merged, tc.in)
+		})
+	}
+}
+
+// assertObligationsOnlyTighten checks the fail-safe merge invariant
+// (mergeObligations: combining permits can only tighten, never loosen)
+// independently of the merge implementation, so it catches a loosening
+// regression even for input shapes the enumerated table omits:
+//   - merged.RowScope is no wider than any non-zero input scope, and
+//   - merged.FieldMask.Fields is the deduped superset of every input's fields.
+//
+// It pairs with the enumerated wantScope/wantFields above: the property catches
+// under-tightening (the security failure), the enumerated values catch over- or
+// wrong-tightening (a correctness failure the property alone cannot see).
+func assertObligationsOnlyTighten(t *testing.T, merged authz.Obligations, in []authz.Obligations) {
+	t.Helper()
+	for _, o := range in {
+		if o.RowScope != 0 {
+			// Narrowing an already-narrowest scope by any input is a no-op; if
+			// merged were wider than o, Narrower would return o instead.
+			assert.Equalf(t, merged.RowScope, merged.RowScope.Narrower(o.RowScope),
+				"merged RowScope %v must be no wider than input %v", merged.RowScope, o.RowScope)
+		}
+		for _, f := range o.FieldMask.Fields {
+			assert.Containsf(t, merged.FieldMask.Fields, f,
+				"merged FieldMask must contain every input field %q (union)", f)
+		}
+	}
+	seen := make(map[string]struct{}, len(merged.FieldMask.Fields))
+	for _, f := range merged.FieldMask.Fields {
+		_, dup := seen[f]
+		assert.Falsef(t, dup, "merged FieldMask must be deduped; %q appears twice", f)
+		seen[f] = struct{}{}
+	}
 }
 
 // --- resource attribute provider wiring tests (PR-9 #1347) -------------------


### PR DESCRIPTION
## Summary

为 PDP `mergeObligations` 补一个穷尽 table-driven 合并矩阵 + only-tighten property 守卫，锁死「合并多个 permit 只能收紧、不能放宽」的安全不变量。纯测试改动，无生产代码变更。

## Why / 背景

Issue #1985（六角色 review，P2 测试盲区 Top 3）提出三处 PDP/authz 测试盲区，并**显式要求先核销现有覆盖、缺则补**。核销（已直读现有测试，非轻信）结论：

| 项 | issue 字面要求 | 核销结果 |
|----|---------------|---------|
| ② baseline↔role 四象限（audit:read / config:read\|write\|publish / flag:read\|write） | admin/super-admin allow + user deny + 无 principal deny | **100% 已覆盖**：`TestBuiltinBaseline_AuditRead`（完整四象限）+ `TestBuiltinBaseline_ConfigcorePerms`（5 perm × {admin/super-admin/viewer/no-roles}=20 组）+ `TestAuthorize_NoPrincipal_FailsClosed` + `TestAuthorize_NoTenant_Denies`。不动。 |
| ③ masked-filter oracle 负向（device/self→403 + admin→200） | 负向 + 正向 | **100% 已覆盖**：`TestHandleQuery_MaskedFilterOracle_Rejected` 已含 self/device→403 + admin→200 全 6 例 + 403 命名 masked 列（oracle-safe）。super-admin(RowScopeAll) 正向**经裁定跳过**（走 admin 读取池 + CrossTenantVisibility，未 provision 时 501；RowScopeAll 不 mask、`rejectMaskedFilters` 非其 gate，加了非 masked-oracle 真相、易误导）。不动。 |
| ① mergeObligations 多 permit 组合 | tenant+self→self / FieldMask 并集 / Narrower property | **唯一真实缺口**：`mergeObligations` 作为 `tenant.RowScope.Narrower` 的消费方，RowScope 对组合只锁了 1 对（tenant+self）。 |

本 PR 只补 ①。

## 改动

- 用穷尽 table-driven `TestMergeObligations` **替换**原窄测 `TestMergeObligations_SkipsZeroRowScope_UnionsFieldMask`（吸收其全部 case，不留平行冗余）。聚焦 `mergeObligations` 自身逻辑：N 元 fold（全局最严、顺序无关）、zero-seed、FieldMask 并集/去重——**不再枚举全 6 个 Narrower 对**，因 lattice（self<device<tenant<all）已被 `framework/pkg/tenant` 的 `TestRowScope_Narrower` / `TestRowScope_StrictnessOrdering` 单源，再枚举即重测。
- 新增 `assertObligationsOnlyTighten` property 守卫，对**每个** case 验安全不变量（merged 不宽于任一非零输入 + 字段并集去重）：property 捕获 under-tighten（安全失效，含未枚举输入），枚举值捕获 over/wrong-tighten（正确性失效）。两层互补。
- 集成测试 `TestAuthorize_ObligationsMerge_NarrowestRowScope_UnionFieldMask`（证 wiring）保留不动。

## 验证补充（anti-vacuity / mutation check）

因纯测试、不改生产行为，矩阵首跑即 GREEN。用 mutation check 证两层断言都有牙（已还原，生产代码 `evaluator.go` 未改动）：

1. fold 改 last-wins（`Narrower(o)`→`o`）：property「no wider」+ 枚举 `wantScope` 双双 RED；
2. 去掉 dedup `continue`：property「appears twice」+ 枚举 `ElementsMatch` 双双 RED。

## Refs

Closes #1985

## Risk / 兼容性

无。纯测试改动，不触 contract / wire / 生产代码；契约扇出 N/A。

## Test plan

- [x] `go build ./...` 本地通过（per-module，corecells 绿）
- [x] `go test ./corecells/accesscore/slices/authorizationdecide/...` 本地通过（含 mutation RED 验证 + 还原后全 GREEN；corecells 全模块 69 包 0 FAIL）
- [x] `golangci-lint run ./...` 0 issues（corecells 全模块）

> 注：CI 前的本地 pre-push hook 因 #1565 解散根模块后未同步、对工作区根跑裸 `go build/vet ./...`（结构性失败，与本 PR 无关；`./module/...` 与逐模块 funnel 均绿），经 hack/README.md:39「fast feedback loop, not an unbypassable gate」+ 人工授权一次 `--no-verify` 推送，真门禁交 CI。
