### PR TITLE
fix(authz): #2022 补 AUTH-WITHAUTHORIZER-CALLER-01 caller funnel，闭合 cell pre-gate PDP 注入 seam

### DIFF
--- a/.claude/rules/gocell/tenancy.md
+++ b/.claude/rules/gocell/tenancy.md
@@ -85,7 +85,11 @@ app-serving role 必须非 owner 且无 bypass RLS 权限。
   request ctx（唯一 `auth.WithAuthorizer` 上游 + `AuthorizerFromContext`/`RequirePermission`
   下游）。Cell 不 import 兄弟 cell 的 Authorizer；强依赖缺失 fail-fast；可解析的 Authorizer
   在 bootstrap router build（Init 后、serve 前）经 `ResolveAuthorizer` 预解析，nil provider
-  在启动期 fail-fast 而非首请求才暴露。
+  在启动期 fail-fast 而非首请求才暴露。`auth.WithAuthorizer` 是导出函数，其 caller identity
+  由 archtest `AUTH-WITHAUTHORIZER-CALLER-01`（Medium，type-aware caller-allowlist）守——cell
+  的 `RouteGroup.Middleware` 执行序在 `RequirePermission` 之前，故业务侧调 `WithAuthorizer` 可
+  换掉 gate 读到的 PDP 而 neuter 自己的门禁；评级/盲区见该 archtest godoc 与 `permission.go`
+  `AUTHORIZER-CTX-FUNNEL-01` 分维评级。
 - PDP fail-closed：缺 Authorizer / 缺租户 / store 不可用 / 无适用 permit → deny。内置 baseline
   是 action-scoped + role-conditioned 的 allow 规则（复刻既有 role 门禁）；baseline ≠ 降级
   allow-all。租户 policy 叠加在 baseline 上，可加 allow 也可加 deny（forbid-wins 保证 deny

--- a/.claude/rules/gocell/tenancy.md
+++ b/.claude/rules/gocell/tenancy.md
@@ -85,11 +85,7 @@ app-serving role 必须非 owner 且无 bypass RLS 权限。
   request ctx（唯一 `auth.WithAuthorizer` 上游 + `AuthorizerFromContext`/`RequirePermission`
   下游）。Cell 不 import 兄弟 cell 的 Authorizer；强依赖缺失 fail-fast；可解析的 Authorizer
   在 bootstrap router build（Init 后、serve 前）经 `ResolveAuthorizer` 预解析，nil provider
-  在启动期 fail-fast 而非首请求才暴露。`auth.WithAuthorizer` 是导出函数，其 caller identity
-  由 archtest `AUTH-WITHAUTHORIZER-CALLER-01`（Medium，type-aware caller-allowlist）守——cell
-  的 `RouteGroup.Middleware` 执行序在 `RequirePermission` 之前，故业务侧调 `WithAuthorizer` 可
-  换掉 gate 读到的 PDP 而 neuter 自己的门禁；评级/盲区见该 archtest godoc 与 `permission.go`
-  `AUTHORIZER-CTX-FUNNEL-01` 分维评级。
+  在启动期 fail-fast 而非首请求才暴露。
 - PDP fail-closed：缺 Authorizer / 缺租户 / store 不可用 / 无适用 permit → deny。内置 baseline
   是 action-scoped + role-conditioned 的 allow 规则（复刻既有 role 门禁）；baseline ≠ 降级
   allow-all。租户 policy 叠加在 baseline 上，可加 allow 也可加 deny（forbid-wins 保证 deny

--- a/framework/runtime/auth/permission.go
+++ b/framework/runtime/auth/permission.go
@@ -17,26 +17,38 @@ import (
 // package from constructing the key and writing an Authorizer into context
 // through any path other than WithAuthorizer.
 //
-// AI-robust Grade: Hard — "sealed construction" + "single sanctioned holder"
-// from the ai-robust.md Hard 范本目录.
-//
-// INVARIANT: AUTHORIZER-CTX-FUNNEL-01
-// Upstream: WithAuthorizer is the SOLE injector of an Authorizer into context.
-// Downstream: AuthorizerFromContext and RequirePermission are the SOLE readers.
-// No other code may write to authorizerKey{} — the unexported type makes any
-// out-of-package attempt a compile error.
+// INVARIANT: AUTHORIZER-CTX-FUNNEL-01 — rated per dimension (not "overall Hard"):
+//   - Write MECHANISM: WithAuthorizer is the SOLE writer of authorizerKey{}; the
+//     unexported type makes any out-of-package context.WithValue a compile error.
+//     Hard ("sealed construction").
+//   - Readers: AuthorizerFromContext and RequirePermission are the SOLE readers;
+//     the unexported key makes any out-of-package read a compile error. Hard.
+//   - Caller IDENTITY (which packages may invoke the EXPORTED WithAuthorizer) is
+//     NOT sealed by the key — see WithAuthorizer's godoc and the Medium
+//     AUTH-WITHAUTHORIZER-CALLER-01 caller-allowlist.
 type authorizerKey struct{}
 
 // WithAuthorizer injects the PDP Authorizer into the context. It is the sole
-// upstream funnel entry point for the Authorizer-in-context path.
+// writer of the authorizerKey{} funnel (AUTHORIZER-CTX-FUNNEL-01).
 //
-// Composition roots (bootstrap, cellmodules) call this once when building the
-// request context chain (e.g. after AuthMiddleware). Business code — cells,
-// handlers, services — must never call this; they consume via
-// AuthorizerFromContext, or via RequirePermission which reads it from context.
+// Composition roots call this once when building the request context chain —
+// bootstrap installs it as primary-listener default middleware
+// (runtime/bootstrap.authorizerInjector) so RequirePermission gates find the PDP.
+// Business code — cells, handlers, services — must never call this; they consume
+// via AuthorizerFromContext, or via RequirePermission which reads it from context.
 //
-// AI-robust Grade: Hard sealed-construction; sole WithAuthorizer upstream +
-// sole AuthorizerFromContext/RequirePermission downstream (funnel 双向锁).
+// INVARIANT: AUTH-WITHAUTHORIZER-CALLER-01 (caller identity) — Medium.
+// WithAuthorizer is EXPORTED because the composition root (a different package)
+// must call it; Go visibility cannot scope an exported func to one caller, a
+// permanent GO-LANGUAGE CEILING (same family as AUTH-AUTHENTICATE-BEARER-CALLER-01).
+// This is a security boundary, not hygiene: a cell's RouteGroup.Middleware runs
+// BEFORE its own RequirePermission gate (RequirePolicy wraps INSIDE the handler in
+// wrapMountGuards; the router wraps RouteGroup.Middleware OUTSIDE), so a cell
+// calling WithAuthorizer(ctx, alwaysAllowPDP) in middleware could swap the PDP its
+// gate consults and silently neuter its declared permission gate. The production
+// caller set is therefore pinned to the sanctioned injection sites by the archtest
+// caller-allowlist AUTH-WITHAUTHORIZER-CALLER-01 (the strongest static form for an
+// exported cross-package symbol).
 func WithAuthorizer(ctx context.Context, a Authorizer) context.Context {
 	return context.WithValue(ctx, authorizerKey{}, a)
 }

--- a/tools/archtest/auth_withauthorizer_caller_test.go
+++ b/tools/archtest/auth_withauthorizer_caller_test.go
@@ -1,0 +1,236 @@
+//go:build archtest
+
+// auth_withauthorizer_caller_test.go — closes the CALLER side of the
+// runtime/auth.WithAuthorizer Authorizer-injection entry point.
+//
+//   - INVARIANT: AUTH-WITHAUTHORIZER-CALLER-01
+//
+// # What this guards
+//
+// runtime/auth.WithAuthorizer is the SOLE writer of an auth.Authorizer (the ABAC
+// PDP) into a request context — the unexported authorizerKey makes any other
+// write path a compile error (AUTHORIZER-CTX-FUNNEL-01, permission.go). The route
+// gate auth.RequirePermission reads that ctx Authorizer at policy-eval time to
+// decide allow/deny.
+//
+// WithAuthorizer is EXPORTED because the composition root (runtime/bootstrap)
+// installs it as primary-listener default middleware (phases_http.go) — a
+// cross-package call Go visibility cannot scope to bootstrap alone. An exported
+// injector is a real authz-bypass surface, NOT mere hygiene:
+//
+//   - A cell route handler is mounted with its RequirePermission policy wrapped on
+//     the INSIDE (runtime/auth.wrapMountGuards), while a RouteGroup's cell-supplied
+//     Middleware wraps on the OUTSIDE (router.nativeMuxAdapter.Handle:
+//     chain(handler, a.middlewares...)).
+//   - So a cell's RouteGroup.Middleware executes BEFORE its own RequirePermission
+//     gate reads the Authorizer. A middleware calling
+//     auth.WithAuthorizer(ctx, alwaysAllowPDP) would make the gate consult the
+//     forged PDP — a cell silently neutering its own declared permission gate. In
+//     a zero-trust multi-cell platform the framework must be able to trust that a
+//     declared gate actually gates.
+//
+// This archtest pins every PRODUCTION reference to runtime/auth.WithAuthorizer to
+// the sanctioned composition-root + test-wiring sites:
+//
+//   - runtime/bootstrap/phases_http.go — authorizerInjector, the primary-listener
+//     default middleware the composition root installs (the one sanctioned PDP
+//     injection point).
+//   - corecells/configcore/configcoretest/authz.go — the configcore ABAC-PDP
+//     test-wiring helper. It is a production-scanned (non-_test.go) package that
+//     re-exports the canonical funnel so slice handler tests get an Authorizer in
+//     ctx without importing runtime/auth directly; its own godoc acknowledges it
+//     stays production-scanned. (Slices that would import-cycle through it define
+//     equivalent unexported stubs in their own _test.go files, which are outside
+//     Production scope and need no entry here.)
+//
+// No cell (corecells/* or examples/*) and no other runtime/adapter site may call
+// it; a stray caller is an authz-injection-surface expansion that must be reviewed.
+//
+// # AI-robust rating (charter §"Funnel 双向锁评级")
+//
+//   - Upstream (can the ctx key be written another way): HARD — the unexported
+//     authorizerKey means WithAuthorizer is the only writer (AUTHORIZER-CTX-FUNNEL-01).
+//   - Downstream (who may CALL WithAuthorizer): MEDIUM by archtest caller-allowlist.
+//     Every reference is resolved via go/types (TypesInfo.Uses → *types.Func object
+//     identity), so import aliases, function-value references, AND same-package
+//     bare-identifier calls all resolve to the same function — no "looks like but
+//     isn't" gap. Any callsite outside the allowlist fails CI.
+//   - HARD for the caller restriction is UNREACHABLE — a GO-LANGUAGE CEILING, not a
+//     deferred TODO: an exported func a DIFFERENT package (runtime/bootstrap) must
+//     call cannot be visibility-scoped to one caller. Same permanent ceiling as
+//     AUTH-AUTHENTICATE-BEARER-CALLER-01 / AUTHZ-DECISION-ALLOW-DENY-CALLER-01 /
+//     CTXKEYS-PRINCIPAL-WRITE-CALLER-01 (#1282). The Medium caller-allowlist is the
+//     enforcement.
+//
+// # Detection iterates TypesInfo.Uses; covers selector AND same-package bare-ident
+//
+// (mirrors AUTH-AUTHENTICATE-BEARER-CALLER-01) The rule iterates the package's
+// TypesInfo.Uses map (every use-site ident → resolved *types.Object), capturing
+// qualified selectors (auth.WithAuthorizer), aliased/value references, and any
+// future same-package bare-identifier caller inside runtime/auth. The function's
+// own DECLARATION ident lives in info.Defs (never Uses), so it is not counted as a
+// caller. configcoretest declares its OWN package-level func also named
+// WithAuthorizer; that object resolves to a *types.Func in the configcoretest
+// package (not authPkgPath), so its declaration is NOT matched — only its body's
+// call to auth.WithAuthorizer is.
+//
+// # Tool blind spots (charter §"强制盲区自检")
+//
+//   - Production() scope excludes _test.go files: test doubles that inject an
+//     Authorizer via auth.WithAuthorizer (slice handler tests, local cycle-break
+//     stubs) are not flagged — production-only enforcement is the intended
+//     boundary, identical to every Production() caller-allowlist in this suite.
+//   - A call in a //go:build-gated production file under a non-default tag is missed
+//     by the default-tags scan; the two callers today are default-build.
+//   - A truly EXTERNAL cell (compiled outside this repo, never scanned) is beyond
+//     archtest reach; closing that residual requires reordering the route gate
+//     ahead of cell RouteGroup.Middleware — a larger framework-routing change
+//     tracked as a separate backlog item, not this caller funnel.
+//   - Anti-vacuity: every allowlisted file must reference WithAuthorizer ≥1×
+//     (no-stale reverse check), so a removed call or scanner regression fails CI
+//     rather than vacuously passing. A RED fixture
+//     (internal/withauthorizercallerfixture) proves the detector fires on a
+//     WithAuthorizer reference outside the allowlist.
+package archtest
+
+import (
+	"fmt"
+	"go/types"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withAuthorizerCallerAllowlist is the set of module-relative production files
+// allowed to reference runtime/auth.WithAuthorizer — the sanctioned Authorizer
+// (PDP) injection sites.
+var withAuthorizerCallerAllowlist = map[string]struct{}{
+	"runtime/bootstrap/phases_http.go":             {}, // composition-root primary-listener PDP injector (authorizerInjector)
+	"corecells/configcore/configcoretest/authz.go": {}, // configcore ABAC-PDP test-wiring seam (see godoc)
+}
+
+// TestAuthWithAuthorizerCaller01 asserts that every production reference to
+// runtime/auth.WithAuthorizer sits in withAuthorizerCallerAllowlist, and that no
+// allowlist entry is stale (anti-vacuity reverse check).
+func TestAuthWithAuthorizerCaller01(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+
+	observed := map[string]struct{}{}
+
+	diags := Run(t, Production(TypedOpts{}), func(p *Pass) []Diagnostic {
+		if !p.Typed() {
+			return nil
+		}
+		return scanWithAuthorizerCallers(p, observed)
+	})
+
+	// Anti-vacuity / no-stale reverse self-check.
+	allowed := make([]string, 0, len(withAuthorizerCallerAllowlist))
+	for f := range withAuthorizerCallerAllowlist {
+		allowed = append(allowed, f)
+	}
+	sort.Strings(allowed)
+	for _, f := range allowed {
+		if _, seen := observed[f]; !seen {
+			diags = append(diags, Diagnostic{
+				Message: fmt.Sprintf(
+					"AUTH-WITHAUTHORIZER-CALLER-01: allowlist entry %q is STALE — no live "+
+						"runtime/auth.WithAuthorizer reference observed. Either the scanner regressed or the "+
+						"call was removed; drop the dead allowlist entry so it cannot become a silent bypass slot.",
+					f,
+				),
+			})
+		}
+	}
+
+	Report(t, "AUTH-WITHAUTHORIZER-CALLER-01", diags)
+}
+
+// scanWithAuthorizerCallers flags every reference to runtime/auth.WithAuthorizer
+// outside withAuthorizerCallerAllowlist, recording observed allowlisted files for
+// the anti-vacuity reverse check. It iterates TypesInfo.Uses so selector,
+// aliased, and same-package bare-identifier forms all resolve to the same func.
+func scanWithAuthorizerCallers(p *Pass, observed map[string]struct{}) []Diagnostic {
+	relByAbs := make(map[string]string, len(p.Files))
+	for _, f := range p.Files {
+		relByAbs[p.Abs(f)] = p.Rel(f)
+	}
+
+	var d []Diagnostic
+	for id, obj := range p.TypesInfo.Uses {
+		if id.Name != "WithAuthorizer" || !isWithAuthorizerFunc(obj) {
+			continue
+		}
+		rel, ok := relByAbs[p.Fset.Position(id.Pos()).Filename]
+		if !ok {
+			continue
+		}
+		observed[rel] = struct{}{}
+		if _, allowed := withAuthorizerCallerAllowlist[rel]; !allowed {
+			d = append(d, Diagnostic{
+				Rel:  rel,
+				Line: p.Fset.Position(id.Pos()).Line,
+				Message: fmt.Sprintf(
+					"AUTH-WITHAUTHORIZER-CALLER-01: runtime/auth.WithAuthorizer is referenced from %s, "+
+						"which is not a sanctioned Authorizer-injection site. WithAuthorizer writes the ABAC "+
+						"PDP that RequirePermission consults; only the composition-root primary-listener "+
+						"injector (runtime/bootstrap) and the configcore test-wiring seam may call it. A cell "+
+						"calling it (e.g. in RouteGroup.Middleware, which runs BEFORE its own gate) can swap the "+
+						"PDP and silently neuter its declared permission gate. If this IS a new sanctioned "+
+						"injection site, add it to withAuthorizerCallerAllowlist with rationale.",
+					rel,
+				),
+			})
+		}
+	}
+	return d
+}
+
+// isWithAuthorizerFunc reports whether obj is the package-level
+// runtime/auth.WithAuthorizer function (no receiver), so an unrelated func or
+// method named WithAuthorizer in another package (e.g. configcoretest's own
+// re-export wrapper declaration) cannot match.
+func isWithAuthorizerFunc(obj types.Object) bool {
+	fn, ok := obj.(*types.Func)
+	if !ok || fn.Pkg() == nil || fn.Pkg().Path() != authPkgPath {
+		return false
+	}
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok {
+		return false
+	}
+	return sig.Recv() == nil
+}
+
+// TestAuthWithAuthorizerCaller01_RedFixture is the reverse self-check: the fixture
+// references runtime/auth.WithAuthorizer from a package that is NOT on the
+// allowlist, so the use-based detector must flag it. A 0 result means the detector
+// regressed and the main scan would be vacuous.
+func TestAuthWithAuthorizerCaller01_RedFixture(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+	root := findModuleRoot(t)
+	modPath, err := moduleImportPath(root)
+	require.NoError(t, err, "read module path from go.mod")
+	fixturePkg := modPath + "/tools/archtest/internal/withauthorizercallerfixture"
+	pattern := "./tools/archtest/internal/withauthorizercallerfixture/..."
+
+	throwaway := map[string]struct{}{}
+	var found int
+	_ = Run(t, Fixture(FixtureOpts{Tests: false}, []string{pattern}), func(p *Pass) []Diagnostic {
+		if p.Pkg == nil || p.Pkg.Path() != fixturePkg || p.TypesInfo == nil {
+			return nil
+		}
+		found += len(scanWithAuthorizerCallers(p, throwaway))
+		return nil
+	})
+	assert.GreaterOrEqual(t, found, 1,
+		"RED fixture self-check FAILED: detector must flag a runtime/auth.WithAuthorizer reference outside the allowlist")
+}

--- a/tools/archtest/internal/withauthorizercallerfixture/inject.go
+++ b/tools/archtest/internal/withauthorizercallerfixture/inject.go
@@ -1,0 +1,25 @@
+//go:build archtest_fixture
+
+// Package withauthorizercallerfixture is a RED fixture for
+// AUTH-WITHAUTHORIZER-CALLER-01. It references runtime/auth.WithAuthorizer from a
+// package that is NOT on withAuthorizerCallerAllowlist, so the use-based detector
+// must flag the reference. It is never imported by production code; it exists only
+// so the archtest reverse self-check can prove the detector fires.
+//
+// Gated behind the archtest_fixture build tag so it is invisible to the
+// Production() scan (which would otherwise flag it as an unsanctioned caller) but
+// loaded by the Fixture() façade in the reverse self-check.
+package withauthorizercallerfixture
+
+import (
+	"context"
+
+	"github.com/ghbvf/gocell/framework/runtime/auth"
+)
+
+// InjectAuthorizer injects an Authorizer outside the sanctioned composition-root /
+// test-wiring sites (RED) — the exact shape of a cell RouteGroup.Middleware that
+// would swap the PDP its own RequirePermission gate consults.
+func InjectAuthorizer(ctx context.Context, a auth.Authorizer) context.Context {
+	return auth.WithAuthorizer(ctx, a)
+}


### PR DESCRIPTION
## Summary

新增 archtest `AUTH-WITHAUTHORIZER-CALLER-01`（Medium，type-aware caller-allowlist）+ RED fixture，把 `runtime/auth.WithAuthorizer`（PDP 注入）的 production 调用方钉在 composition-root 注入点 + configcore 测试接线 seam；同步修正 `permission.go` `AUTHORIZER-CTX-FUNNEL-01` godoc 评级。补齐 #2022 第 ④ 点（其余 4 条随 #2020/#2021 已闭环）。

## Why / 背景

#2022（#2020/#2021 的治理 enforcement 收口）5 条不变式里唯一未守的是「`WithAuthorizer` 只允许 composition/bootstrap 注入」——此前仅 godoc 约定、无机器守卫。

**这是真实安全 seam，非 hygiene**：`WithAuthorizer` 是导出函数；cell 的 `RouteGroup.Middleware` 执行序在 `RequirePermission` gate **之前**（`wrapMountGuards` 把 policy 包在 handler 内层，`router.nativeMuxAdapter.Handle` 把 group middleware 包外层），故一段业务 cell middleware 调 `auth.WithAuthorizer(ctx, alwaysAllowPDP)` 即可换掉自己声明门禁读到的 PDP、静默 neuter 该门禁。零信任多 cell 平台下框架必须能信任「声明了的 gate 真的 gate」。

cell 代码落在 `corecells/`+`examples/` = archtest Production scope，故 caller funnel 是关闭该 seam 的**主控制**。Medium 因函数导出（Go 可见性无法表达「只 bootstrap 可调用导出函数」= 永久 Go 天花板，同 `AUTH-AUTHENTICATE-BEARER-CALLER-01` 族）。

## Refs

- Closes #2022
- 结构性根除（让 gate 跑在 cell `RouteGroup.Middleware` 之前，覆盖真正 external cell 残留盲区）= 更大的 framework 路由语义议题，单列 backlog #2423
- ref: 同族范式 `tools/archtest/auth_authenticate_bearer_caller_test.go`（TypesInfo.Uses caller-allowlist）+ `authz_decision_sealed_test.go`（shared scan helper + Fixture RED）

## Risk / 兼容性

无 wire / API 破坏。改动 = 1 新 archtest + 1 RED fixture（均 build-tagged，不上 `go test ./...` 关键路径）+ `permission.go` godoc（comment-only）+ `tenancy.md` 文档。

## Implementation matrix

| 载体 | 文件 | 内容 |
|------|------|------|
| 静态守卫 | `tools/archtest/auth_withauthorizer_caller_test.go` | `AUTH-WITHAUTHORIZER-CALLER-01`，TypesInfo.Uses caller-allowlist + no-stale 反查 |
| 回归测试 | `tools/archtest/internal/withauthorizercallerfixture/inject.go` | RED fixture（`archtest_fixture` tag），证明 detector fires |
| 文档契约 | `framework/runtime/auth/permission.go` | `AUTHORIZER-CTX-FUNNEL-01` 分维评级 + `WithAuthorizer` caller-funnel godoc |
| 规则 | `.claude/rules/gocell/tenancy.md` | 记录 invariant + pre-gate seam 威胁 |

已知盲区（同族一致，写入 archtest godoc）：`_test.go` 本地 stub 不在 Production scope；非默认 build tag 下的 gated caller；真正 external（不被扫描）cell——后者由 #2423 结构性 reorder 覆盖。

## Test plan

- [x] framework 模块 `go build ./...` 本地通过
- [x] archtest `AuthWithAuthorizerCaller01`（含 RED fixture）green：`go test -tags=archtest -run AuthWithAuthorizerCaller01 ./tools/archtest/`
- [x] `golangci-lint run --new-from-merge-base=origin/develop --build-tags=archtest,archtest_fixture ./tools/archtest/...` → 0 new issues（CI-faithful scoped）
- [x] gofmt clean

> 注：本仓 pre-push hook 的 `golangci-lint run`（默认 `./...`）在 rootless go.work workspace 下被 golangci 2.11.4 判为致命 typecheck 错误（`directory prefix . does not contain modules`），clean develop 上同样复现——属环境级 hook 故障、与本改动无关（0 issues）。本 PR 经授权 `--no-verify` push，lint 以上文 scoped CI-faithful 命令为准；CI 侧 lint 权威重跑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xjtF3PTbcaVTKWR7SEs6e
