### PR TITLE
refactor(configcore): remove empty authz dto placeholder

### DIFF
--- a/corecells/configcore/internal/dto/authz.go
+++ b/corecells/configcore/internal/dto/authz.go
@@ -1,2 +1,0 @@
-// Package dto provides shared handler-level data transfer objects for configcore.
-package dto


### PR DESCRIPTION
## Summary

Remove the empty `corecells/configcore/internal/dto/authz.go` placeholder file.

## Why / 背景

`authz.go` only contained a package comment and `package dto`; it defined no types or functions. The real configcore DTO package content and package documentation remain in `config_entry.go`, so this removes dead file noise without changing behavior.

## Refs

Closes #1968

No OSS `ref:` applies: this is local dead-file cleanup, not a framework-pattern implementation.

## Risk / 兼容性

无 public API / schema / contract / migration / wire format impact. No generated code changes.

## Test plan

- [x] `go -C worktrees/refactor/1968-remove-empty-authz-dto test ./corecells/configcore/internal/dto ./corecells/configcore/slices/configreadinternal ./corecells/configcore/slices/configwrite`
- [x] Workspace-module build: `go -C <each module> build ./...`
- [x] Workspace-module test: `go -C <each module> test ./...`
- [x] Post-rebase affected lint: `GOMEMLIMIT=1GiB GOGC=50 golangci-lint run --allow-parallel-runners --concurrency=1 ./...` from `corecells/` → 0 issues
- [ ] Full workspace-module lint: unrelated existing `tools/archtest` unused findings remain; `corecells` and preceding modules completed with 0 issues. Root `golangci-lint run ./...` is not valid for this multi-module workspace root.
