### PR TITLE
fix(githooks): #2415 删除 #1565 后根级 go build/vet ./... dead gate 与 go.mod compat guard

### DIFF
--- a/hack/githooks/pre-push
+++ b/hack/githooks/pre-push
@@ -4,12 +4,12 @@
 # memory: ai-robust.md §1). It is NOT a full `make verify` — only the
 # subset that is (a) deterministic offline, (b) sub-10s on a WARM cache,
 # (c) high "forgot to run" rate. Infra-bound gates (go test against
-# testcontainers) stay in CI. CI-faithful golangci-lint (deviation 4) is
+# testcontainers) stay in CI. CI-faithful golangci-lint (deviation 5) is
 # the only inclusion that breaches the sub-10s budget on cold cache; it
 # is accepted because warm steady-state is ~7s alongside build/vet, and
 # the cold cost is unavoidable CI work that the push pays regardless.
 #
-# Not a 1:1 CI mirror — four deliberate deviations:
+# Not a 1:1 CI mirror — five deliberate deviations:
 #   - The gofumpt gate runs `go -C tools run mvdan.cc/gofumpt` (version
 #     resolved from tools/go.mod) rather than an ambient $PATH `gofumpt`. A host-installed
 #     gofumpt drifts from the version the CI formatter gate enforces
@@ -83,7 +83,7 @@
 # Wall cost is ~max(slowest gate), not the sum of serial tiers. Each gate
 # is still change-gated: a docs-only push launches nothing (~0s); a .go
 # push on a WARM cache pays ~max(build/vet/lint) ≈ 7-15s. Cold-cache is
-# dominated by golangci-lint (~5min measured, see deviation 4 —
+# dominated by golangci-lint (~5min measured, see deviation 5 —
 # unavoidable CI work, paid once, then warm); a schema/contract push
 # additionally runs the codegen staleness probe in the same fan-out (no
 # extra wall time unless it is the slowest job).
@@ -316,7 +316,7 @@ lint_gate() {
 #                               deliberate CI-structure deviations.
 #   Tier 4  golangci-lint     — CI-faithful PR-mode lint
 #                               (--new-from-merge-base=origin/develop);
-#                               warm ~7s, cold ~5min (deviation 4).
+#                               warm ~7s, cold ~5min (deviation 5).
 #   Tier 3  codegen staleness — only when a codegen *source* changed; can
 #                               fire with go_changed=0 (schema/tmpl-only
 #                               push), so it has its own gate, not nested

--- a/hack/githooks/pre-push
+++ b/hack/githooks/pre-push
@@ -22,18 +22,21 @@
 #     generated/ edits can therefore pass here but fail CI (which runs from
 #     a clean checkout). This is inherent to pre-push hooks, not a bug —
 #     stage your work before relying on the result.
-#   - `go build -tags=integration ./...` has no standalone CI step; CI
+#   - `go build -tags=integration` has no standalone CI step; CI
 #     compiles the integration tag transitively inside `go test
 #     -tags=integration` (integration-test job). It is added here as an
 #     extra local guard because the integration-tag build break is a
 #     repeatedly-forgotten failure mode (project memory: integration-tag
-#     build). In pure go.work mode these commands run per workspace module
-#     through hack/lib/modules.sh; if a root go.mod exists, the root commands
-#     also mirror real CI steps (_build-lint.yml: go build ./... /
-#     go vet -tags=e2e ./tests/e2e/...;
-#     bare `go vet ./...` is intentionally absent from CI because govet
-#     is in golangci-lint v2's default linter set, but the hook still runs
-#     it as a fast standalone fail-fast independent of the lint step).
+#     build). All of build / build-tags=integration / vet run per workspace
+#     module through hack/lib/modules.sh — the repo root is a pure go.work
+#     workspace with no root module post-#1565, so there is no root-level
+#     `./...` form; the per-module build/vet mirror _build-lint.yml's
+#     per-module CI gates. The e2e-tagged vet (go vet -tags=e2e
+#     ./tests/e2e/...) stays at root because it resolves into the real
+#     ./tests module. bare `go vet ./...` is intentionally absent from CI
+#     because govet is in golangci-lint v2's default linter set, but the
+#     hook still runs per-module vet as a fast standalone fail-fast
+#     independent of the lint step).
 #   - archtest is NOT run here. PR #887 first round wired
 #     `SHARD_COUNT=4 bash hack/verify-archtest.sh` as a PR-time
 #     replacement after ADR 202605120000 §Amendment 2026-05-23-pr-time-
@@ -75,7 +78,7 @@
 #
 # Execution: every gate is independent (no shared mutable state; the Go
 # build/test cache is concurrency-safe across parallel `go` invocations),
-# so all of them — gofumpt / build×2 / vet×2 / golangci-lint / codegen-
+# so all of them — gofumpt / per-module build+vet / golangci-lint / codegen-
 # verify — run in a SINGLE parallel fan-out behind one wait barrier.
 # Wall cost is ~max(slowest gate), not the sum of serial tiers. Each gate
 # is still change-gated: a docs-only push launches nothing (~0s); a .go
@@ -307,8 +310,9 @@ lint_gate() {
 #
 #   Tier 1  gofumpt           — formatter drift on the changed .go files
 #                               (the exact gate that failed CI #525).
-#   Tier 2  build/vet ×4      — whole-module compile + vet; integration
-#                               and e2e tags are the header-documented
+#   Tier 2  build/vet         — per-module compile + vet via `go -C` over the
+#                               go.work funnel (root has no module post-#1565);
+#                               integration and e2e tags are header-documented
 #                               deliberate CI-structure deviations.
 #   Tier 4  golangci-lint     — CI-faithful PR-mode lint
 #                               (--new-from-merge-base=origin/develop);
@@ -339,35 +343,39 @@ if [[ ${go_changed} -eq 1 ]]; then
     [[ ${#fmt_targets[@]} -gt 0 ]] && \
         run_bg "gofumpt formatter (run: make fmt)" gofumpt_gate "${fmt_targets[@]}"
 
-    if [[ -f go.mod ]]; then
-        run_bg "go build ./..."                   go build ./...
-        run_bg "go build -tags=integration ./..." go build -tags=integration ./...
-        run_bg "go vet ./..."                     go vet ./...
-    fi
+    # The repo root is a pure go.work workspace with NO root module (#1565), so a
+    # bare `go build/vet ./...` from root matches no module and errors ("directory
+    # prefix . does not contain modules listed in go.work"). Every module is built
+    # and vetted per-module in the funnel loop below — there is no root-level
+    # whole-repo build/vet form. The lone gate that stays at root is the e2e-tagged
+    # vet: `./tests/e2e/...` is a tag+path-scoped target that resolves INTO the real
+    # `./tests` workspace module (so it works), and the funnel's plain `vet ./...`
+    # does not carry the e2e tag — an irreducible complement, not a redundant
+    # whole-repo `./...` gate.
     run_bg "go vet -tags=e2e ./tests/e2e/..." go vet -tags=e2e ./tests/e2e/...
-    # examples/* are their own go.work modules (#1556); root ./... stops at the
-    # nested-module boundary. Enumerate every satellite from the SAME go.work
-    # funnel the CI build/test gates use (hack/lib/modules.sh → `go work edit
-    # -json`) and build/vet each with `go -C`. A hardcoded import-path wildcard
+    # Enumerate every workspace module from the SAME go.work funnel the CI
+    # build/lint gates use (hack/lib/modules.sh → `go work edit -json`) and
+    # build/vet each with `go -C` — framework, adapters/*, examples/* (#1556),
+    # tests, and so on. A hardcoded import-path wildcard
     # (`github.com/ghbvf/gocell/examples/...`) silently mis-covers under an
-    # ambient GOWORK=off and never covers a future non-examples satellite — so
-    # iterate the funnel instead, fail-closed if it breaks.
+    # ambient GOWORK=off and never covers a future workspace module — so iterate
+    # the funnel instead, fail-closed if it breaks.
     # shellcheck source=../lib/util.sh
     source "${ROOT}/hack/lib/util.sh"
     # shellcheck source=../lib/modules.sh
     source "${ROOT}/hack/lib/modules.sh"
-    if satellite_dirs_raw="$(gocell::modules::dirs)"; then
+    if module_dirs_raw="$(gocell::modules::dirs)"; then
         while IFS= read -r moddir; do
             [[ -z "${moddir}" || "${moddir}" == "." ]] && continue
             run_bg "go build (${moddir})"                   go -C "${moddir}" build ./...
             run_bg "go build -tags=integration (${moddir})" go -C "${moddir}" build -tags=integration ./...
             run_bg "go vet (${moddir})"                     go -C "${moddir}" vet ./...
-        done <<<"${satellite_dirs_raw}"
+        done <<<"${module_dirs_raw}"
     else
         # Fail-closed: a broken go.work funnel (missing jq, malformed `use`) must
-        # not silently skip satellite coverage. The funnel already printed its
+        # not silently skip module coverage. The funnel already printed its
         # error to stderr above; block the push.
-        note "FAIL: go.work module enumeration (hack/lib/modules.sh) failed — examples/* satellites NOT built/vetted; install jq and fix go.work, then re-push"
+        note "FAIL: go.work module enumeration (hack/lib/modules.sh) failed — go.work modules NOT built/vetted; install jq and fix go.work, then re-push"
         fail=1
     fi
 


### PR DESCRIPTION
## Summary

删除 `hack/githooks/pre-push` 中 #1565 后失效的根级 `go build/vet ./...` dead gate 及 #2412 遗留的 `if [[ -f go.mod ]]` compat guard，使 go.work funnel 逐模块 build/vet 成为唯一单源。

## Why / 背景

#1565 模块拆分后仓库根已无 `go.mod`，根级 `go build/vet ./...` 必然失败（`directory prefix . does not contain modules listed in go.work`），曾阻断所有含 `.go` 变更的本地推送（#2415 即由 PR #2414 push 被阻断后经 owner 授权 `--no-verify` 绕过而发现）。

今天合入的 #2412（squash 入 `008371285`，主题 "docs(saga)" 但捆绑 `fix(githooks): honor workspace modules in pre-push`）已用 `if [[ -f go.mod ]]` guard 把根级 gate 包住——**阻断已解除**，但留下：
- **compat 双路径 guard**：预设「根可能再变 module」，而 #1565 后根是 pure go.work workspace、永无 root module（`_build-lint.yml` / `verify-workspace-test.sh` 均已据此逐模块化），该前提已死；
- **被它包的 3 行 dead gate**：恒不执行的遗留。

本 PR 做彻底清理（issue #2415 的「彻底/重构」方向），消除「根 `./...` vs funnel loop」双形态，让 funnel loop 单源。预期结果：pre-push 文档与「根已非 module」一致、无 dead/compat 代码。

**保留 `go vet -tags=e2e ./tests/e2e/...`**：它 tag+path-scoped（e2e build tag 仅在 `tests/e2e` 子树），解析进真实 `./tests` 工作区模块仍有效，且 funnel 的无 tag `vet ./...` 不覆盖——是不可约的互补 gate，非整仓 `./...` 冗余。

同步订正因删 gate 而失实的注释（header deviation 3 / Execution 计数 / Tier-2 `×4`）+ 去「satellite」失真概念（root 已非 primary：`satellite_dirs_raw`→`module_dirs_raw` + 注释/`note` 文案）。

## Refs

- Closes #2415
- 关联：#1565（模块拆分根因）、#2412（前序 guard band-aid，本 PR 在其上彻底化）
- 无新增模块/接口，纯 tooling 回归清理，无开源对标 ref（hook 头部既有 `ref: kubernetes/kubernetes hack/verify-*.sh diff-mode` 不动）

## Risk / 兼容性

- **行为无变化**：被删 guard 在本仓恒为假（根无 go.mod），删前即不执行；funnel loop（逐模块 build/vet）byte 级不变（仅变量改名），是真正的覆盖单源。
- **无契约 / wire / migration 影响**；纯 shell。
- **不向后兼容**：直接删 compat guard，未保留任何 fallback / detect-and-fallback 双路径。
- **externalcells/mdm 正交评估**：`externalcells/mdm/go.work` 是 self-rooted shadow workspace、刻意不在根 go.work（`verify-workspace-test.sh:79-90` 显式 prune，覆盖归专属 CI lane #2395）；被删根级 gate 从不覆盖它，本 PR 对其零影响。
- **旁路发现（pre-existing，OUT_OF_SCOPE，非本 PR 引入）**：验证时发现 develop HEAD 的生成文件 `cmd/corebundle/modules_gen.go` 存在 gofumpt 漂移——任何触它的 `.go` push 会被 pre-push gofumpt gate 拦。与 #2415 无关、本 PR 不改任何 `.go`（故不触发该 gate），仅在此记录待裁。

## Test plan

shell hook 无 Go 测试 harness，按行为验证：

- [x] `bash -n hack/githooks/pre-push` 语法通过
- [x] `shellcheck` 零新增 finding（与 HEAD 同为 3×SC1091 + 3×SC2329，均 info 级既有假阳：`run_bg` 间接调用 + `source` 指令）
- [x] guard 已删除、`satellite`→`module` 改名一致、无残留
- [x] **GREEN**：改后 hook 端到端跑全 31 个 go.work 模块 build/vet + e2e-vet，我的改动区零失败（2 个失败均正交：上述 `modules_gen.go` 预存 gofumpt 漂移 + 环境并发 golangci-lint 锁）
- [x] **负控（fail-closed）**：注入编译错误后 `go -C <module> build ./...`（满足 satellite-loop 命令）返回非零 → 逐模块覆盖仍 fail-closed
- [x] 真实 push 时 `pre-push: ok (0s)`（shell-only 变更 `go_changed=0`，gates 正确跳过）
