### PR TITLE
test(registrycore): #2388 mem/PG ports.Registry 共享 contract conformance suite + enrollment archtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,7 @@ test-integration:
 		./accesscore/... \
 		./configcore/... \
 		./auditcore/... \
+		./registrycore/... \
 		-count=1 -timeout 15m -v
 
 # ---------------------------------------------------------------------------

--- a/corecells/registrycore/internal/adapters/postgres/registry_repo_conformance_integration_test.go
+++ b/corecells/registrycore/internal/adapters/postgres/registry_repo_conformance_integration_test.go
@@ -1,0 +1,26 @@
+//go:build integration
+
+package postgres
+
+import (
+	"testing"
+
+	"github.com/ghbvf/gocell/corecells/registrycore/internal/ports"
+	"github.com/ghbvf/gocell/corecells/registrycore/internal/ports/conformance"
+	"github.com/ghbvf/gocell/framework/kernel/persistence"
+)
+
+// TestPGRegistry_Conformance enrolls the PostgreSQL Registry in the shared
+// ports.Registry contract suite (REGISTRY-CONFORMANCE-ENROLLMENT-01). Each
+// sub-test gets a fresh per-test database clone via setupRegistryPG; the returned
+// TxManager provides the ambient tx the suite wraps writes in (PG reads isolate
+// via the explicit tenant predicate, mirroring the existing integration tests).
+func TestPGRegistry_Conformance(t *testing.T) {
+	conformance.RunRegistryConformance(t, pgRegistryFactory)
+}
+
+func pgRegistryFactory(t *testing.T) (ports.Registry, persistence.TxRunner, func()) {
+	t.Helper()
+	repo, txMgr := setupRegistryPG(t)
+	return repo, txMgr, func() {}
+}

--- a/corecells/registrycore/internal/adapters/postgres/registry_repo_conformance_integration_test.go
+++ b/corecells/registrycore/internal/adapters/postgres/registry_repo_conformance_integration_test.go
@@ -22,5 +22,7 @@ func TestPGRegistry_Conformance(t *testing.T) {
 func pgRegistryFactory(t *testing.T) (ports.Registry, persistence.TxRunner, func()) {
 	t.Helper()
 	repo, txMgr := setupRegistryPG(t)
+	// No-op cleanup: setupRegistryPG registers the per-test database teardown via
+	// t.Cleanup, so the factory's cleanup func has nothing left to release.
 	return repo, txMgr, func() {}
 }

--- a/corecells/registrycore/internal/adapters/postgres/registry_repo_integration_test.go
+++ b/corecells/registrycore/internal/adapters/postgres/registry_repo_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/clock"
 	"github.com/ghbvf/gocell/framework/kernel/registry"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/panicregister"
 	"github.com/ghbvf/gocell/framework/pkg/query"
 	"github.com/ghbvf/gocell/framework/pkg/tenant"
 )
@@ -27,7 +28,8 @@ var (
 func mustTenant(s string) tenant.TenantID {
 	t, err := tenant.ParseTenantID(s)
 	if err != nil {
-		panic("mustTenant: " + err.Error())
+		panic(panicregister.Approved("registry-integration-test-tenant-id",
+			errcode.Assertion("mustTenant: invalid tenant id %q: %v", s, err)))
 	}
 	return t
 }

--- a/corecells/registrycore/internal/mem/registry_conformance_test.go
+++ b/corecells/registrycore/internal/mem/registry_conformance_test.go
@@ -1,0 +1,24 @@
+package mem
+
+import (
+	"testing"
+
+	"github.com/ghbvf/gocell/corecells/registrycore/internal/ports"
+	"github.com/ghbvf/gocell/corecells/registrycore/internal/ports/conformance"
+	"github.com/ghbvf/gocell/framework/kernel/clock"
+	"github.com/ghbvf/gocell/framework/kernel/outbox"
+	"github.com/ghbvf/gocell/framework/kernel/persistence"
+)
+
+// TestMemRegistry_Conformance enrolls the in-memory Registry in the shared
+// ports.Registry contract suite (REGISTRY-CONFORMANCE-ENROLLMENT-01). The mem
+// store needs no ambient tx, so the factory pairs it with the cell-boundary
+// pass-through outbox.DemoTxRunner the suite wraps writes in.
+func TestMemRegistry_Conformance(t *testing.T) {
+	conformance.RunRegistryConformance(t, memRegistryFactory)
+}
+
+func memRegistryFactory(t *testing.T) (ports.Registry, persistence.TxRunner, func()) {
+	t.Helper()
+	return NewRegistry(clock.Real()), outbox.DemoTxRunner{}, func() {}
+}

--- a/corecells/registrycore/internal/ports/conformance/conformance.go
+++ b/corecells/registrycore/internal/ports/conformance/conformance.go
@@ -1,0 +1,439 @@
+// Package conformance defines a ports.Registry contract acceptance suite shared
+// by every ports.Registry implementation (mem, PG, future). Each implementation
+// MUST call RunRegistryConformance from a _test.go in its own package; the
+// archtest REGISTRY-CONFORMANCE-ENROLLMENT-01 enforces enrollment so the two
+// stores (in-memory + PostgreSQL) can never silently diverge on the interface
+// contract (#2388 — finding F16 from PR #2383: independent per-impl tests do not
+// catch a boundary divergence such as History returning nil vs an empty slice).
+//
+// The suite asserts the *documented* port contract, not byte-level impl detail:
+// History's "no events" result is checked with require.Empty (the port godoc
+// states callers MUST NOT distinguish a nil from an empty slice), so the suite is
+// purely additive — it forces semantic equivalence without mandating a behavior
+// change in either store.
+//
+// Writes (Create/Transition) require an ambient tx (the port contract; the PG
+// store asserts it), so the factory hands back a persistence.TxRunner the suite
+// wraps every write in. Reads (Get/List/History) are issued directly: both stores
+// isolate by the explicit typed tenant parameter (PG additionally via a
+// WHERE tenant_id predicate), so no read needs an ambient tx under the test role.
+// There is no Features struct — unlike UserRepository there is no mem/PG behavior
+// fork to gate; every sub-test exercises one concrete path on both stores.
+//
+// ref: corecells/accesscore/internal/ports/conformance/conformance.go (in-repo template)
+// ref: ThreeDotsLabs/watermill pubsub/tests/test_pubsub.go (factory + shared suite)
+package conformance
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/corecells/registrycore/internal/ports"
+	"github.com/ghbvf/gocell/framework/kernel/persistence"
+	"github.com/ghbvf/gocell/framework/kernel/registry"
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/panicregister"
+	"github.com/ghbvf/gocell/framework/pkg/query"
+	"github.com/ghbvf/gocell/framework/pkg/tenant"
+)
+
+// idASC is the canonical keyset sort (id ASC) — the only sort column the Registry
+// list interface supports.
+var idASC = []query.SortColumn{{Name: "id", Direction: query.SortASC}}
+
+// testTenantID / testTenantIDOther are the canonical tenant UUIDs used across the
+// suite: every read/write is scoped to testTenantID; the cross-tenant isolation
+// sub-test probes testTenantIDOther to prove rows are partitioned by tenant.
+var (
+	testTenantID      = mustParseTenant("00000000-0000-0000-0000-000000000001")
+	testTenantIDOther = mustParseTenant("00000000-0000-0000-0000-000000000002")
+)
+
+// mustParseTenant parses a canonical tenant UUID for the package-level fixtures.
+// A parse failure is a programmer error in a constant literal; it surfaces through
+// the registered-panic funnel (conformance.go is a non-_test.go file scanned by
+// PANIC-REGISTERED-01).
+func mustParseTenant(s string) tenant.TenantID {
+	id, err := tenant.ParseTenantID(s)
+	if err != nil {
+		panic(panicregister.Approved("registry-conformance-test-tenant-id",
+			errcode.Assertion("conformance: invalid test tenant id %q: %v", s, err)))
+	}
+	return id
+}
+
+// RegistryFactory constructs a fresh ports.Registry, its paired
+// persistence.TxRunner (used to provide the ambient tx writes require — a
+// pass-through for stores that need none), and a cleanup func, for one sub-case.
+// The factory is called once per sub-test; cleanup is registered via t.Cleanup.
+type RegistryFactory func(t *testing.T) (repo ports.Registry, txRunner persistence.TxRunner, cleanup func())
+
+// RunRegistryConformance executes the full ports.Registry conformance suite.
+func RunRegistryConformance(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	t.Run("Create_RecordsSubmitted", func(t *testing.T) { conformCreateRecordsSubmitted(t, factory) })
+	t.Run("Create_DuplicateRejected", func(t *testing.T) { conformCreateDuplicateRejected(t, factory) })
+	t.Run("Create_MissingFieldRejected", func(t *testing.T) { conformCreateMissingFieldRejected(t, factory) })
+	t.Run("Transition_LegalAdvancesAndAppends", func(t *testing.T) { conformTransitionLegal(t, factory) })
+	t.Run("Transition_IllegalRejectedNoMutation", func(t *testing.T) { conformTransitionIllegal(t, factory) })
+	t.Run("Transition_UnknownIDNotFound", func(t *testing.T) { conformTransitionUnknownID(t, factory) })
+	t.Run("Transition_ApprovedRecordsApprover", func(t *testing.T) { conformTransitionApprover(t, factory) })
+	t.Run("Get_UnknownReturnsNotFound", func(t *testing.T) { conformGetUnknown(t, factory) })
+	t.Run("List_OrderedCursorPaginated", func(t *testing.T) { conformListPaginated(t, factory) })
+	t.Run("List_Empty", func(t *testing.T) { conformListEmpty(t, factory) })
+	t.Run("List_StateFilter", func(t *testing.T) { conformListStateFilter(t, factory) })
+	t.Run("History_OrderedSeq", func(t *testing.T) { conformHistoryOrdered(t, factory) })
+	t.Run("History_UnknownIDEmpty", func(t *testing.T) { conformHistoryUnknownEmpty(t, factory) })
+	t.Run("CrossTenant_Isolation", func(t *testing.T) { conformCrossTenantIsolation(t, factory) })
+	t.Run("InvalidTenant_Rejected", func(t *testing.T) { conformInvalidTenantRejected(t, factory) })
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+// create submits one registration inside an ambient tx (the write contract) and
+// returns the projected ContractRegistration.
+func create(
+	t *testing.T, txRunner persistence.TxRunner, repo ports.Registry, tn tenant.TenantID, in registry.SubmitInput,
+) registry.ContractRegistration {
+	t.Helper()
+	var out registry.ContractRegistration
+	require.NoError(t, txRunner.RunInTx(context.Background(), func(ctx context.Context) error {
+		var err error
+		out, err = repo.Create(ctx, tn, in)
+		return err
+	}), "create: %s", in.ID)
+	return out
+}
+
+// transition advances one registration inside an ambient tx and returns the repo
+// result (projection, error) for the caller to assert.
+func transition(
+	t *testing.T, txRunner persistence.TxRunner, repo ports.Registry, tn tenant.TenantID, in registry.AdvanceInput,
+) (registry.ContractRegistration, error) {
+	t.Helper()
+	var out registry.ContractRegistration
+	err := txRunner.RunInTx(context.Background(), func(ctx context.Context) error {
+		var e error
+		out, e = repo.Transition(ctx, tn, in)
+		return e
+	})
+	return out, err
+}
+
+// assertCode asserts err carries a *errcode.Error with the wanted Code.
+func assertCode(t *testing.T, err error, want errcode.Code) {
+	t.Helper()
+	var ce *errcode.Error
+	require.True(t, errors.As(err, &ce), "want *errcode.Error %s, got %v", want, err)
+	assert.Equal(t, want, ce.Code)
+}
+
+// submitInput is a small fixture builder for the common http submission shape.
+func submitInput(id string) registry.SubmitInput {
+	return registry.SubmitInput{ID: id, Kind: "http", Submitter: "alice"}
+}
+
+// ─── sub-tests ──────────────────────────────────────────────────────────────
+
+func conformCreateRecordsSubmitted(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	repo, txRunner, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	reg := create(t, txRunner, repo, testTenantID, registry.SubmitInput{
+		ID: "http.foo.v1", Kind: "http", Submitter: "alice", PayloadSchema: "sha256:abc",
+	})
+	assert.Equal(t, "http.foo.v1", reg.ID)
+	assert.Equal(t, "http", reg.Kind)
+	assert.Equal(t, "alice", reg.Submitter)
+	assert.Equal(t, registry.StateSubmitted(), reg.State)
+
+	got, ok, err := repo.Get(context.Background(), testTenantID, "http.foo.v1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, registry.StateSubmitted(), got.State)
+	assert.Equal(t, "alice", got.Submitter)
+
+	// Initial migration event: From = zero sentinel, To = submitted, Seq = 1.
+	evs, err := repo.History(context.Background(), testTenantID, "http.foo.v1")
+	require.NoError(t, err)
+	require.Len(t, evs, 1)
+	assert.True(t, evs[0].From.IsZero())
+	assert.Equal(t, registry.StateSubmitted(), evs[0].To)
+	assert.Equal(t, 1, evs[0].Seq)
+	assert.Equal(t, "alice", evs[0].Actor)
+}
+
+func conformCreateDuplicateRejected(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	repo, txRunner, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	create(t, txRunner, repo, testTenantID, submitInput("dup"))
+	dupErr := txRunner.RunInTx(context.Background(), func(ctx context.Context) error {
+		_, e := repo.Create(ctx, testTenantID, registry.SubmitInput{ID: "dup", Kind: "http", Submitter: "bob"})
+		return e
+	})
+	assertCode(t, dupErr, errcode.ErrRegistrationDuplicate)
+}
+
+func conformCreateMissingFieldRejected(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	repo, txRunner, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	err := txRunner.RunInTx(context.Background(), func(ctx context.Context) error {
+		_, e := repo.Create(ctx, testTenantID, registry.SubmitInput{ID: "", Kind: "http", Submitter: "alice"})
+		return e
+	})
+	assertCode(t, err, errcode.ErrValidationFailed)
+}
+
+func conformTransitionLegal(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	repo, txRunner, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	create(t, txRunner, repo, testTenantID, submitInput("http.foo.v1"))
+	got, err := transition(t, txRunner, repo, testTenantID, registry.AdvanceInput{
+		ID: "http.foo.v1", To: registry.StateProbing(), Actor: "system",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, registry.StateProbing(), got.State)
+
+	evs, err := repo.History(context.Background(), testTenantID, "http.foo.v1")
+	require.NoError(t, err)
+	require.Len(t, evs, 2)
+	assert.Equal(t, registry.StateSubmitted(), evs[1].From)
+	assert.Equal(t, registry.StateProbing(), evs[1].To)
+	assert.Equal(t, 2, evs[1].Seq)
+}
+
+func conformTransitionIllegal(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	repo, txRunner, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	create(t, txRunner, repo, testTenantID, submitInput("http.foo.v1"))
+	// submitted → active is illegal (must go through the lifecycle).
+	_, err := transition(t, txRunner, repo, testTenantID, registry.AdvanceInput{
+		ID: "http.foo.v1", To: registry.StateActive(), Actor: "system",
+	})
+	assertCode(t, err, errcode.ErrRegistrationInvalidTransition)
+
+	// No half-write: still submitted, history unchanged (length 1).
+	got, _, _ := repo.Get(context.Background(), testTenantID, "http.foo.v1")
+	assert.Equal(t, registry.StateSubmitted(), got.State)
+	evs, _ := repo.History(context.Background(), testTenantID, "http.foo.v1")
+	assert.Len(t, evs, 1)
+}
+
+func conformTransitionUnknownID(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	repo, txRunner, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	_, err := transition(t, txRunner, repo, testTenantID, registry.AdvanceInput{
+		ID: "missing", To: registry.StateProbing(), Actor: "system",
+	})
+	assertCode(t, err, errcode.ErrRegistrationNotFound)
+}
+
+func conformTransitionApprover(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	repo, txRunner, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	create(t, txRunner, repo, testTenantID, submitInput("http.foo.v1"))
+	for _, to := range []registry.RegistrationState{
+		registry.StateProbing(), registry.StateConformant(), registry.StatePendingApproval(), registry.StateApproved(),
+	} {
+		_, err := transition(t, txRunner, repo, testTenantID, registry.AdvanceInput{ID: "http.foo.v1", To: to, Actor: "admin"})
+		require.NoError(t, err)
+	}
+	got, ok, err := repo.Get(context.Background(), testTenantID, "http.foo.v1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, registry.StateApproved(), got.State)
+	assert.Equal(t, "admin", got.Approver)
+}
+
+func conformGetUnknown(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	repo, _, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	got, ok, err := repo.Get(context.Background(), testTenantID, "nobody")
+	require.NoError(t, err)
+	assert.False(t, ok, "unknown id must report ok=false")
+	assert.Equal(t, registry.ContractRegistration{}, got, "unknown id must return the zero registration")
+}
+
+func conformListPaginated(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	repo, txRunner, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	for _, id := range []string{"c", "a", "b", "d"} {
+		create(t, txRunner, repo, testTenantID, submitInput(id))
+	}
+	ctx := context.Background()
+
+	// Page 1: Limit=2 → FetchLimit=3; 4 rows → returns a,b,c (the +1 row signals hasMore).
+	page, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 2, Sort: idASC}, ports.ListFilter{})
+	require.NoError(t, err)
+	require.Len(t, page, 3)
+	assert.Equal(t, "a", page[0].ID)
+	assert.Equal(t, "b", page[1].ID)
+	assert.Equal(t, "c", page[2].ID)
+
+	// Page 2: cursor after the last visible id "b" → returns c,d (< FetchLimit → no more).
+	page2, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 2, Sort: idASC, CursorValues: []any{"b"}}, ports.ListFilter{})
+	require.NoError(t, err)
+	require.Len(t, page2, 2)
+	assert.Equal(t, "c", page2[0].ID)
+	assert.Equal(t, "d", page2[1].ID)
+}
+
+func conformListEmpty(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	repo, _, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	page, err := repo.List(context.Background(), testTenantID, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{})
+	require.NoError(t, err)
+	assert.Empty(t, page)
+}
+
+func conformListStateFilter(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	repo, txRunner, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	create(t, txRunner, repo, testTenantID, submitInput("a"))
+	create(t, txRunner, repo, testTenantID, submitInput("b"))
+	_, err := transition(t, txRunner, repo, testTenantID, registry.AdvanceInput{ID: "b", To: registry.StateProbing(), Actor: "system"})
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// submitted filter → only "a".
+	subPage, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{State: registry.StateSubmitted()})
+	require.NoError(t, err)
+	require.Len(t, subPage, 1)
+	assert.Equal(t, "a", subPage[0].ID)
+
+	// probing filter → only "b".
+	probePage, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{State: registry.StateProbing()})
+	require.NoError(t, err)
+	require.Len(t, probePage, 1)
+	assert.Equal(t, "b", probePage[0].ID)
+
+	// a state with no rows → empty.
+	nonePage, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{State: registry.StateApproved()})
+	require.NoError(t, err)
+	assert.Empty(t, nonePage)
+}
+
+func conformHistoryOrdered(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	repo, txRunner, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	create(t, txRunner, repo, testTenantID, submitInput("r1"))
+	for _, to := range []registry.RegistrationState{
+		registry.StateProbing(), registry.StateConformant(), registry.StatePendingApproval(), registry.StateApproved(),
+	} {
+		_, err := transition(t, txRunner, repo, testTenantID, registry.AdvanceInput{ID: "r1", To: to, Actor: "admin"})
+		require.NoError(t, err)
+	}
+
+	evs, err := repo.History(context.Background(), testTenantID, "r1")
+	require.NoError(t, err)
+	require.Len(t, evs, 5) // submit + 4 transitions
+	for i, ev := range evs {
+		assert.Equal(t, i+1, ev.Seq, "Seq must be 1-based contiguous ascending")
+	}
+}
+
+// conformHistoryUnknownEmpty pins the #2388 / F16 divergence: History on an
+// unknown id returns a no-events result on both stores. Asserted with
+// require.Empty (NOT a nil-specific check): the port godoc states callers MUST
+// NOT distinguish a nil from an empty slice, so mem (nil) and PG (empty slice)
+// are both contract-conformant and the suite must treat them as equivalent.
+func conformHistoryUnknownEmpty(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	repo, _, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	evs, err := repo.History(context.Background(), testTenantID, "nobody")
+	require.NoError(t, err)
+	assert.Empty(t, evs, "History on an unknown id must be a no-events result (nil or empty both conform)")
+}
+
+func conformCrossTenantIsolation(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	repo, txRunner, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	create(t, txRunner, repo, testTenantID, registry.SubmitInput{ID: "shared.id", Kind: "event", Submitter: "carol"})
+	ctx := context.Background()
+
+	// Tenant B cannot see tenant A's row by Get / List / History.
+	_, ok, err := repo.Get(ctx, testTenantIDOther, "shared.id")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	page, err := repo.List(ctx, testTenantIDOther, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{})
+	require.NoError(t, err)
+	assert.Empty(t, page)
+	evs, err := repo.History(ctx, testTenantIDOther, "shared.id")
+	require.NoError(t, err)
+	assert.Empty(t, evs)
+
+	// Per-tenant dedup: the same id is independently creatable under tenant B.
+	create(t, txRunner, repo, testTenantIDOther, registry.SubmitInput{ID: "shared.id", Kind: "http", Submitter: "bob"})
+	gotB, ok, err := repo.Get(ctx, testTenantIDOther, "shared.id")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "bob", gotB.Submitter)
+
+	// Sanity: tenant A's row is still visible under its own tenant.
+	gotA, ok, err := repo.Get(ctx, testTenantID, "shared.id")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "carol", gotA.Submitter)
+}
+
+// conformInvalidTenantRejected asserts every method rejects an empty (invalid)
+// tenant with ErrValidationFailed — the typed tenant boundary fail-closes before
+// any store access.
+func conformInvalidTenantRejected(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	repo, txRunner, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	zero := tenant.TenantID("")
+	ctx := context.Background()
+
+	cErr := txRunner.RunInTx(ctx, func(ctx context.Context) error {
+		_, e := repo.Create(ctx, zero, submitInput("x"))
+		return e
+	})
+	assertCode(t, cErr, errcode.ErrValidationFailed)
+
+	tErr := txRunner.RunInTx(ctx, func(ctx context.Context) error {
+		_, e := repo.Transition(ctx, zero, registry.AdvanceInput{ID: "x", To: registry.StateProbing(), Actor: "s"})
+		return e
+	})
+	assertCode(t, tErr, errcode.ErrValidationFailed)
+
+	_, _, gErr := repo.Get(ctx, zero, "x")
+	assertCode(t, gErr, errcode.ErrValidationFailed)
+	_, lErr := repo.List(ctx, zero, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{})
+	assertCode(t, lErr, errcode.ErrValidationFailed)
+	_, hErr := repo.History(ctx, zero, "x")
+	assertCode(t, hErr, errcode.ErrValidationFailed)
+}

--- a/corecells/registrycore/internal/ports/conformance/conformance.go
+++ b/corecells/registrycore/internal/ports/conformance/conformance.go
@@ -7,20 +7,25 @@
 // catch a boundary divergence such as History returning nil vs an empty slice).
 //
 // The suite asserts the *documented* port contract, not byte-level impl detail:
-// History's "no events" result is checked with wantEmpty (the port godoc states
-// callers MUST NOT distinguish a nil from an empty slice), so the suite is purely
-// additive — it forces semantic equivalence without mandating a behavior change
-// in either store.
+// History's "no events" result is checked with a len()==0 assertion (the port
+// godoc states callers MUST NOT distinguish a nil from an empty slice), so the
+// suite is purely additive — it forces semantic equivalence without mandating a
+// behavior change in either store.
 //
 // Writes (Create/Transition) require an ambient tx (the port contract; the PG
 // store asserts it), so the factory hands back a persistence.TxRunner the suite
-// wraps every write in. Reads (Get/List/History) are issued directly: both stores
-// isolate by the explicit typed tenant parameter (PG additionally via a
-// WHERE tenant_id predicate), so no read needs an ambient tx under the test role.
-// (In production the PG read path also runs inside a tenant-scoped tx so FORCE
-// RLS fail-closes an unscoped read; that GUC/RLS behavior is exercised by the PG
-// RLS integration tests, not by this contract suite, which asserts the
-// tenant-parameter isolation common to both stores.)
+// wraps every write in. Reads (Get/List/History) of a valid tenant are issued
+// through getScoped/listScoped/historyScoped, which wrap each read in
+// tenant.WithScope(ctx, t) + TxRunner.RunInTx — modeling the production PG read
+// caller obligation (port godoc §"Read scoping under RLS": the RLS GUC is injected
+// (SET LOCAL) only inside TxManager.RunInTx). The mem store's pass-through runner
+// makes this a no-op wrapper, so the call shape is identical across stores. The
+// suite runs under the test pool's owner role, so it asserts the tenant-parameter
+// isolation common to both stores, not RLS fail-closed enforcement — the latter
+// (which needs the restricted serving role) is covered by the PG RLS integration
+// tests. The InvalidTenant sub-test calls reads directly (an invalid tenant cannot
+// be scoped): the repo's tenant.Validate must fail-close before any store access.
+//
 // There is no Features struct — unlike UserRepository there is no mem/PG behavior
 // fork to gate; every sub-test exercises one concrete path on both stores.
 //
@@ -31,6 +36,7 @@
 //
 // ref: corecells/accesscore/internal/ports/conformance/conformance.go (in-repo template)
 // ref: ThreeDotsLabs/watermill pubsub/tests/test_pubsub.go (factory + shared suite)
+// ref: corecells/configcore/internal/scopedread/scopedread.go (WithScope + RunInTx read funnel)
 package conformance
 
 import (
@@ -73,11 +79,11 @@ func mustParseTenant(s string) tenant.TenantID {
 }
 
 // RegistryFactory constructs a fresh ports.Registry, its paired
-// persistence.TxRunner (used to provide the ambient tx writes require — a
-// pass-through for stores that need none), and a cleanup func, for one sub-case.
-// The factory is called once per sub-test; cleanup is registered via t.Cleanup.
-// A store that needs no real ambient tx (e.g. the in-memory Registry) can pass
-// outbox.DemoTxRunner{} as the TxRunner.
+// persistence.TxRunner (used to provide the ambient tx writes require AND the
+// tenant-scoped read tx — a pass-through for stores that need neither), and a
+// cleanup func, for one sub-case. The factory is called once per sub-test; cleanup
+// is registered via t.Cleanup. A store that needs no real ambient tx (e.g. the
+// in-memory Registry) can pass outbox.DemoTxRunner{} as the TxRunner.
 type RegistryFactory func(t *testing.T) (repo ports.Registry, txRunner persistence.TxRunner, cleanup func())
 
 // RunRegistryConformance executes the full ports.Registry conformance suite.
@@ -169,9 +175,66 @@ func transition(
 	return out, err
 }
 
+// getScoped reads (t, id) inside a tenant-scoped tx (tenant.WithScope + RunInTx),
+// modeling the production PG read caller obligation; mem's pass-through runner makes
+// it a no-op wrapper. A read error fails the sub-test (no valid-tenant read should
+// error); callers assert on the (registration, ok) result.
+func getScoped(
+	t *testing.T, txRunner persistence.TxRunner, repo ports.Registry, tn tenant.TenantID, id string,
+) (registry.ContractRegistration, bool) {
+	t.Helper()
+	var (
+		out registry.ContractRegistration
+		ok  bool
+	)
+	err := txRunner.RunInTx(tenant.WithScope(context.Background(), tn), func(ctx context.Context) error {
+		var e error
+		out, ok, e = repo.Get(ctx, tn, id)
+		return e
+	})
+	fatalIfErr(t, err, "Get "+id)
+	return out, ok
+}
+
+// listScoped is getScoped's List counterpart (tenant-scoped read tx).
+func listScoped(
+	t *testing.T, txRunner persistence.TxRunner, repo ports.Registry,
+	tn tenant.TenantID, params query.ListParams, filter ports.ListFilter,
+) []registry.ContractRegistration {
+	t.Helper()
+	var out []registry.ContractRegistration
+	err := txRunner.RunInTx(tenant.WithScope(context.Background(), tn), func(ctx context.Context) error {
+		var e error
+		out, e = repo.List(ctx, tn, params, filter)
+		return e
+	})
+	fatalIfErr(t, err, "List")
+	return out
+}
+
+// historyScoped is getScoped's History counterpart (tenant-scoped read tx).
+func historyScoped(
+	t *testing.T, txRunner persistence.TxRunner, repo ports.Registry, tn tenant.TenantID, id string,
+) []registry.RegistrationEvent {
+	t.Helper()
+	var out []registry.RegistrationEvent
+	err := txRunner.RunInTx(tenant.WithScope(context.Background(), tn), func(ctx context.Context) error {
+		var e error
+		out, e = repo.History(ctx, tn, id)
+		return e
+	})
+	fatalIfErr(t, err, "History "+id)
+	return out
+}
+
 // submitInput is a small fixture builder for the common http submission shape.
 func submitInput(id string) registry.SubmitInput {
 	return registry.SubmitInput{ID: id, Kind: "http", Submitter: "alice"}
+}
+
+// pageParams builds a first-page ListParams with the canonical id-ASC sort.
+func pageParams(limit int) query.ListParams {
+	return query.ListParams{Limit: limit, Sort: idASC}
 }
 
 // ─── sub-tests ──────────────────────────────────────────────────────────────
@@ -189,15 +252,13 @@ func conformCreateRecordsSubmitted(t *testing.T, factory RegistryFactory) {
 	errUnless(t, reg.Submitter == "alice", "Create: submitter = %q, want alice", reg.Submitter)
 	errUnless(t, reg.State == registry.StateSubmitted(), "Create: state = %s, want submitted", reg.State)
 
-	got, ok, err := repo.Get(context.Background(), testTenantID, "http.foo.v1")
-	fatalIfErr(t, err, "Get")
+	got, ok := getScoped(t, txRunner, repo, testTenantID, "http.foo.v1")
 	fatalUnless(t, ok, "Get: want ok=true for created registration")
 	errUnless(t, got.State == registry.StateSubmitted(), "Get: state = %s, want submitted", got.State)
 	errUnless(t, got.Submitter == "alice", "Get: submitter = %q, want alice", got.Submitter)
 
 	// Initial migration event: From = zero sentinel, To = submitted, Seq = 1.
-	evs, err := repo.History(context.Background(), testTenantID, "http.foo.v1")
-	fatalIfErr(t, err, "History")
+	evs := historyScoped(t, txRunner, repo, testTenantID, "http.foo.v1")
 	fatalUnless(t, len(evs) == 1, "History: len = %d, want 1", len(evs))
 	errUnless(t, evs[0].From.IsZero(), "History: initial event From must be the zero sentinel")
 	errUnless(t, evs[0].To == registry.StateSubmitted(), "History: initial event To = %s, want submitted", evs[0].To)
@@ -255,8 +316,7 @@ func conformTransitionLegal(t *testing.T, factory RegistryFactory) {
 	fatalIfErr(t, err, "Transition")
 	errUnless(t, got.State == registry.StateProbing(), "Transition: state = %s, want probing", got.State)
 
-	evs, err := repo.History(context.Background(), testTenantID, "http.foo.v1")
-	fatalIfErr(t, err, "History")
+	evs := historyScoped(t, txRunner, repo, testTenantID, "http.foo.v1")
 	fatalUnless(t, len(evs) == 2, "History: len = %d, want 2", len(evs))
 	errUnless(t, evs[1].From == registry.StateSubmitted(), "History: event[1] From = %s, want submitted", evs[1].From)
 	errUnless(t, evs[1].To == registry.StateProbing(), "History: event[1] To = %s, want probing", evs[1].To)
@@ -275,15 +335,11 @@ func conformTransitionIllegal(t *testing.T, factory RegistryFactory) {
 	})
 	assertCode(t, err, errcode.ErrRegistrationInvalidTransition, "Transition illegal")
 
-	// No half-write: still submitted, history unchanged (length 1). The reads must
-	// not swallow errors — a failed Get/History would otherwise masquerade as a
-	// state-drift assertion with no diagnostic context.
-	got, ok, gerr := repo.Get(context.Background(), testTenantID, "http.foo.v1")
-	fatalIfErr(t, gerr, "Get after illegal transition")
+	// No half-write: still submitted, history unchanged (length 1).
+	got, ok := getScoped(t, txRunner, repo, testTenantID, "http.foo.v1")
 	fatalUnless(t, ok, "Get after illegal transition: want ok=true")
 	errUnless(t, got.State == registry.StateSubmitted(), "Transition illegal: state must stay submitted, got %s", got.State)
-	evs, herr := repo.History(context.Background(), testTenantID, "http.foo.v1")
-	fatalIfErr(t, herr, "History after illegal transition")
+	evs := historyScoped(t, txRunner, repo, testTenantID, "http.foo.v1")
 	errUnless(t, len(evs) == 1, "Transition illegal: history must stay length 1, got %d", len(evs))
 }
 
@@ -343,8 +399,7 @@ func conformTransitionApprover(t *testing.T, factory RegistryFactory) {
 		_, err := transition(t, txRunner, repo, testTenantID, registry.AdvanceInput{ID: "http.foo.v1", To: to, Actor: "admin"})
 		fatalIfErr(t, err, "Transition to "+to.String())
 	}
-	got, ok, err := repo.Get(context.Background(), testTenantID, "http.foo.v1")
-	fatalIfErr(t, err, "Get")
+	got, ok := getScoped(t, txRunner, repo, testTenantID, "http.foo.v1")
 	fatalUnless(t, ok, "Get: want ok=true")
 	errUnless(t, got.State == registry.StateApproved(), "Approver: state = %s, want approved", got.State)
 	errUnless(t, got.Approver == "admin", "Approver: approver = %q, want admin", got.Approver)
@@ -352,11 +407,10 @@ func conformTransitionApprover(t *testing.T, factory RegistryFactory) {
 
 func conformGetUnknown(t *testing.T, factory RegistryFactory) {
 	t.Helper()
-	repo, _, cleanup := factory(t)
+	repo, txRunner, cleanup := factory(t)
 	t.Cleanup(cleanup)
 
-	got, ok, err := repo.Get(context.Background(), testTenantID, "nobody")
-	fatalIfErr(t, err, "Get unknown")
+	got, ok := getScoped(t, txRunner, repo, testTenantID, "nobody")
 	errUnless(t, !ok, "Get unknown: want ok=false")
 	errUnless(t, got.ID == "" && got.State.IsZero(), "Get unknown: want the zero registration, got %+v", got)
 }
@@ -369,18 +423,16 @@ func conformListPaginated(t *testing.T, factory RegistryFactory) {
 	for _, id := range []string{"c", "a", "b", "d"} {
 		create(t, txRunner, repo, testTenantID, submitInput(id))
 	}
-	ctx := context.Background()
 
 	// Page 1: Limit=2 → FetchLimit=3; 4 rows → returns a,b,c (the +1 row signals hasMore).
-	page, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 2, Sort: idASC}, ports.ListFilter{})
-	fatalIfErr(t, err, "List page1")
+	page := listScoped(t, txRunner, repo, testTenantID, pageParams(2), ports.ListFilter{})
 	fatalUnless(t, len(page) == 3, "List page1: len = %d, want 3 (N+1)", len(page))
 	errUnless(t, page[0].ID == "a" && page[1].ID == "b" && page[2].ID == "c",
 		"List page1: ids = [%s %s %s], want [a b c]", page[0].ID, page[1].ID, page[2].ID)
 
 	// Page 2: cursor after the last visible id "b" → returns c,d (< FetchLimit → no more).
-	page2, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 2, Sort: idASC, CursorValues: []any{"b"}}, ports.ListFilter{})
-	fatalIfErr(t, err, "List page2")
+	page2 := listScoped(t, txRunner, repo, testTenantID,
+		query.ListParams{Limit: 2, Sort: idASC, CursorValues: []any{"b"}}, ports.ListFilter{})
 	fatalUnless(t, len(page2) == 2, "List page2: len = %d, want 2", len(page2))
 	errUnless(t, page2[0].ID == "c" && page2[1].ID == "d",
 		"List page2: ids = [%s %s], want [c d]", page2[0].ID, page2[1].ID)
@@ -388,11 +440,10 @@ func conformListPaginated(t *testing.T, factory RegistryFactory) {
 
 func conformListEmpty(t *testing.T, factory RegistryFactory) {
 	t.Helper()
-	repo, _, cleanup := factory(t)
+	repo, txRunner, cleanup := factory(t)
 	t.Cleanup(cleanup)
 
-	page, err := repo.List(context.Background(), testTenantID, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{})
-	fatalIfErr(t, err, "List empty")
+	page := listScoped(t, txRunner, repo, testTenantID, pageParams(10), ports.ListFilter{})
 	errUnless(t, len(page) == 0, "List empty: want 0 rows, got %d", len(page))
 }
 
@@ -405,29 +456,24 @@ func conformListStateFilter(t *testing.T, factory RegistryFactory) {
 	create(t, txRunner, repo, testTenantID, submitInput("b"))
 	_, err := transition(t, txRunner, repo, testTenantID, registry.AdvanceInput{ID: "b", To: registry.StateProbing(), Actor: "system"})
 	fatalIfErr(t, err, "Transition b→probing")
-	ctx := context.Background()
 
 	// submitted filter → only "a".
-	subPage, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{State: registry.StateSubmitted()})
-	fatalIfErr(t, err, "List submitted")
+	subPage := listScoped(t, txRunner, repo, testTenantID, pageParams(10), ports.ListFilter{State: registry.StateSubmitted()})
 	fatalUnless(t, len(subPage) == 1, "List submitted: len = %d, want 1", len(subPage))
 	errUnless(t, subPage[0].ID == "a", "List submitted: id = %q, want a", subPage[0].ID)
 
 	// probing filter → only "b".
-	probePage, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{State: registry.StateProbing()})
-	fatalIfErr(t, err, "List probing")
+	probePage := listScoped(t, txRunner, repo, testTenantID, pageParams(10), ports.ListFilter{State: registry.StateProbing()})
 	fatalUnless(t, len(probePage) == 1, "List probing: len = %d, want 1", len(probePage))
 	errUnless(t, probePage[0].ID == "b", "List probing: id = %q, want b", probePage[0].ID)
 
 	// a state with no rows → empty.
-	nonePage, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{State: registry.StateApproved()})
-	fatalIfErr(t, err, "List approved")
+	nonePage := listScoped(t, txRunner, repo, testTenantID, pageParams(10), ports.ListFilter{State: registry.StateApproved()})
 	errUnless(t, len(nonePage) == 0, "List approved: want 0 rows, got %d", len(nonePage))
 
 	// Zero-value ListFilter{} means "all states" (the port contract): a mixed-state
 	// store must return every row, not silently treat the zero State as a predicate.
-	allPage, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{})
-	fatalIfErr(t, err, "List all-states")
+	allPage := listScoped(t, txRunner, repo, testTenantID, pageParams(10), ports.ListFilter{})
 	fatalUnless(t, len(allPage) == 2, "List all-states: len = %d, want 2 (submitted a + probing b)", len(allPage))
 	errUnless(t, allPage[0].ID == "a" && allPage[1].ID == "b",
 		"List all-states: ids = [%s %s], want [a b]", allPage[0].ID, allPage[1].ID)
@@ -446,8 +492,7 @@ func conformHistoryOrdered(t *testing.T, factory RegistryFactory) {
 		fatalIfErr(t, err, "Transition to "+to.String())
 	}
 
-	evs, err := repo.History(context.Background(), testTenantID, "r1")
-	fatalIfErr(t, err, "History")
+	evs := historyScoped(t, txRunner, repo, testTenantID, "r1")
 	fatalUnless(t, len(evs) == 5, "History: len = %d, want 5 (submit + 4 transitions)", len(evs))
 	for i, ev := range evs {
 		errUnless(t, ev.Seq == i+1, "History: event[%d] Seq = %d, want %d (1-based contiguous)", i, ev.Seq, i+1)
@@ -455,17 +500,16 @@ func conformHistoryOrdered(t *testing.T, factory RegistryFactory) {
 }
 
 // conformHistoryUnknownEmpty pins the #2388 / F16 divergence: History on an
-// unknown id returns a no-events result on both stores. Asserted with wantEmpty
+// unknown id returns a no-events result on both stores. Asserted with len()==0
 // (NOT a nil-specific check): the port godoc states callers MUST NOT distinguish
 // a nil from an empty slice, so mem (nil) and PG (empty slice) are both
 // contract-conformant and the suite must treat them as equivalent.
 func conformHistoryUnknownEmpty(t *testing.T, factory RegistryFactory) {
 	t.Helper()
-	repo, _, cleanup := factory(t)
+	repo, txRunner, cleanup := factory(t)
 	t.Cleanup(cleanup)
 
-	evs, err := repo.History(context.Background(), testTenantID, "nobody")
-	fatalIfErr(t, err, "History unknown")
+	evs := historyScoped(t, txRunner, repo, testTenantID, "nobody")
 	errUnless(t, len(evs) == 0, "History unknown: want a no-events result (nil or empty), got len %d", len(evs))
 }
 
@@ -475,17 +519,13 @@ func conformCrossTenantIsolation(t *testing.T, factory RegistryFactory) {
 	t.Cleanup(cleanup)
 
 	create(t, txRunner, repo, testTenantID, registry.SubmitInput{ID: "shared.id", Kind: "event", Submitter: "carol"})
-	ctx := context.Background()
 
-	// Tenant B cannot see tenant A's row by Get / List / History.
-	_, ok, err := repo.Get(ctx, testTenantIDOther, "shared.id")
-	fatalIfErr(t, err, "Get cross-tenant")
+	// Tenant B cannot see tenant A's row by Get / List / History (each scoped to B).
+	_, ok := getScoped(t, txRunner, repo, testTenantIDOther, "shared.id")
 	errUnless(t, !ok, "Get cross-tenant: tenant B must not see tenant A's row")
-	page, err := repo.List(ctx, testTenantIDOther, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{})
-	fatalIfErr(t, err, "List cross-tenant")
+	page := listScoped(t, txRunner, repo, testTenantIDOther, pageParams(10), ports.ListFilter{})
 	errUnless(t, len(page) == 0, "List cross-tenant: tenant B must see 0 rows, got %d", len(page))
-	evs, err := repo.History(ctx, testTenantIDOther, "shared.id")
-	fatalIfErr(t, err, "History cross-tenant")
+	evs := historyScoped(t, txRunner, repo, testTenantIDOther, "shared.id")
 	errUnless(t, len(evs) == 0, "History cross-tenant: tenant B must see 0 events, got %d", len(evs))
 
 	// Write-path isolation: tenant B cannot advance tenant A's registration. Probed
@@ -498,45 +538,56 @@ func conformCrossTenantIsolation(t *testing.T, factory RegistryFactory) {
 
 	// Per-tenant dedup: the same id is independently creatable under tenant B.
 	create(t, txRunner, repo, testTenantIDOther, registry.SubmitInput{ID: "shared.id", Kind: "http", Submitter: "bob"})
-	gotB, ok, err := repo.Get(ctx, testTenantIDOther, "shared.id")
-	fatalIfErr(t, err, "Get tenant B")
+	gotB, ok := getScoped(t, txRunner, repo, testTenantIDOther, "shared.id")
 	fatalUnless(t, ok, "Get tenant B: want ok=true")
 	errUnless(t, gotB.Submitter == "bob", "Get tenant B: submitter = %q, want bob", gotB.Submitter)
 
 	// Sanity: tenant A's row is still visible under its own tenant.
-	gotA, ok, err := repo.Get(ctx, testTenantID, "shared.id")
-	fatalIfErr(t, err, "Get tenant A")
+	gotA, ok := getScoped(t, txRunner, repo, testTenantID, "shared.id")
 	fatalUnless(t, ok, "Get tenant A: want ok=true")
 	errUnless(t, gotA.Submitter == "carol", "Get tenant A: submitter = %q, want carol", gotA.Submitter)
 }
 
-// conformInvalidTenantRejected asserts every method rejects an empty (invalid)
-// tenant with ErrValidationFailed — the typed tenant boundary fail-closes before
-// any store access.
+// conformInvalidTenantRejected asserts every method rejects an invalid tenant with
+// ErrValidationFailed — the typed tenant boundary fail-closes before any store
+// access. The invalid set covers the full TenantID.Validate rejection contract
+// (empty / reserved nil UUID / non-canonical), not just the empty symptom. Reads
+// are issued directly (NOT through the scoped helpers): an invalid tenant cannot be
+// scoped (tenant.WithScope of an invalid id is meaningless), and the repo's
+// tenant.Validate must reject before any tx/store access regardless of scoping.
 func conformInvalidTenantRejected(t *testing.T, factory RegistryFactory) {
 	t.Helper()
 	repo, txRunner, cleanup := factory(t)
 	t.Cleanup(cleanup)
 
-	zero := tenant.TenantID("")
+	invalids := []struct {
+		name string
+		tn   tenant.TenantID
+	}{
+		{"empty", tenant.TenantID("")},
+		{"reserved-nil-uuid", tenant.TenantID("00000000-0000-0000-0000-000000000000")},
+		{"uppercase-non-canonical", tenant.TenantID("AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")},
+		{"malformed", tenant.TenantID("not-a-uuid")},
+	}
 	ctx := context.Background()
+	for _, inv := range invalids {
+		cErr := txRunner.RunInTx(ctx, func(ctx context.Context) error {
+			_, e := repo.Create(ctx, inv.tn, submitInput("x"))
+			return e
+		})
+		assertCode(t, cErr, errcode.ErrValidationFailed, "Create invalid tenant ("+inv.name+")")
 
-	cErr := txRunner.RunInTx(ctx, func(ctx context.Context) error {
-		_, e := repo.Create(ctx, zero, submitInput("x"))
-		return e
-	})
-	assertCode(t, cErr, errcode.ErrValidationFailed, "Create invalid tenant")
+		tErr := txRunner.RunInTx(ctx, func(ctx context.Context) error {
+			_, e := repo.Transition(ctx, inv.tn, registry.AdvanceInput{ID: "x", To: registry.StateProbing(), Actor: "s"})
+			return e
+		})
+		assertCode(t, tErr, errcode.ErrValidationFailed, "Transition invalid tenant ("+inv.name+")")
 
-	tErr := txRunner.RunInTx(ctx, func(ctx context.Context) error {
-		_, e := repo.Transition(ctx, zero, registry.AdvanceInput{ID: "x", To: registry.StateProbing(), Actor: "s"})
-		return e
-	})
-	assertCode(t, tErr, errcode.ErrValidationFailed, "Transition invalid tenant")
-
-	_, _, gErr := repo.Get(ctx, zero, "x")
-	assertCode(t, gErr, errcode.ErrValidationFailed, "Get invalid tenant")
-	_, lErr := repo.List(ctx, zero, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{})
-	assertCode(t, lErr, errcode.ErrValidationFailed, "List invalid tenant")
-	_, hErr := repo.History(ctx, zero, "x")
-	assertCode(t, hErr, errcode.ErrValidationFailed, "History invalid tenant")
+		_, _, gErr := repo.Get(ctx, inv.tn, "x")
+		assertCode(t, gErr, errcode.ErrValidationFailed, "Get invalid tenant ("+inv.name+")")
+		_, lErr := repo.List(ctx, inv.tn, pageParams(10), ports.ListFilter{})
+		assertCode(t, lErr, errcode.ErrValidationFailed, "List invalid tenant ("+inv.name+")")
+		_, hErr := repo.History(ctx, inv.tn, "x")
+		assertCode(t, hErr, errcode.ErrValidationFailed, "History invalid tenant ("+inv.name+")")
+	}
 }

--- a/corecells/registrycore/internal/ports/conformance/conformance.go
+++ b/corecells/registrycore/internal/ports/conformance/conformance.go
@@ -7,10 +7,10 @@
 // catch a boundary divergence such as History returning nil vs an empty slice).
 //
 // The suite asserts the *documented* port contract, not byte-level impl detail:
-// History's "no events" result is checked with require.Empty (the port godoc
-// states callers MUST NOT distinguish a nil from an empty slice), so the suite is
-// purely additive — it forces semantic equivalence without mandating a behavior
-// change in either store.
+// History's "no events" result is checked with wantEmpty (the port godoc states
+// callers MUST NOT distinguish a nil from an empty slice), so the suite is purely
+// additive — it forces semantic equivalence without mandating a behavior change
+// in either store.
 //
 // Writes (Create/Transition) require an ambient tx (the port contract; the PG
 // store asserts it), so the factory hands back a persistence.TxRunner the suite
@@ -20,6 +20,11 @@
 // There is no Features struct — unlike UserRepository there is no mem/PG behavior
 // fork to gate; every sub-test exercises one concrete path on both stores.
 //
+// Assertions use the stdlib testing.T directly (no testify): conformance.go is a
+// non-_test.go file in the corecells module, where the cells-isolation depguard
+// bans third-party test libraries — same constraint and pattern as the accesscore
+// ports/conformance suite.
+//
 // ref: corecells/accesscore/internal/ports/conformance/conformance.go (in-repo template)
 // ref: ThreeDotsLabs/watermill pubsub/tests/test_pubsub.go (factory + shared suite)
 package conformance
@@ -28,9 +33,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/ghbvf/gocell/corecells/registrycore/internal/ports"
 	"github.com/ghbvf/gocell/framework/kernel/persistence"
@@ -92,7 +94,41 @@ func RunRegistryConformance(t *testing.T, factory RegistryFactory) {
 	t.Run("InvalidTenant_Rejected", func(t *testing.T) { conformInvalidTenantRejected(t, factory) })
 }
 
-// ─── helpers ────────────────────────────────────────────────────────────────
+// ─── assertion + fixture helpers (stdlib testing, no testify) ─────────────────
+
+// fatalIfErr fails the sub-test immediately on a non-nil error.
+func fatalIfErr(t *testing.T, err error, what string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: unexpected error: %v", what, err)
+	}
+}
+
+// fatalUnless fails the sub-test immediately when cond is false (preconditions).
+func fatalUnless(t *testing.T, cond bool, format string, args ...any) {
+	t.Helper()
+	if !cond {
+		t.Fatalf(format, args...)
+	}
+}
+
+// errUnless records a non-fatal failure when cond is false (assertions).
+func errUnless(t *testing.T, cond bool, format string, args ...any) {
+	t.Helper()
+	if !cond {
+		t.Errorf(format, args...)
+	}
+}
+
+// assertCode asserts err carries a *errcode.Error with the wanted Code.
+func assertCode(t *testing.T, err error, want errcode.Code, what string) {
+	t.Helper()
+	var ce *errcode.Error
+	if !errors.As(err, &ce) {
+		t.Fatalf("%s: want *errcode.Error %s, got %v", what, want, err)
+	}
+	errUnless(t, ce.Code == want, "%s: code = %s, want %s", what, ce.Code, want)
+}
 
 // create submits one registration inside an ambient tx (the write contract) and
 // returns the projected ContractRegistration.
@@ -101,11 +137,12 @@ func create(
 ) registry.ContractRegistration {
 	t.Helper()
 	var out registry.ContractRegistration
-	require.NoError(t, txRunner.RunInTx(context.Background(), func(ctx context.Context) error {
-		var err error
-		out, err = repo.Create(ctx, tn, in)
-		return err
-	}), "create: %s", in.ID)
+	err := txRunner.RunInTx(context.Background(), func(ctx context.Context) error {
+		var e error
+		out, e = repo.Create(ctx, tn, in)
+		return e
+	})
+	fatalIfErr(t, err, "create "+in.ID)
 	return out
 }
 
@@ -124,14 +161,6 @@ func transition(
 	return out, err
 }
 
-// assertCode asserts err carries a *errcode.Error with the wanted Code.
-func assertCode(t *testing.T, err error, want errcode.Code) {
-	t.Helper()
-	var ce *errcode.Error
-	require.True(t, errors.As(err, &ce), "want *errcode.Error %s, got %v", want, err)
-	assert.Equal(t, want, ce.Code)
-}
-
 // submitInput is a small fixture builder for the common http submission shape.
 func submitInput(id string) registry.SubmitInput {
 	return registry.SubmitInput{ID: id, Kind: "http", Submitter: "alice"}
@@ -147,25 +176,25 @@ func conformCreateRecordsSubmitted(t *testing.T, factory RegistryFactory) {
 	reg := create(t, txRunner, repo, testTenantID, registry.SubmitInput{
 		ID: "http.foo.v1", Kind: "http", Submitter: "alice", PayloadSchema: "sha256:abc",
 	})
-	assert.Equal(t, "http.foo.v1", reg.ID)
-	assert.Equal(t, "http", reg.Kind)
-	assert.Equal(t, "alice", reg.Submitter)
-	assert.Equal(t, registry.StateSubmitted(), reg.State)
+	errUnless(t, reg.ID == "http.foo.v1", "Create: id = %q, want http.foo.v1", reg.ID)
+	errUnless(t, reg.Kind == "http", "Create: kind = %q, want http", reg.Kind)
+	errUnless(t, reg.Submitter == "alice", "Create: submitter = %q, want alice", reg.Submitter)
+	errUnless(t, reg.State == registry.StateSubmitted(), "Create: state = %s, want submitted", reg.State)
 
 	got, ok, err := repo.Get(context.Background(), testTenantID, "http.foo.v1")
-	require.NoError(t, err)
-	require.True(t, ok)
-	assert.Equal(t, registry.StateSubmitted(), got.State)
-	assert.Equal(t, "alice", got.Submitter)
+	fatalIfErr(t, err, "Get")
+	fatalUnless(t, ok, "Get: want ok=true for created registration")
+	errUnless(t, got.State == registry.StateSubmitted(), "Get: state = %s, want submitted", got.State)
+	errUnless(t, got.Submitter == "alice", "Get: submitter = %q, want alice", got.Submitter)
 
 	// Initial migration event: From = zero sentinel, To = submitted, Seq = 1.
 	evs, err := repo.History(context.Background(), testTenantID, "http.foo.v1")
-	require.NoError(t, err)
-	require.Len(t, evs, 1)
-	assert.True(t, evs[0].From.IsZero())
-	assert.Equal(t, registry.StateSubmitted(), evs[0].To)
-	assert.Equal(t, 1, evs[0].Seq)
-	assert.Equal(t, "alice", evs[0].Actor)
+	fatalIfErr(t, err, "History")
+	fatalUnless(t, len(evs) == 1, "History: len = %d, want 1", len(evs))
+	errUnless(t, evs[0].From.IsZero(), "History: initial event From must be the zero sentinel")
+	errUnless(t, evs[0].To == registry.StateSubmitted(), "History: initial event To = %s, want submitted", evs[0].To)
+	errUnless(t, evs[0].Seq == 1, "History: initial event Seq = %d, want 1", evs[0].Seq)
+	errUnless(t, evs[0].Actor == "alice", "History: initial event Actor = %q, want alice", evs[0].Actor)
 }
 
 func conformCreateDuplicateRejected(t *testing.T, factory RegistryFactory) {
@@ -178,7 +207,7 @@ func conformCreateDuplicateRejected(t *testing.T, factory RegistryFactory) {
 		_, e := repo.Create(ctx, testTenantID, registry.SubmitInput{ID: "dup", Kind: "http", Submitter: "bob"})
 		return e
 	})
-	assertCode(t, dupErr, errcode.ErrRegistrationDuplicate)
+	assertCode(t, dupErr, errcode.ErrRegistrationDuplicate, "Create duplicate")
 }
 
 func conformCreateMissingFieldRejected(t *testing.T, factory RegistryFactory) {
@@ -190,7 +219,7 @@ func conformCreateMissingFieldRejected(t *testing.T, factory RegistryFactory) {
 		_, e := repo.Create(ctx, testTenantID, registry.SubmitInput{ID: "", Kind: "http", Submitter: "alice"})
 		return e
 	})
-	assertCode(t, err, errcode.ErrValidationFailed)
+	assertCode(t, err, errcode.ErrValidationFailed, "Create missing field")
 }
 
 func conformTransitionLegal(t *testing.T, factory RegistryFactory) {
@@ -202,15 +231,15 @@ func conformTransitionLegal(t *testing.T, factory RegistryFactory) {
 	got, err := transition(t, txRunner, repo, testTenantID, registry.AdvanceInput{
 		ID: "http.foo.v1", To: registry.StateProbing(), Actor: "system",
 	})
-	require.NoError(t, err)
-	assert.Equal(t, registry.StateProbing(), got.State)
+	fatalIfErr(t, err, "Transition")
+	errUnless(t, got.State == registry.StateProbing(), "Transition: state = %s, want probing", got.State)
 
 	evs, err := repo.History(context.Background(), testTenantID, "http.foo.v1")
-	require.NoError(t, err)
-	require.Len(t, evs, 2)
-	assert.Equal(t, registry.StateSubmitted(), evs[1].From)
-	assert.Equal(t, registry.StateProbing(), evs[1].To)
-	assert.Equal(t, 2, evs[1].Seq)
+	fatalIfErr(t, err, "History")
+	fatalUnless(t, len(evs) == 2, "History: len = %d, want 2", len(evs))
+	errUnless(t, evs[1].From == registry.StateSubmitted(), "History: event[1] From = %s, want submitted", evs[1].From)
+	errUnless(t, evs[1].To == registry.StateProbing(), "History: event[1] To = %s, want probing", evs[1].To)
+	errUnless(t, evs[1].Seq == 2, "History: event[1] Seq = %d, want 2", evs[1].Seq)
 }
 
 func conformTransitionIllegal(t *testing.T, factory RegistryFactory) {
@@ -223,13 +252,13 @@ func conformTransitionIllegal(t *testing.T, factory RegistryFactory) {
 	_, err := transition(t, txRunner, repo, testTenantID, registry.AdvanceInput{
 		ID: "http.foo.v1", To: registry.StateActive(), Actor: "system",
 	})
-	assertCode(t, err, errcode.ErrRegistrationInvalidTransition)
+	assertCode(t, err, errcode.ErrRegistrationInvalidTransition, "Transition illegal")
 
 	// No half-write: still submitted, history unchanged (length 1).
 	got, _, _ := repo.Get(context.Background(), testTenantID, "http.foo.v1")
-	assert.Equal(t, registry.StateSubmitted(), got.State)
+	errUnless(t, got.State == registry.StateSubmitted(), "Transition illegal: state must stay submitted, got %s", got.State)
 	evs, _ := repo.History(context.Background(), testTenantID, "http.foo.v1")
-	assert.Len(t, evs, 1)
+	errUnless(t, len(evs) == 1, "Transition illegal: history must stay length 1, got %d", len(evs))
 }
 
 func conformTransitionUnknownID(t *testing.T, factory RegistryFactory) {
@@ -240,7 +269,7 @@ func conformTransitionUnknownID(t *testing.T, factory RegistryFactory) {
 	_, err := transition(t, txRunner, repo, testTenantID, registry.AdvanceInput{
 		ID: "missing", To: registry.StateProbing(), Actor: "system",
 	})
-	assertCode(t, err, errcode.ErrRegistrationNotFound)
+	assertCode(t, err, errcode.ErrRegistrationNotFound, "Transition unknown id")
 }
 
 func conformTransitionApprover(t *testing.T, factory RegistryFactory) {
@@ -253,13 +282,13 @@ func conformTransitionApprover(t *testing.T, factory RegistryFactory) {
 		registry.StateProbing(), registry.StateConformant(), registry.StatePendingApproval(), registry.StateApproved(),
 	} {
 		_, err := transition(t, txRunner, repo, testTenantID, registry.AdvanceInput{ID: "http.foo.v1", To: to, Actor: "admin"})
-		require.NoError(t, err)
+		fatalIfErr(t, err, "Transition to "+to.String())
 	}
 	got, ok, err := repo.Get(context.Background(), testTenantID, "http.foo.v1")
-	require.NoError(t, err)
-	require.True(t, ok)
-	assert.Equal(t, registry.StateApproved(), got.State)
-	assert.Equal(t, "admin", got.Approver)
+	fatalIfErr(t, err, "Get")
+	fatalUnless(t, ok, "Get: want ok=true")
+	errUnless(t, got.State == registry.StateApproved(), "Approver: state = %s, want approved", got.State)
+	errUnless(t, got.Approver == "admin", "Approver: approver = %q, want admin", got.Approver)
 }
 
 func conformGetUnknown(t *testing.T, factory RegistryFactory) {
@@ -268,9 +297,9 @@ func conformGetUnknown(t *testing.T, factory RegistryFactory) {
 	t.Cleanup(cleanup)
 
 	got, ok, err := repo.Get(context.Background(), testTenantID, "nobody")
-	require.NoError(t, err)
-	assert.False(t, ok, "unknown id must report ok=false")
-	assert.Equal(t, registry.ContractRegistration{}, got, "unknown id must return the zero registration")
+	fatalIfErr(t, err, "Get unknown")
+	errUnless(t, !ok, "Get unknown: want ok=false")
+	errUnless(t, got.ID == "" && got.State.IsZero(), "Get unknown: want the zero registration, got %+v", got)
 }
 
 func conformListPaginated(t *testing.T, factory RegistryFactory) {
@@ -285,18 +314,17 @@ func conformListPaginated(t *testing.T, factory RegistryFactory) {
 
 	// Page 1: Limit=2 → FetchLimit=3; 4 rows → returns a,b,c (the +1 row signals hasMore).
 	page, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 2, Sort: idASC}, ports.ListFilter{})
-	require.NoError(t, err)
-	require.Len(t, page, 3)
-	assert.Equal(t, "a", page[0].ID)
-	assert.Equal(t, "b", page[1].ID)
-	assert.Equal(t, "c", page[2].ID)
+	fatalIfErr(t, err, "List page1")
+	fatalUnless(t, len(page) == 3, "List page1: len = %d, want 3 (N+1)", len(page))
+	errUnless(t, page[0].ID == "a" && page[1].ID == "b" && page[2].ID == "c",
+		"List page1: ids = [%s %s %s], want [a b c]", page[0].ID, page[1].ID, page[2].ID)
 
 	// Page 2: cursor after the last visible id "b" → returns c,d (< FetchLimit → no more).
 	page2, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 2, Sort: idASC, CursorValues: []any{"b"}}, ports.ListFilter{})
-	require.NoError(t, err)
-	require.Len(t, page2, 2)
-	assert.Equal(t, "c", page2[0].ID)
-	assert.Equal(t, "d", page2[1].ID)
+	fatalIfErr(t, err, "List page2")
+	fatalUnless(t, len(page2) == 2, "List page2: len = %d, want 2", len(page2))
+	errUnless(t, page2[0].ID == "c" && page2[1].ID == "d",
+		"List page2: ids = [%s %s], want [c d]", page2[0].ID, page2[1].ID)
 }
 
 func conformListEmpty(t *testing.T, factory RegistryFactory) {
@@ -305,8 +333,8 @@ func conformListEmpty(t *testing.T, factory RegistryFactory) {
 	t.Cleanup(cleanup)
 
 	page, err := repo.List(context.Background(), testTenantID, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{})
-	require.NoError(t, err)
-	assert.Empty(t, page)
+	fatalIfErr(t, err, "List empty")
+	errUnless(t, len(page) == 0, "List empty: want 0 rows, got %d", len(page))
 }
 
 func conformListStateFilter(t *testing.T, factory RegistryFactory) {
@@ -317,25 +345,25 @@ func conformListStateFilter(t *testing.T, factory RegistryFactory) {
 	create(t, txRunner, repo, testTenantID, submitInput("a"))
 	create(t, txRunner, repo, testTenantID, submitInput("b"))
 	_, err := transition(t, txRunner, repo, testTenantID, registry.AdvanceInput{ID: "b", To: registry.StateProbing(), Actor: "system"})
-	require.NoError(t, err)
+	fatalIfErr(t, err, "Transition b→probing")
 	ctx := context.Background()
 
 	// submitted filter → only "a".
 	subPage, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{State: registry.StateSubmitted()})
-	require.NoError(t, err)
-	require.Len(t, subPage, 1)
-	assert.Equal(t, "a", subPage[0].ID)
+	fatalIfErr(t, err, "List submitted")
+	fatalUnless(t, len(subPage) == 1, "List submitted: len = %d, want 1", len(subPage))
+	errUnless(t, subPage[0].ID == "a", "List submitted: id = %q, want a", subPage[0].ID)
 
 	// probing filter → only "b".
 	probePage, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{State: registry.StateProbing()})
-	require.NoError(t, err)
-	require.Len(t, probePage, 1)
-	assert.Equal(t, "b", probePage[0].ID)
+	fatalIfErr(t, err, "List probing")
+	fatalUnless(t, len(probePage) == 1, "List probing: len = %d, want 1", len(probePage))
+	errUnless(t, probePage[0].ID == "b", "List probing: id = %q, want b", probePage[0].ID)
 
 	// a state with no rows → empty.
 	nonePage, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{State: registry.StateApproved()})
-	require.NoError(t, err)
-	assert.Empty(t, nonePage)
+	fatalIfErr(t, err, "List approved")
+	errUnless(t, len(nonePage) == 0, "List approved: want 0 rows, got %d", len(nonePage))
 }
 
 func conformHistoryOrdered(t *testing.T, factory RegistryFactory) {
@@ -348,30 +376,30 @@ func conformHistoryOrdered(t *testing.T, factory RegistryFactory) {
 		registry.StateProbing(), registry.StateConformant(), registry.StatePendingApproval(), registry.StateApproved(),
 	} {
 		_, err := transition(t, txRunner, repo, testTenantID, registry.AdvanceInput{ID: "r1", To: to, Actor: "admin"})
-		require.NoError(t, err)
+		fatalIfErr(t, err, "Transition to "+to.String())
 	}
 
 	evs, err := repo.History(context.Background(), testTenantID, "r1")
-	require.NoError(t, err)
-	require.Len(t, evs, 5) // submit + 4 transitions
+	fatalIfErr(t, err, "History")
+	fatalUnless(t, len(evs) == 5, "History: len = %d, want 5 (submit + 4 transitions)", len(evs))
 	for i, ev := range evs {
-		assert.Equal(t, i+1, ev.Seq, "Seq must be 1-based contiguous ascending")
+		errUnless(t, ev.Seq == i+1, "History: event[%d] Seq = %d, want %d (1-based contiguous)", i, ev.Seq, i+1)
 	}
 }
 
 // conformHistoryUnknownEmpty pins the #2388 / F16 divergence: History on an
-// unknown id returns a no-events result on both stores. Asserted with
-// require.Empty (NOT a nil-specific check): the port godoc states callers MUST
-// NOT distinguish a nil from an empty slice, so mem (nil) and PG (empty slice)
-// are both contract-conformant and the suite must treat them as equivalent.
+// unknown id returns a no-events result on both stores. Asserted with wantEmpty
+// (NOT a nil-specific check): the port godoc states callers MUST NOT distinguish
+// a nil from an empty slice, so mem (nil) and PG (empty slice) are both
+// contract-conformant and the suite must treat them as equivalent.
 func conformHistoryUnknownEmpty(t *testing.T, factory RegistryFactory) {
 	t.Helper()
 	repo, _, cleanup := factory(t)
 	t.Cleanup(cleanup)
 
 	evs, err := repo.History(context.Background(), testTenantID, "nobody")
-	require.NoError(t, err)
-	assert.Empty(t, evs, "History on an unknown id must be a no-events result (nil or empty both conform)")
+	fatalIfErr(t, err, "History unknown")
+	errUnless(t, len(evs) == 0, "History unknown: want a no-events result (nil or empty), got len %d", len(evs))
 }
 
 func conformCrossTenantIsolation(t *testing.T, factory RegistryFactory) {
@@ -384,27 +412,27 @@ func conformCrossTenantIsolation(t *testing.T, factory RegistryFactory) {
 
 	// Tenant B cannot see tenant A's row by Get / List / History.
 	_, ok, err := repo.Get(ctx, testTenantIDOther, "shared.id")
-	require.NoError(t, err)
-	assert.False(t, ok)
+	fatalIfErr(t, err, "Get cross-tenant")
+	errUnless(t, !ok, "Get cross-tenant: tenant B must not see tenant A's row")
 	page, err := repo.List(ctx, testTenantIDOther, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{})
-	require.NoError(t, err)
-	assert.Empty(t, page)
+	fatalIfErr(t, err, "List cross-tenant")
+	errUnless(t, len(page) == 0, "List cross-tenant: tenant B must see 0 rows, got %d", len(page))
 	evs, err := repo.History(ctx, testTenantIDOther, "shared.id")
-	require.NoError(t, err)
-	assert.Empty(t, evs)
+	fatalIfErr(t, err, "History cross-tenant")
+	errUnless(t, len(evs) == 0, "History cross-tenant: tenant B must see 0 events, got %d", len(evs))
 
 	// Per-tenant dedup: the same id is independently creatable under tenant B.
 	create(t, txRunner, repo, testTenantIDOther, registry.SubmitInput{ID: "shared.id", Kind: "http", Submitter: "bob"})
 	gotB, ok, err := repo.Get(ctx, testTenantIDOther, "shared.id")
-	require.NoError(t, err)
-	require.True(t, ok)
-	assert.Equal(t, "bob", gotB.Submitter)
+	fatalIfErr(t, err, "Get tenant B")
+	fatalUnless(t, ok, "Get tenant B: want ok=true")
+	errUnless(t, gotB.Submitter == "bob", "Get tenant B: submitter = %q, want bob", gotB.Submitter)
 
 	// Sanity: tenant A's row is still visible under its own tenant.
 	gotA, ok, err := repo.Get(ctx, testTenantID, "shared.id")
-	require.NoError(t, err)
-	require.True(t, ok)
-	assert.Equal(t, "carol", gotA.Submitter)
+	fatalIfErr(t, err, "Get tenant A")
+	fatalUnless(t, ok, "Get tenant A: want ok=true")
+	errUnless(t, gotA.Submitter == "carol", "Get tenant A: submitter = %q, want carol", gotA.Submitter)
 }
 
 // conformInvalidTenantRejected asserts every method rejects an empty (invalid)
@@ -422,18 +450,18 @@ func conformInvalidTenantRejected(t *testing.T, factory RegistryFactory) {
 		_, e := repo.Create(ctx, zero, submitInput("x"))
 		return e
 	})
-	assertCode(t, cErr, errcode.ErrValidationFailed)
+	assertCode(t, cErr, errcode.ErrValidationFailed, "Create invalid tenant")
 
 	tErr := txRunner.RunInTx(ctx, func(ctx context.Context) error {
 		_, e := repo.Transition(ctx, zero, registry.AdvanceInput{ID: "x", To: registry.StateProbing(), Actor: "s"})
 		return e
 	})
-	assertCode(t, tErr, errcode.ErrValidationFailed)
+	assertCode(t, tErr, errcode.ErrValidationFailed, "Transition invalid tenant")
 
 	_, _, gErr := repo.Get(ctx, zero, "x")
-	assertCode(t, gErr, errcode.ErrValidationFailed)
+	assertCode(t, gErr, errcode.ErrValidationFailed, "Get invalid tenant")
 	_, lErr := repo.List(ctx, zero, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{})
-	assertCode(t, lErr, errcode.ErrValidationFailed)
+	assertCode(t, lErr, errcode.ErrValidationFailed, "List invalid tenant")
 	_, hErr := repo.History(ctx, zero, "x")
-	assertCode(t, hErr, errcode.ErrValidationFailed)
+	assertCode(t, hErr, errcode.ErrValidationFailed, "History invalid tenant")
 }

--- a/corecells/registrycore/internal/ports/conformance/conformance.go
+++ b/corecells/registrycore/internal/ports/conformance/conformance.go
@@ -17,6 +17,10 @@
 // wraps every write in. Reads (Get/List/History) are issued directly: both stores
 // isolate by the explicit typed tenant parameter (PG additionally via a
 // WHERE tenant_id predicate), so no read needs an ambient tx under the test role.
+// (In production the PG read path also runs inside a tenant-scoped tx so FORCE
+// RLS fail-closes an unscoped read; that GUC/RLS behavior is exercised by the PG
+// RLS integration tests, not by this contract suite, which asserts the
+// tenant-parameter isolation common to both stores.)
 // There is no Features struct — unlike UserRepository there is no mem/PG behavior
 // fork to gate; every sub-test exercises one concrete path on both stores.
 //
@@ -72,6 +76,8 @@ func mustParseTenant(s string) tenant.TenantID {
 // persistence.TxRunner (used to provide the ambient tx writes require — a
 // pass-through for stores that need none), and a cleanup func, for one sub-case.
 // The factory is called once per sub-test; cleanup is registered via t.Cleanup.
+// A store that needs no real ambient tx (e.g. the in-memory Registry) can pass
+// outbox.DemoTxRunner{} as the TxRunner.
 type RegistryFactory func(t *testing.T) (repo ports.Registry, txRunner persistence.TxRunner, cleanup func())
 
 // RunRegistryConformance executes the full ports.Registry conformance suite.
@@ -82,6 +88,8 @@ func RunRegistryConformance(t *testing.T, factory RegistryFactory) {
 	t.Run("Create_MissingFieldRejected", func(t *testing.T) { conformCreateMissingFieldRejected(t, factory) })
 	t.Run("Transition_LegalAdvancesAndAppends", func(t *testing.T) { conformTransitionLegal(t, factory) })
 	t.Run("Transition_IllegalRejectedNoMutation", func(t *testing.T) { conformTransitionIllegal(t, factory) })
+	t.Run("Transition_SelfTransitionRejected", func(t *testing.T) { conformTransitionSelf(t, factory) })
+	t.Run("Transition_TerminalRejected", func(t *testing.T) { conformTransitionTerminal(t, factory) })
 	t.Run("Transition_UnknownIDNotFound", func(t *testing.T) { conformTransitionUnknownID(t, factory) })
 	t.Run("Transition_ApprovedRecordsApprover", func(t *testing.T) { conformTransitionApprover(t, factory) })
 	t.Run("Get_UnknownReturnsNotFound", func(t *testing.T) { conformGetUnknown(t, factory) })
@@ -215,11 +223,24 @@ func conformCreateMissingFieldRejected(t *testing.T, factory RegistryFactory) {
 	repo, txRunner, cleanup := factory(t)
 	t.Cleanup(cleanup)
 
-	err := txRunner.RunInTx(context.Background(), func(ctx context.Context) error {
-		_, e := repo.Create(ctx, testTenantID, registry.SubmitInput{ID: "", Kind: "http", Submitter: "alice"})
-		return e
-	})
-	assertCode(t, err, errcode.ErrValidationFailed, "Create missing field")
+	// Every required field (id / kind / submitter) blank must be rejected with
+	// ErrValidationFailed — the contract is per-field, not just the id. Validation
+	// fires before any store write, so the shared "x" id never collides.
+	cases := []struct {
+		name string
+		in   registry.SubmitInput
+	}{
+		{"missing-id", registry.SubmitInput{ID: "", Kind: "http", Submitter: "alice"}},
+		{"missing-kind", registry.SubmitInput{ID: "x", Kind: "", Submitter: "alice"}},
+		{"missing-submitter", registry.SubmitInput{ID: "x", Kind: "http", Submitter: ""}},
+	}
+	for _, tc := range cases {
+		err := txRunner.RunInTx(context.Background(), func(ctx context.Context) error {
+			_, e := repo.Create(ctx, testTenantID, tc.in)
+			return e
+		})
+		assertCode(t, err, errcode.ErrValidationFailed, "Create "+tc.name)
+	}
 }
 
 func conformTransitionLegal(t *testing.T, factory RegistryFactory) {
@@ -254,11 +275,49 @@ func conformTransitionIllegal(t *testing.T, factory RegistryFactory) {
 	})
 	assertCode(t, err, errcode.ErrRegistrationInvalidTransition, "Transition illegal")
 
-	// No half-write: still submitted, history unchanged (length 1).
-	got, _, _ := repo.Get(context.Background(), testTenantID, "http.foo.v1")
+	// No half-write: still submitted, history unchanged (length 1). The reads must
+	// not swallow errors — a failed Get/History would otherwise masquerade as a
+	// state-drift assertion with no diagnostic context.
+	got, ok, gerr := repo.Get(context.Background(), testTenantID, "http.foo.v1")
+	fatalIfErr(t, gerr, "Get after illegal transition")
+	fatalUnless(t, ok, "Get after illegal transition: want ok=true")
 	errUnless(t, got.State == registry.StateSubmitted(), "Transition illegal: state must stay submitted, got %s", got.State)
-	evs, _ := repo.History(context.Background(), testTenantID, "http.foo.v1")
+	evs, herr := repo.History(context.Background(), testTenantID, "http.foo.v1")
+	fatalIfErr(t, herr, "History after illegal transition")
 	errUnless(t, len(evs) == 1, "Transition illegal: history must stay length 1, got %d", len(evs))
+}
+
+// conformTransitionSelf asserts a self-transition (submitted → submitted) is
+// rejected — the frozen legalTransitions table has no self-edges.
+func conformTransitionSelf(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	repo, txRunner, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	create(t, txRunner, repo, testTenantID, submitInput("self"))
+	_, err := transition(t, txRunner, repo, testTenantID, registry.AdvanceInput{
+		ID: "self", To: registry.StateSubmitted(), Actor: "system",
+	})
+	assertCode(t, err, errcode.ErrRegistrationInvalidTransition, "Transition self")
+}
+
+// conformTransitionTerminal drives a registration to the terminal rejected state
+// (submitted → probing → rejected) and asserts any further transition out of it
+// is rejected — terminal states have no outgoing edges.
+func conformTransitionTerminal(t *testing.T, factory RegistryFactory) {
+	t.Helper()
+	repo, txRunner, cleanup := factory(t)
+	t.Cleanup(cleanup)
+
+	create(t, txRunner, repo, testTenantID, submitInput("term"))
+	for _, to := range []registry.RegistrationState{registry.StateProbing(), registry.StateRejected()} {
+		_, err := transition(t, txRunner, repo, testTenantID, registry.AdvanceInput{ID: "term", To: to, Actor: "system"})
+		fatalIfErr(t, err, "Transition to "+to.String())
+	}
+	_, err := transition(t, txRunner, repo, testTenantID, registry.AdvanceInput{
+		ID: "term", To: registry.StateProbing(), Actor: "system",
+	})
+	assertCode(t, err, errcode.ErrRegistrationInvalidTransition, "Transition out of terminal")
 }
 
 func conformTransitionUnknownID(t *testing.T, factory RegistryFactory) {
@@ -364,6 +423,14 @@ func conformListStateFilter(t *testing.T, factory RegistryFactory) {
 	nonePage, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{State: registry.StateApproved()})
 	fatalIfErr(t, err, "List approved")
 	errUnless(t, len(nonePage) == 0, "List approved: want 0 rows, got %d", len(nonePage))
+
+	// Zero-value ListFilter{} means "all states" (the port contract): a mixed-state
+	// store must return every row, not silently treat the zero State as a predicate.
+	allPage, err := repo.List(ctx, testTenantID, query.ListParams{Limit: 10, Sort: idASC}, ports.ListFilter{})
+	fatalIfErr(t, err, "List all-states")
+	fatalUnless(t, len(allPage) == 2, "List all-states: len = %d, want 2 (submitted a + probing b)", len(allPage))
+	errUnless(t, allPage[0].ID == "a" && allPage[1].ID == "b",
+		"List all-states: ids = [%s %s], want [a b]", allPage[0].ID, allPage[1].ID)
 }
 
 func conformHistoryOrdered(t *testing.T, factory RegistryFactory) {
@@ -420,6 +487,14 @@ func conformCrossTenantIsolation(t *testing.T, factory RegistryFactory) {
 	evs, err := repo.History(ctx, testTenantIDOther, "shared.id")
 	fatalIfErr(t, err, "History cross-tenant")
 	errUnless(t, len(evs) == 0, "History cross-tenant: tenant B must see 0 events, got %d", len(evs))
+
+	// Write-path isolation: tenant B cannot advance tenant A's registration. Probed
+	// before tenant B creates its own shared.id below, so not-found is genuinely the
+	// cross-tenant predicate, not a missing row.
+	_, tErr := transition(t, txRunner, repo, testTenantIDOther, registry.AdvanceInput{
+		ID: "shared.id", To: registry.StateProbing(), Actor: "attacker",
+	})
+	assertCode(t, tErr, errcode.ErrRegistrationNotFound, "Transition cross-tenant")
 
 	// Per-tenant dedup: the same id is independently creatable under tenant B.
 	create(t, txRunner, repo, testTenantIDOther, registry.SubmitInput{ID: "shared.id", Kind: "http", Submitter: "bob"})

--- a/docs/guides/integration-testing.md
+++ b/docs/guides/integration-testing.md
@@ -37,6 +37,7 @@ GOCELL_TEST_DOCKER_REQUIRED=1 go -C corecells test -tags=integration,e2e \
   ./accesscore/... \
   ./auditcore/... \
   ./configcore/... \
+  ./registrycore/... \
   -count=1 -timeout 15m -v
 ```
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -194,6 +194,7 @@ sonar.coverage.exclusions=\
   **/runtime/audit/ledger/storetest/**,\
   **/runtime/distlock/locktest/conformance.go,\
   **/corecells/accesscore/internal/ports/conformance/**,\
+  **/corecells/registrycore/internal/ports/conformance/**,\
   **/kernel/persistence/persistencetest/**,\
   **/kernel/projection/projectiontest/**,\
   **/kernel/reconcile/reconciletest/**,\
@@ -237,7 +238,8 @@ sonar.coverage.exclusions=\
 # gated (e.g. mem/repo, adapter, service code is NOT excluded).
 sonar.cpd.exclusions=\
   **/*_test.go,\
-  **/corecells/accesscore/internal/ports/conformance/**
+  **/corecells/accesscore/internal/ports/conformance/**,\
+  **/corecells/registrycore/internal/ports/conformance/**
 
 # --- Rule exclusions for Go conventions ---
 

--- a/tools/archtest/conformance_enrollment.go
+++ b/tools/archtest/conformance_enrollment.go
@@ -47,23 +47,33 @@ import (
 //
 //	*_repo_conformance_enrollment.go detector files) ────────────────────────
 const (
-	rulePolicyRepoConformanceEnrollment01 = "POLICYREPO-CONFORMANCE-ENROLLMENT-01"
-	ruleRoleRepoConformanceEnrollment01   = "ROLEREPO-CONFORMANCE-ENROLLMENT-01"
-	ruleUserRepoConformanceEnrollment01   = "USERREPO-CONFORMANCE-ENROLLMENT-01"
+	rulePolicyRepoConformanceEnrollment01   = "POLICYREPO-CONFORMANCE-ENROLLMENT-01"
+	ruleRoleRepoConformanceEnrollment01     = "ROLEREPO-CONFORMANCE-ENROLLMENT-01"
+	ruleUserRepoConformanceEnrollment01     = "USERREPO-CONFORMANCE-ENROLLMENT-01"
+	ruleRegistryRepoConformanceEnrollment01 = "REGISTRY-CONFORMANCE-ENROLLMENT-01"
 
-	// repoConformancePkg is the shared ports/conformance package: all three
-	// repo conformance suites (RunPolicyRepoConformance / RunRoleRepoConformance /
-	// RunUserRepoConformance) live here.
+	// repoPortsPkg / repoConformancePkg are the accesscore ports + shared
+	// ports/conformance packages: the three accesscore repo conformance suites
+	// (RunPolicyRepoConformance / RunRoleRepoConformance / RunUserRepoConformance)
+	// live in repoConformancePkg. registrycore (#2388) is a SECOND cell with its
+	// own ports + conformance packages, so each repoConformanceSpec carries its
+	// own portsPkg/conformancePkg rather than the check body hardcoding the
+	// accesscore pair.
 	repoPortsPkg       = PlatformCellsModulePath + "/accesscore/internal/ports"
 	repoConformancePkg = PlatformCellsModulePath + "/accesscore/internal/ports/conformance"
 
-	policyRepoIfaceName = "PolicyRepository"
-	roleRepoIfaceName   = "RoleRepository"
-	userRepoIfaceName   = "UserRepository"
+	registryPortsPkg       = PlatformCellsModulePath + "/registrycore/internal/ports"
+	registryConformancePkg = PlatformCellsModulePath + "/registrycore/internal/ports/conformance"
 
-	policyConformanceFunc = "RunPolicyRepoConformance"
-	roleConformanceFunc   = "RunRoleRepoConformance"
-	userConformanceFunc   = "RunUserRepoConformance"
+	policyRepoIfaceName   = "PolicyRepository"
+	roleRepoIfaceName     = "RoleRepository"
+	userRepoIfaceName     = "UserRepository"
+	registryRepoIfaceName = "Registry"
+
+	policyConformanceFunc   = "RunPolicyRepoConformance"
+	roleConformanceFunc     = "RunRoleRepoConformance"
+	userConformanceFunc     = "RunUserRepoConformance"
+	registryConformanceFunc = "RunRegistryConformance"
 )
 
 // enrollPass captures, during the single Tests=true load, the per-package data the
@@ -307,9 +317,13 @@ func flagUnenrolledByImplKey(
 
 // ─── repo family ────────────────────────────────────────────────────────────
 
-// repoConformanceSpec parameterizes the three ports.*Repository enrollment rules.
+// repoConformanceSpec parameterizes the ports.*Repository / ports.Registry
+// enrollment rules. portsPkg / conformancePkg are per-member (accesscore and
+// registrycore are distinct cells with their own ports + conformance packages).
 type repoConformanceSpec struct {
 	ruleID          string
+	portsPkg        string // import path of the interface's ports package
+	conformancePkg  string // import path of the package holding conformanceFunc
 	ifaceName       string
 	conformanceFunc string
 	humanIface      string // e.g. "ports.PolicyRepository" for messages
@@ -320,6 +334,8 @@ type repoConformanceSpec struct {
 func policyRepoConformanceSpec() repoConformanceSpec {
 	return repoConformanceSpec{
 		ruleID:          rulePolicyRepoConformanceEnrollment01,
+		portsPkg:        repoPortsPkg,
+		conformancePkg:  repoConformancePkg,
 		ifaceName:       policyRepoIfaceName,
 		conformanceFunc: policyConformanceFunc,
 		humanIface:      "ports.PolicyRepository",
@@ -331,6 +347,8 @@ func policyRepoConformanceSpec() repoConformanceSpec {
 func roleRepoConformanceSpec() repoConformanceSpec {
 	return repoConformanceSpec{
 		ruleID:          ruleRoleRepoConformanceEnrollment01,
+		portsPkg:        repoPortsPkg,
+		conformancePkg:  repoConformancePkg,
 		ifaceName:       roleRepoIfaceName,
 		conformanceFunc: roleConformanceFunc,
 		humanIface:      "ports.RoleRepository",
@@ -342,11 +360,28 @@ func roleRepoConformanceSpec() repoConformanceSpec {
 func userRepoConformanceSpec() repoConformanceSpec {
 	return repoConformanceSpec{
 		ruleID:          ruleUserRepoConformanceEnrollment01,
+		portsPkg:        repoPortsPkg,
+		conformancePkg:  repoConformancePkg,
 		ifaceName:       userRepoIfaceName,
 		conformanceFunc: userConformanceFunc,
 		humanIface:      "ports.UserRepository",
 		emptyImplHint:   "Expect at least mem.UserRepository and postgres.PGUserRepo.",
 		callSuffix:      "(t, factory, features)",
+	}
+}
+
+// registryRepoConformanceSpec is the registrycore member (#2388): ports.Registry
+// has mem + PG implementations that must both enroll in conformance.RunRegistryConformance.
+func registryRepoConformanceSpec() repoConformanceSpec {
+	return repoConformanceSpec{
+		ruleID:          ruleRegistryRepoConformanceEnrollment01,
+		portsPkg:        registryPortsPkg,
+		conformancePkg:  registryConformancePkg,
+		ifaceName:       registryRepoIfaceName,
+		conformanceFunc: registryConformanceFunc,
+		humanIface:      "ports.Registry",
+		emptyImplHint:   "Expect at least mem.Registry and postgres.Registry.",
+		callSuffix:      "(t, factory)",
 	}
 }
 
@@ -366,15 +401,15 @@ func checkRepoConformanceEnrollment(t *testing.T, spec repoConformanceSpec, cfg 
 
 	iface, implSet, passes := loadConformanceEnrollmentImpls(
 		t, repoConformanceLoadPatterns(root), cfg.BuildTags,
-		repoPortsPkg, spec.ifaceName, true /*exportedOnly*/, false /*collectFromIfacePkg*/)
+		spec.portsPkg, spec.ifaceName, true /*exportedOnly*/, false /*collectFromIfacePkg*/)
 
 	if iface == nil {
-		return []Diagnostic{{Rel: repoPortsPkg, Message: fmt.Sprintf(
+		return []Diagnostic{{Rel: spec.portsPkg, Message: fmt.Sprintf(
 			"%s: failed to resolve %s interface; check import path %s",
-			spec.ruleID, spec.humanIface, repoPortsPkg)}}
+			spec.ruleID, spec.humanIface, spec.portsPkg)}}
 	}
 	if len(implSet) == 0 {
-		return []Diagnostic{{Rel: repoPortsPkg, Message: fmt.Sprintf(
+		return []Diagnostic{{Rel: spec.portsPkg, Message: fmt.Sprintf(
 			"%s: zero %s implementations collected — likely a type-universe regression "+
 				"(iface and impls must share one packages.Load). %s",
 			spec.ruleID, spec.ifaceName, spec.emptyImplHint)}}
@@ -383,7 +418,7 @@ func checkRepoConformanceEnrollment(t *testing.T, spec repoConformanceSpec, cfg 
 	enrolledPkgs := map[string]bool{}
 	for _, pd := range passes {
 		for _, f := range pd.testFiles {
-			if hasConformanceCallTo(f, pd.info, repoConformancePkg, spec.conformanceFunc) {
+			if hasConformanceCallTo(f, pd.info, spec.conformancePkg, spec.conformanceFunc) {
 				enrolledPkgs[canonicalPkgPath(pd.pkgPath)] = true
 			}
 		}

--- a/tools/archtest/conformance_enrollment.go
+++ b/tools/archtest/conformance_enrollment.go
@@ -372,6 +372,8 @@ func userRepoConformanceSpec() repoConformanceSpec {
 
 // registryRepoConformanceSpec is the registrycore member (#2388): ports.Registry
 // has mem + PG implementations that must both enroll in conformance.RunRegistryConformance.
+// Blind-spot catalog (including the intentional B1 reverse-guard omission) is in the
+// TestRegistryRepoConformanceEnrollment godoc.
 func registryRepoConformanceSpec() repoConformanceSpec {
 	return repoConformanceSpec{
 		ruleID:          ruleRegistryRepoConformanceEnrollment01,

--- a/tools/archtest/conformance_enrollment.go
+++ b/tools/archtest/conformance_enrollment.go
@@ -65,6 +65,14 @@ const (
 	registryPortsPkg       = PlatformCellsModulePath + "/registrycore/internal/ports"
 	registryConformancePkg = PlatformCellsModulePath + "/registrycore/internal/ports/conformance"
 
+	// registryMemPkg / registryPGPkg are the two ports.Registry implementation
+	// packages the registry spec pins via expectedImplPkgs (#2388 review F4): the
+	// rule must collect BOTH, else dropping one (e.g. a load-pattern gap losing the
+	// PG package) would leave the guard enforcing only mem enrollment — vacuous-green
+	// for the missing impl. The zero-impl guard alone cannot catch that.
+	registryMemPkg = PlatformCellsModulePath + "/registrycore/internal/mem"
+	registryPGPkg  = PlatformCellsModulePath + "/registrycore/internal/adapters/postgres"
+
 	policyRepoIfaceName   = "PolicyRepository"
 	roleRepoIfaceName     = "RoleRepository"
 	userRepoIfaceName     = "UserRepository"
@@ -329,6 +337,11 @@ type repoConformanceSpec struct {
 	humanIface      string // e.g. "ports.PolicyRepository" for messages
 	emptyImplHint   string // e.g. "Expect at least mem.PolicyRepository."
 	callSuffix      string // factory-arg shape shown in the remediation message
+	// expectedImplPkgs, when non-empty, are impl package paths the rule MUST collect
+	// (anti-vacuity beyond the zero-impl guard): if any is absent from the collected
+	// impl set the check fails loud, so a load-pattern gap that drops one impl (e.g.
+	// the PG package) cannot leave the rule silently enforcing only the survivors.
+	expectedImplPkgs []string
 }
 
 func policyRepoConformanceSpec() repoConformanceSpec {
@@ -376,14 +389,15 @@ func userRepoConformanceSpec() repoConformanceSpec {
 // TestRegistryRepoConformanceEnrollment godoc.
 func registryRepoConformanceSpec() repoConformanceSpec {
 	return repoConformanceSpec{
-		ruleID:          ruleRegistryRepoConformanceEnrollment01,
-		portsPkg:        registryPortsPkg,
-		conformancePkg:  registryConformancePkg,
-		ifaceName:       registryRepoIfaceName,
-		conformanceFunc: registryConformanceFunc,
-		humanIface:      "ports.Registry",
-		emptyImplHint:   "Expect at least mem.Registry and postgres.Registry.",
-		callSuffix:      "(t, factory)",
+		ruleID:           ruleRegistryRepoConformanceEnrollment01,
+		portsPkg:         registryPortsPkg,
+		conformancePkg:   registryConformancePkg,
+		ifaceName:        registryRepoIfaceName,
+		conformanceFunc:  registryConformanceFunc,
+		humanIface:       "ports.Registry",
+		emptyImplHint:    "Expect at least mem.Registry and postgres.Registry.",
+		callSuffix:       "(t, factory)",
+		expectedImplPkgs: []string{registryMemPkg, registryPGPkg},
 	}
 }
 
@@ -392,6 +406,28 @@ func registryRepoConformanceSpec() repoConformanceSpec {
 // does not cross into it — ./corecells/... is required to load the iface + impls.
 func repoConformanceLoadPatterns(root string) []string {
 	return append([]string{"./corecells/..."}, prodscan.Patterns(root)...)
+}
+
+// missingExpectedImplPkgs returns the expectedImplPkgs absent from implSet (keys
+// are "pkgPath.TypeName"). Empty expectedImplPkgs disables the check (returns nil).
+// Used by the expected-impl anti-vacuity guard (#2388 F4).
+func missingExpectedImplPkgs(expectedImplPkgs []string, implSet map[string]bool) []string {
+	if len(expectedImplPkgs) == 0 {
+		return nil
+	}
+	present := map[string]bool{}
+	for implKey := range implSet {
+		if dot := strings.LastIndex(implKey, "."); dot > 0 {
+			present[implKey[:dot]] = true
+		}
+	}
+	var missing []string
+	for _, pkg := range expectedImplPkgs {
+		if !present[pkg] {
+			missing = append(missing, pkg)
+		}
+	}
+	return missing
 }
 
 // checkRepoConformanceEnrollment is the shared body for the three ports.*Repository
@@ -415,6 +451,20 @@ func checkRepoConformanceEnrollment(t *testing.T, spec repoConformanceSpec, cfg 
 			"%s: zero %s implementations collected — likely a type-universe regression "+
 				"(iface and impls must share one packages.Load). %s",
 			spec.ruleID, spec.ifaceName, spec.emptyImplHint)}}
+	}
+	// Anti-vacuity beyond the zero-impl guard (#2388 F4): every pinned impl package
+	// must be among the collected impls, else the rule would silently enforce only
+	// the survivors (e.g. a load-pattern gap dropping the PG package leaves mem the
+	// sole guarded impl — vacuous-green for PG).
+	if missing := missingExpectedImplPkgs(spec.expectedImplPkgs, implSet); len(missing) > 0 {
+		var diags []Diagnostic
+		for _, pkg := range missing {
+			diags = append(diags, Diagnostic{Rel: spec.portsPkg, Message: fmt.Sprintf(
+				"%s: expected impl package %q not among the collected %s implementations — "+
+					"the rule would be vacuous-green for it (type-universe regression or load-pattern gap). %s",
+				spec.ruleID, pkg, spec.ifaceName, spec.emptyImplHint)})
+		}
+		return diags
 	}
 
 	enrolledPkgs := map[string]bool{}

--- a/tools/archtest/conformance_enrollment_test.go
+++ b/tools/archtest/conformance_enrollment_test.go
@@ -151,12 +151,13 @@ func TestConformanceEnrollmentFoldEquivalence01(t *testing.T) {
 		t.Parallel()
 		for _, spec := range []repoConformanceSpec{
 			policyRepoConformanceSpec(), roleRepoConformanceSpec(), userRepoConformanceSpec(),
+			registryRepoConformanceSpec(),
 		} {
 			patterns := repoConformanceLoadPatterns(root)
 			_, newSet, _ := loadConformanceEnrollmentImpls(
-				t, patterns, FlatNonDefaultTags(), repoPortsPkg, spec.ifaceName,
+				t, patterns, FlatNonDefaultTags(), spec.portsPkg, spec.ifaceName,
 				true /*exportedOnly*/, false /*collectFromIfacePkg*/)
-			old := oldFoldImplSet(t, patterns, repoPortsPkg, spec.ifaceName, true, false)
+			old := oldFoldImplSet(t, patterns, spec.portsPkg, spec.ifaceName, true, false)
 			assertImplSetEqual(t, spec.ruleID, old, newSet)
 		}
 	})

--- a/tools/archtest/policy_repo_conformance_enrollment_test.go
+++ b/tools/archtest/policy_repo_conformance_enrollment_test.go
@@ -40,14 +40,10 @@ package archtest
 
 import (
 	"go/ast"
-	"go/types"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/ghbvf/gocell/tools/internal/prodscan"
 )
 
 // INVARIANT: POLICYREPO-CONFORMANCE-ENROLLMENT-01
@@ -65,98 +61,13 @@ func TestPolicyRepoConformanceEnrollment(t *testing.T) {
 		checkRepoConformanceEnrollment(t, policyRepoConformanceSpec(), ConfigForExternalCell{BuildTags: FlatNonDefaultTags()}))
 }
 
-// TestPolicyRepoConformanceEnrollment_REDFixture verifies that the enrollment
-// detection logic flags an implementation when the owning package is not in the
-// enrolledPkgs set. This exercises the core of the enrollment check without
-// requiring a standalone fixture module (ports.PolicyRepository lives in an
-// internal package, making cross-module fixture modules impossible).
-//
-// Strategy: collect the real implSet and enrolledPkgs from the production tree,
-// then simulate a "missing enrollment" by removing one impl's pkg from enrolled.
-// Assert that exactly that impl is reported as a violation.
+// TestPolicyRepoConformanceEnrollment_REDFixture proves the enrollment detector is
+// non-vacuous for PolicyRepository: removing one impl's package from the enrolled
+// set must flag exactly that package. The shared body lives in
+// runRepoEnrollmentREDFixture (repo_conformance_enrollment_helpers_test.go).
 func TestPolicyRepoConformanceEnrollment_REDFixture(t *testing.T) {
 	t.Parallel()
-	if testing.Short() {
-		t.Skip("skipping packages.Load-based fixture test in -short mode")
-	}
-
-	root := findModuleRoot(t)
-
-	// ─── Load production iface + impls ─────────────────────────────────────
-	prodPatterns := prodscan.Patterns(root)
-	// corecells is a separate go module, so prodscan.Patterns's root-relative
-	// ./... does not cross the module boundary into it — the explicit
-	// ./corecells/... is required to load the iface + impls in one packages.Load.
-	ifacePatterns := append([]string{"./corecells/..."}, prodPatterns...)
-
-	var policyRepoIface *types.Interface
-	var implPkgs []*types.Package
-
-	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, ifacePatterns),
-		func(p *Pass) []Diagnostic {
-			if p.Pkg == nil {
-				return nil
-			}
-			if p.Pkg.Path() == repoPortsPkg {
-				if obj := p.Pkg.Scope().Lookup(policyRepoIfaceName); obj != nil {
-					if named, ok := obj.Type().(*types.Named); ok {
-						if iface, ok := named.Underlying().(*types.Interface); ok {
-							policyRepoIface = iface.Complete()
-						}
-					}
-				}
-				return nil
-			}
-			implPkgs = append(implPkgs, p.Pkg)
-			return nil
-		})
-
-	require.NotNil(t, policyRepoIface, "REDFixture: could not resolve PolicyRepository interface")
-
-	implSet := make(map[string]bool)
-	implPkgSet := make(map[string]bool)
-	for _, pkg := range implPkgs {
-		if pkg != nil {
-			collectImplsFromScope(pkg, policyRepoIface, true, implSet, implPkgSet)
-		}
-	}
-	require.NotEmpty(t, implSet, "REDFixture: implSet must not be empty (need at least one impl)")
-
-	// Pick the first impl key and derive its pkg path.
-	var targetImplKey string
-	for k := range implSet {
-		targetImplKey = k
-		break
-	}
-	dotIdx := strings.LastIndex(targetImplKey, ".")
-	require.Greater(t, dotIdx, 0, "REDFixture: malformed impl key %q", targetImplKey)
-	targetPkg := targetImplKey[:dotIdx]
-
-	// Simulate missing enrollment: enrolledPkgs contains all impls EXCEPT targetPkg.
-	enrolledPkgs := make(map[string]bool)
-	for pkg := range implPkgSet {
-		if pkg != targetPkg {
-			enrolledPkgs[pkg] = true
-		}
-	}
-
-	// Run the real flagging logic with the simulated enrolled set.
-	diags := flagUnenrolledByPkg(implSet, enrolledPkgs,
-		func(implKey, _ string) string { return implKey + " not enrolled" })
-
-	assert.GreaterOrEqual(t, len(diags), 1,
-		"REDFixture: removing pkg %q from enrolledPkgs must produce at least 1 violation, got 0", targetPkg)
-
-	// Extra: confirm at least one diagnostic targets the removed pkg.
-	var foundTarget bool
-	for _, d := range diags {
-		if strings.HasPrefix(d.Rel, targetPkg) {
-			foundTarget = true
-			break
-		}
-	}
-	assert.True(t, foundTarget,
-		"REDFixture: expected at least one diagnostic with Rel prefix %q, got %v", targetPkg, diags)
+	runRepoEnrollmentREDFixture(t, repoPortsPkg, policyRepoIfaceName)
 }
 
 // TestPolicyRepoConformanceEnrollment_ReverseBlindSpot_NoReflectImpl (blind spot B1)

--- a/tools/archtest/registry_repo_conformance_enrollment_test.go
+++ b/tools/archtest/registry_repo_conformance_enrollment_test.go
@@ -1,0 +1,79 @@
+//go:build archtest
+
+// INVARIANT: REGISTRY-CONFORMANCE-ENROLLMENT-01
+//
+// AI-robust: Medium
+//
+//   - 实现扫描: types.Implements(*types.Interface) — type-aware，identifies every
+//     concrete named type that satisfies ports.Registry (or *T).
+//   - conformance 调用扫描: ResolvePackageRef + _test.go path filter — type-aware
+//     callee resolution via *types.Info. Identifies every package with a
+//     conformance.RunRegistryConformance call site.
+//   - 综合: Medium 天花板 — Go cannot require a test to exist at compile time;
+//     the enforcement is archtest-bound (CI fails), not compile-time. This is the
+//     same documented ceiling as the accesscore repo-family siblings; Hard is
+//     genuinely unreachable for "a test must exist and call the suite".
+//
+// Enforces (#2388): every concrete type in the production source tree that
+// implements registrycore ports.Registry (mem.Registry + postgres.Registry) must
+// have at least one conformance.RunRegistryConformance call in a _test.go file
+// belonging to its package. A store that never enrolls is never held to the
+// shared contract suite, which is exactly how a mem/PG semantic divergence
+// (e.g. History nil vs empty — PR #2383 finding F16) slips through independent
+// per-impl tests. This is the registrycore sibling of
+// USERREPO-CONFORMANCE-ENROLLMENT-01, sharing checkRepoConformanceEnrollment +
+// the runRepoEnrollmentREDFixture anti-vacuity proof.
+//
+// # Blind-spot catalog (forms not reachable by *types.Info)
+//
+//   - B1 (reverse reflect-bait scan): OMITTED for this rule, by design. The
+//     accesscore siblings scan production code for a string literal equal to the
+//     interface name ("UserRepository" / "PolicyRepository" / "RoleRepository")
+//     as a cheap reverse guard against a reflect.MethodByName-based implicit impl.
+//     The registrycore interface name is the bare word "Registry", which appears
+//     pervasively as a string literal in production code (type names, metric
+//     labels, log messages, the "registrycore" cell id, the kernel registry
+//     package, …), so the same scan would be massively vacuous-red — it cannot
+//     distinguish reflect bait from ordinary usage. The core types.Implements
+//     enrollment (the Medium guarantee) is unaffected; this only forgoes the
+//     defense-in-depth reverse sentinel, which no production code triggers anyway.
+//
+//   - B2. generated mock implementations (mockery / gomock in _test.go) are
+//     excluded: the single Tests=true load collects impls through a non-_test.go
+//     declaration filter (productionImplCandidates / isTestDeclaredObj), so
+//     _test.go-declared types are dropped. A generated mock in a production
+//     non-test file would be flagged — intentionally.
+//
+//   - B3. embedded interface forwarding (struct embedding ports.Registry):
+//     structurally satisfies the interface but provides no real storage; such
+//     types appear only in test helpers (in _test.go, excluded from the impl scan).
+//     A production struct embedding the interface is treated as an impl and must enroll.
+//
+// ref: tools/archtest/user_repo_conformance_enrollment_test.go (sibling pattern)
+package archtest
+
+import "testing"
+
+// INVARIANT: REGISTRY-CONFORMANCE-ENROLLMENT-01
+
+// TestRegistryRepoConformanceEnrollment enforces REGISTRY-CONFORMANCE-ENROLLMENT-01:
+// every concrete type implementing registrycore ports.Registry in the production
+// tree must have a conformance.RunRegistryConformance call in a _test.go file of
+// its package.
+func TestRegistryRepoConformanceEnrollment(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based archtest in -short mode")
+	}
+	Report(t, ruleRegistryRepoConformanceEnrollment01,
+		checkRepoConformanceEnrollment(t, registryRepoConformanceSpec(), ConfigForExternalCell{BuildTags: FlatNonDefaultTags()}))
+}
+
+// TestRegistryRepoConformanceEnrollment_REDFixture proves the enrollment detector
+// is non-vacuous for ports.Registry: removing one impl's package from the enrolled
+// set must flag exactly that package. The shared body lives in
+// runRepoEnrollmentREDFixture (repo_conformance_enrollment_helpers_test.go).
+func TestRegistryRepoConformanceEnrollment_REDFixture(t *testing.T) {
+	t.Parallel()
+	runRepoEnrollmentREDFixture(t, registryPortsPkg, registryRepoIfaceName)
+}

--- a/tools/archtest/registry_repo_conformance_enrollment_test.go
+++ b/tools/archtest/registry_repo_conformance_enrollment_test.go
@@ -52,7 +52,12 @@
 // ref: tools/archtest/user_repo_conformance_enrollment_test.go (sibling pattern)
 package archtest
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 // INVARIANT: REGISTRY-CONFORMANCE-ENROLLMENT-01
 
@@ -76,4 +81,25 @@ func TestRegistryRepoConformanceEnrollment(t *testing.T) {
 func TestRegistryRepoConformanceEnrollment_REDFixture(t *testing.T) {
 	t.Parallel()
 	runRepoEnrollmentREDFixture(t, registryPortsPkg, registryRepoIfaceName)
+}
+
+// TestRegistryRepoConformanceEnrollment_ExpectedImplREDFixture proves the
+// expectedImplPkgs anti-vacuity guard (#2388 F4) is non-vacuous: a collected impl
+// set missing a pinned package (PG dropped) must be flagged, while the full set is
+// accepted. This guards the "load-pattern gap leaves only mem enforced" risk the
+// zero-impl guard alone cannot catch — a pure-logic synthetic case (no packages.Load).
+func TestRegistryRepoConformanceEnrollment_ExpectedImplREDFixture(t *testing.T) {
+	t.Parallel()
+	spec := registryRepoConformanceSpec()
+	require.NotEmpty(t, spec.expectedImplPkgs, "registry spec must pin expected impl packages (anti-vacuity)")
+
+	// RED: PG impl package dropped from the collected set → flagged.
+	memOnly := map[string]bool{registryMemPkg + ".Registry": true}
+	assert.Contains(t, missingExpectedImplPkgs(spec.expectedImplPkgs, memOnly), registryPGPkg,
+		"dropping the PG impl package must be flagged as a vacuous-green risk")
+
+	// GREEN: both pinned packages present → nothing missing.
+	full := map[string]bool{registryMemPkg + ".Registry": true, registryPGPkg + ".Registry": true}
+	assert.Empty(t, missingExpectedImplPkgs(spec.expectedImplPkgs, full),
+		"the full impl set must satisfy every pinned expected package")
 }

--- a/tools/archtest/repo_conformance_enrollment_helpers_test.go
+++ b/tools/archtest/repo_conformance_enrollment_helpers_test.go
@@ -1,0 +1,108 @@
+//go:build archtest
+
+// repo_conformance_enrollment_helpers_test.go — shared anti-vacuity RED fixture
+// for the repo-family conformance-enrollment rules (POLICYREPO / ROLEREPO /
+// USERREPO / REGISTRY). Each rule's *_REDFixture test is a one-line call into
+// runRepoEnrollmentREDFixture, so the ~80-line "load iface + simulate missing
+// enrollment + assert flagged" body lives in ONE place and cannot drift across
+// the four members (#2388 consolidation; previously each rule file duplicated it).
+package archtest
+
+import (
+	"go/types"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/tools/internal/prodscan"
+)
+
+// runRepoEnrollmentREDFixture verifies the enrollment detection logic flags an
+// implementation when the owning package is not in the enrolledPkgs set. It
+// exercises the core of checkRepoConformanceEnrollment without a standalone
+// fixture module (the ports interfaces live in internal packages, making
+// cross-module fixture modules impossible).
+//
+// Strategy: load the real iface (from portsPkg) + its production impls from the
+// tree, then simulate a "missing enrollment" by removing one impl's package from
+// the enrolled set. Assert flagUnenrolledByPkg reports exactly that package.
+// Parameterized by (portsPkg, ifaceName) so every repo-family member proves its
+// own detector is non-vacuous against its real impl set.
+func runRepoEnrollmentREDFixture(t *testing.T, portsPkg, ifaceName string) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping packages.Load-based fixture test in -short mode")
+	}
+
+	root := findModuleRoot(t)
+
+	// corecells is a separate go module, so prodscan.Patterns's root-relative
+	// ./... does not cross the module boundary into it — the explicit
+	// ./corecells/... is required to load the iface + impls in one packages.Load.
+	ifacePatterns := append([]string{"./corecells/..."}, prodscan.Patterns(root)...)
+
+	var iface *types.Interface
+	var implPkgs []*types.Package
+
+	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, ifacePatterns),
+		func(p *Pass) []Diagnostic {
+			if p.Pkg == nil {
+				return nil
+			}
+			if p.Pkg.Path() == portsPkg {
+				iface = lookupNamedIface(p.Pkg, ifaceName)
+				return nil
+			}
+			implPkgs = append(implPkgs, p.Pkg)
+			return nil
+		})
+
+	require.NotNil(t, iface, "REDFixture: could not resolve %s interface in %s", ifaceName, portsPkg)
+
+	implSet := make(map[string]bool)
+	implPkgSet := make(map[string]bool)
+	for _, pkg := range implPkgs {
+		if pkg != nil {
+			collectImplsFromScope(pkg, iface, true, implSet, implPkgSet)
+		}
+	}
+	require.NotEmpty(t, implSet, "REDFixture: implSet must not be empty (need at least one impl)")
+
+	// Pick the first impl key and derive its pkg path.
+	var targetImplKey string
+	for k := range implSet {
+		targetImplKey = k
+		break
+	}
+	dotIdx := strings.LastIndex(targetImplKey, ".")
+	require.Greater(t, dotIdx, 0, "REDFixture: malformed impl key %q", targetImplKey)
+	targetPkg := targetImplKey[:dotIdx]
+
+	// Simulate missing enrollment: enrolledPkgs contains all impls EXCEPT targetPkg.
+	enrolledPkgs := make(map[string]bool)
+	for pkg := range implPkgSet {
+		if pkg != targetPkg {
+			enrolledPkgs[pkg] = true
+		}
+	}
+
+	// Run the real flagging logic with the simulated enrolled set.
+	diags := flagUnenrolledByPkg(implSet, enrolledPkgs,
+		func(implKey, _ string) string { return implKey + " not enrolled" })
+
+	assert.GreaterOrEqual(t, len(diags), 1,
+		"REDFixture: removing pkg %q from enrolledPkgs must produce at least 1 violation, got 0", targetPkg)
+
+	// Extra: confirm at least one diagnostic targets the removed pkg.
+	var foundTarget bool
+	for _, d := range diags {
+		if strings.HasPrefix(d.Rel, targetPkg) {
+			foundTarget = true
+			break
+		}
+	}
+	assert.True(t, foundTarget,
+		"REDFixture: expected at least one diagnostic with Rel prefix %q, got %v", targetPkg, diags)
+}

--- a/tools/archtest/role_repo_conformance_enrollment_test.go
+++ b/tools/archtest/role_repo_conformance_enrollment_test.go
@@ -51,14 +51,10 @@ package archtest
 
 import (
 	"go/ast"
-	"go/types"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/ghbvf/gocell/tools/internal/prodscan"
 )
 
 // INVARIANT: ROLEREPO-CONFORMANCE-ENROLLMENT-01
@@ -76,98 +72,13 @@ func TestRoleRepoConformanceEnrollment(t *testing.T) {
 		checkRepoConformanceEnrollment(t, roleRepoConformanceSpec(), ConfigForExternalCell{BuildTags: FlatNonDefaultTags()}))
 }
 
-// TestRoleRepoConformanceEnrollment_REDFixture verifies that the enrollment
-// detection logic flags an implementation when the owning package is not in the
-// enrolledPkgs set. This exercises the core of the enrollment check without
-// requiring a standalone fixture module (ports.RoleRepository lives in an
-// internal package, making cross-module fixture modules impossible).
-//
-// Strategy: collect the real implSet and enrolledPkgs from the production tree,
-// then simulate a "missing enrollment" by removing one impl's pkg from enrolled.
-// Assert that exactly that impl is reported as a violation.
+// TestRoleRepoConformanceEnrollment_REDFixture proves the enrollment detector is
+// non-vacuous for RoleRepository: removing one impl's package from the enrolled
+// set must flag exactly that package. The shared body lives in
+// runRepoEnrollmentREDFixture (repo_conformance_enrollment_helpers_test.go).
 func TestRoleRepoConformanceEnrollment_REDFixture(t *testing.T) {
 	t.Parallel()
-	if testing.Short() {
-		t.Skip("skipping packages.Load-based fixture test in -short mode")
-	}
-
-	root := findModuleRoot(t)
-
-	// ─── Load production iface + impls ─────────────────────────────────────
-	prodPatterns := prodscan.Patterns(root)
-	// corecells is a separate go module, so prodscan.Patterns's root-relative
-	// ./... does not cross the module boundary into it — the explicit
-	// ./corecells/... is required to load the iface + impls in one packages.Load.
-	ifacePatterns := append([]string{"./corecells/..."}, prodPatterns...)
-
-	var roleRepoIface *types.Interface
-	var implPkgs []*types.Package
-
-	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, ifacePatterns),
-		func(p *Pass) []Diagnostic {
-			if p.Pkg == nil {
-				return nil
-			}
-			if p.Pkg.Path() == repoPortsPkg {
-				if obj := p.Pkg.Scope().Lookup(roleRepoIfaceName); obj != nil {
-					if named, ok := obj.Type().(*types.Named); ok {
-						if iface, ok := named.Underlying().(*types.Interface); ok {
-							roleRepoIface = iface.Complete()
-						}
-					}
-				}
-				return nil
-			}
-			implPkgs = append(implPkgs, p.Pkg)
-			return nil
-		})
-
-	require.NotNil(t, roleRepoIface, "REDFixture: could not resolve RoleRepository interface")
-
-	implSet := make(map[string]bool)
-	implPkgSet := make(map[string]bool)
-	for _, pkg := range implPkgs {
-		if pkg != nil {
-			collectImplsFromScope(pkg, roleRepoIface, true, implSet, implPkgSet)
-		}
-	}
-	require.NotEmpty(t, implSet, "REDFixture: implSet must not be empty (need at least one impl)")
-
-	// Pick the first impl key and derive its pkg path.
-	var targetImplKey string
-	for k := range implSet {
-		targetImplKey = k
-		break
-	}
-	dotIdx := strings.LastIndex(targetImplKey, ".")
-	require.Greater(t, dotIdx, 0, "REDFixture: malformed impl key %q", targetImplKey)
-	targetPkg := targetImplKey[:dotIdx]
-
-	// Simulate missing enrollment: enrolledPkgs contains all impls EXCEPT targetPkg.
-	enrolledPkgs := make(map[string]bool)
-	for pkg := range implPkgSet {
-		if pkg != targetPkg {
-			enrolledPkgs[pkg] = true
-		}
-	}
-
-	// Run the real flagging logic with the simulated enrolled set.
-	diags := flagUnenrolledByPkg(implSet, enrolledPkgs,
-		func(implKey, _ string) string { return implKey + " not enrolled" })
-
-	assert.GreaterOrEqual(t, len(diags), 1,
-		"REDFixture: removing pkg %q from enrolledPkgs must produce at least 1 violation, got 0", targetPkg)
-
-	// Extra: confirm at least one diagnostic targets the removed pkg.
-	var foundTarget bool
-	for _, d := range diags {
-		if strings.HasPrefix(d.Rel, targetPkg) {
-			foundTarget = true
-			break
-		}
-	}
-	assert.True(t, foundTarget,
-		"REDFixture: expected at least one diagnostic with Rel prefix %q, got %v", targetPkg, diags)
+	runRepoEnrollmentREDFixture(t, repoPortsPkg, roleRepoIfaceName)
 }
 
 // TestRoleRepoConformanceEnrollment_ReverseBlindSpot_NoReflectImpl (blind spot B1)

--- a/tools/archtest/user_repo_conformance_enrollment_test.go
+++ b/tools/archtest/user_repo_conformance_enrollment_test.go
@@ -40,14 +40,10 @@ package archtest
 
 import (
 	"go/ast"
-	"go/types"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/ghbvf/gocell/tools/internal/prodscan"
 )
 
 // INVARIANT: USERREPO-CONFORMANCE-ENROLLMENT-01
@@ -65,98 +61,13 @@ func TestUserRepoConformanceEnrollment(t *testing.T) {
 		checkRepoConformanceEnrollment(t, userRepoConformanceSpec(), ConfigForExternalCell{BuildTags: FlatNonDefaultTags()}))
 }
 
-// TestUserRepoConformanceEnrollment_REDFixture verifies that the enrollment
-// detection logic flags an implementation when the owning package is not in the
-// enrolledPkgs set. This exercises the core of the enrollment check without
-// requiring a standalone fixture module (ports.UserRepository lives in an
-// internal package, making cross-module fixture modules impossible).
-//
-// Strategy: collect the real implSet and enrolledPkgs from the production tree,
-// then simulate a "missing enrollment" by removing one impl's pkg from enrolled.
-// Assert that exactly that impl is reported as a violation.
+// TestUserRepoConformanceEnrollment_REDFixture proves the enrollment detector is
+// non-vacuous for UserRepository: removing one impl's package from the enrolled
+// set must flag exactly that package. The shared body lives in
+// runRepoEnrollmentREDFixture (repo_conformance_enrollment_helpers_test.go).
 func TestUserRepoConformanceEnrollment_REDFixture(t *testing.T) {
 	t.Parallel()
-	if testing.Short() {
-		t.Skip("skipping packages.Load-based fixture test in -short mode")
-	}
-
-	root := findModuleRoot(t)
-
-	// ─── Load production iface + impls ─────────────────────────────────────
-	prodPatterns := prodscan.Patterns(root)
-	// corecells is a separate go module, so prodscan.Patterns's root-relative
-	// ./... does not cross the module boundary into it — the explicit
-	// ./corecells/... is required to load the iface + impls in one packages.Load.
-	ifacePatterns := append([]string{"./corecells/..."}, prodPatterns...)
-
-	var userRepoIface *types.Interface
-	var implPkgs []*types.Package
-
-	_ = Run(t, Typed(TypedOpts{Tests: false, Tags: FlatNonDefaultTags()}, ifacePatterns),
-		func(p *Pass) []Diagnostic {
-			if p.Pkg == nil {
-				return nil
-			}
-			if p.Pkg.Path() == repoPortsPkg {
-				if obj := p.Pkg.Scope().Lookup(userRepoIfaceName); obj != nil {
-					if named, ok := obj.Type().(*types.Named); ok {
-						if iface, ok := named.Underlying().(*types.Interface); ok {
-							userRepoIface = iface.Complete()
-						}
-					}
-				}
-				return nil
-			}
-			implPkgs = append(implPkgs, p.Pkg)
-			return nil
-		})
-
-	require.NotNil(t, userRepoIface, "REDFixture: could not resolve UserRepository interface")
-
-	implSet := make(map[string]bool)
-	implPkgSet := make(map[string]bool)
-	for _, pkg := range implPkgs {
-		if pkg != nil {
-			collectImplsFromScope(pkg, userRepoIface, true, implSet, implPkgSet)
-		}
-	}
-	require.NotEmpty(t, implSet, "REDFixture: implSet must not be empty (need at least one impl)")
-
-	// Pick the first impl key and derive its pkg path.
-	var targetImplKey string
-	for k := range implSet {
-		targetImplKey = k
-		break
-	}
-	dotIdx := strings.LastIndex(targetImplKey, ".")
-	require.Greater(t, dotIdx, 0, "REDFixture: malformed impl key %q", targetImplKey)
-	targetPkg := targetImplKey[:dotIdx]
-
-	// Simulate missing enrollment: enrolledPkgs contains all impls EXCEPT targetPkg.
-	enrolledPkgs := make(map[string]bool)
-	for pkg := range implPkgSet {
-		if pkg != targetPkg {
-			enrolledPkgs[pkg] = true
-		}
-	}
-
-	// Run the real flagging logic with the simulated enrolled set.
-	diags := flagUnenrolledByPkg(implSet, enrolledPkgs,
-		func(implKey, _ string) string { return implKey + " not enrolled" })
-
-	assert.GreaterOrEqual(t, len(diags), 1,
-		"REDFixture: removing pkg %q from enrolledPkgs must produce at least 1 violation, got 0", targetPkg)
-
-	// Extra: confirm at least one diagnostic targets the removed pkg.
-	var foundTarget bool
-	for _, d := range diags {
-		if strings.HasPrefix(d.Rel, targetPkg) {
-			foundTarget = true
-			break
-		}
-	}
-	assert.True(t, foundTarget,
-		"REDFixture: expected at least one diagnostic with Rel prefix %q, got %v", targetPkg, diags)
+	runRepoEnrollmentREDFixture(t, repoPortsPkg, userRepoIfaceName)
 }
 
 // TestUserRepoConformanceEnrollment_ReverseBlindSpot_NoReflectImpl (blind spot B1)


### PR DESCRIPTION
## Summary

为 registrycore `ports.Registry` 的 mem + PG 双实现建立**共享 table-driven contract conformance suite**（`RunRegistryConformance`），并加 **machine-enforced enrollment archtest**（`REGISTRY-CONFORMANCE-ENROLLMENT-01`），强制两实现接口语义等价。

## Why / 背景

PR #2383 finding F16（测试维 reviewer）：`ports.Registry` 由 mem + PG 双实现，但各自独立测试、**无**共享 suite 在两实现上跑同一组断言。若 PG 在某边界（如 `History` 空 slice vs nil）与 mem 行为不同，独立测试不察觉。

- 提取 `conformance.RunRegistryConformance(t, factory)`，mem 与 PG（集成）各以工厂调用，覆盖 Create/Transition/Get/List/History 契约 + 错误码 + 分页 + state filter + 跨租户隔离 + 非法 tenant。
- `History` 未知 id 用 `len()==0` 断言（**契约级**，port godoc 明确「callers MUST NOT distinguish nil from empty」）⇒ **无实现行为变更**，纯增量测试。
- enrollment archtest 把「每个 `ports.Registry` 实现都必须接入 suite」变成 CI 红线（漏接即失败）——复用 accesscore 已有的 `repoConformanceSpec` 家族（`POLICYREPO`/`ROLEREPO`/`USERREPO-CONFORMANCE-ENROLLMENT-01` 的第 4 个 sibling）。

**开源对标**：in-repo 模板 = accesscore `ports/conformance`；上游范式 = watermill `pubsub/tests/test_pubsub.go`（factory + 共享 suite）。

**顺带收口**：policy/role/user 三个 sibling 各自复制的 ~80 行 RED-fixture 同源化为单一 `runRepoEnrollmentREDFixture`（杜绝 4 份漂移）。

**AI-robust 评级**：`REGISTRY-CONFORMANCE-ENROLLMENT-01` = **Medium**（与 6 个 sibling 同档）。「测试必须存在并调用 suite」无法在 Go 编译期强制（语言天花板，sibling godoc 已记录），Hard 不可达；非真空由共享 RED-fixture + fold-equivalence 守。registry 省略 B1 reverse-guard（iface 名 `"Registry"` 字面量太泛会误报，godoc 记录该 blind-spot）。

**放置分歧**：suite 落在 `internal/ports/conformance/`（**非** issue 字面建议的 `internal/registrytest/`）——与已 enrolled 的 accesscore sibling 一致，且 enrollment archtest 扫描 `…/ports/conformance` 包路径。

## Refs

Closes #2388
ref: corecells/accesscore/internal/ports/conformance/conformance.go
ref: ThreeDotsLabs/watermill pubsub/tests/test_pubsub.go

## Risk / 兼容性

无。纯增量测试代码 + archtest 规则泛化，**无实现行为变更**、无 wire/契约/migration 影响。`repoConformanceSpec` 泛化为加 `portsPkg`/`conformancePkg` 字段（替换硬编码常量，3 个 accesscore spec 仍引用旧常量，无死代码、无平行路径）。

**范围切割（OUT_OF_SCOPE → backlog）**：configcore 的 `ConfigRepository`/`FlagRepository` 同样无共享 suite，但双接口形状差异大、需各建独立 suite，超出本 cx-1 scope，另立 backlog issue 跟踪。

## Test plan

- [x] `go build ./corecells/...` 本地通过
- [x] `go test ./corecells/registrycore/...` 通过（mem conformance 15/15）
- [x] PG conformance（`-tags=integration`, Docker）15/15 通过 → mem/PG 语义等价证毕
- [x] archtest：Wave 1 `REGISTRY-CONFORMANCE-ENROLLMENT-01` RED（mem/PG 未接入）→ Wave 2 GREEN；3 sibling + REDFixture + fold-equivalence + single-load 全 GREEN
- [x] `golangci-lint run`（v2.11.4）0 issues（tools archtest + corecells default/integration）；gofumpt v0.9.2 canonical

🤖 Generated with [Claude Code](https://claude.com/claude-code)
