### PR TITLE
fix(outbox): align retry docs and postgres query constants

### DIFF
--- a/adapters/postgres/outbox_store.go
+++ b/adapters/postgres/outbox_store.go
@@ -183,6 +183,10 @@ const cleanupDeadQuery = `DELETE FROM outbox_entries WHERE id IN (
 // status='pending' is a closed-set enum value; bound via $1 parameter (no string interpolation).
 const countPendingQuery = `SELECT count(*) FROM outbox_entries WHERE status = $1 AND (next_retry_at IS NULL OR next_retry_at <= now())`
 
+const oldestPublishedEligibleQuery = `SELECT MIN(published_at) FROM outbox_entries WHERE status = $1`
+
+const oldestDeadEligibleQuery = `SELECT MIN(dead_at) FROM outbox_entries WHERE status = $1`
+
 // ---------------------------------------------------------------------------
 // Store method implementations
 // ---------------------------------------------------------------------------
@@ -531,20 +535,18 @@ func (s *PGOutboxStore) CountPending(ctx context.Context) (int64, error) {
 // status MUST be kout.StatePublished or kout.StateDead. Other values return an
 // error immediately.
 func (s *PGOutboxStore) OldestEligibleAt(ctx context.Context, status kout.State) (time.Time, bool, error) {
-	var col string
+	var query string
 	switch status {
 	case kout.StatePublished:
-		col = "published_at"
+		query = oldestPublishedEligibleQuery
 	case kout.StateDead:
-		col = "dead_at"
+		query = oldestDeadEligibleQuery
 	default:
 		return time.Time{}, false, errcode.New(errcode.KindInternal, ErrAdapterPGQuery,
 			"OldestEligibleAt: invalid status",
 			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("status=%s want StatePublished or StateDead", status))))
 	}
 
-	// The column name cannot be parameterised; the status value is bound via $1.
-	query := fmt.Sprintf("SELECT MIN(%s) FROM outbox_entries WHERE status = $1", col)
 	var oldest *time.Time
 	if err := s.db.QueryRow(ctx, query, status.String()).Scan(&oldest); err != nil {
 		return time.Time{}, false, errcode.Wrap(errcode.KindInternal, ErrAdapterPGQuery, "outbox store: OldestEligibleAt failed", err)

--- a/adapters/postgres/outbox_store_static_test.go
+++ b/adapters/postgres/outbox_store_static_test.go
@@ -1,0 +1,67 @@
+package postgres
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestPGOutboxStore_OldestEligibleAt_DoesNotBuildSQLWithFmtSprintf(t *testing.T) {
+	t.Parallel()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "outbox_store.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse outbox_store.go: %v", err)
+	}
+
+	fn := findFuncDecl(file, "OldestEligibleAt")
+	if fn == nil {
+		t.Fatal("OldestEligibleAt method not found")
+	}
+
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Sprintf" {
+			return true
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if ok && pkg.Name == "fmt" && sprintfBuildsSQL(call) {
+			t.Fatalf("OldestEligibleAt must select from named const SQL queries, not build SQL with fmt.Sprintf at %s",
+				fset.Position(call.Pos()))
+		}
+		return true
+	})
+}
+
+func findFuncDecl(file *ast.File, name string) *ast.FuncDecl {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == name {
+			return fn
+		}
+	}
+	return nil
+}
+
+func sprintfBuildsSQL(call *ast.CallExpr) bool {
+	if len(call.Args) == 0 {
+		return false
+	}
+	lit, ok := call.Args[0].(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return false
+	}
+	format, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToUpper(format), "SELECT")
+}

--- a/adapters/postgres/outbox_store_test.go
+++ b/adapters/postgres/outbox_store_test.go
@@ -609,12 +609,20 @@ func TestPGOutboxStore_OldestEligibleAt_Found(t *testing.T) {
 	t.Parallel()
 	want := time.Now().UTC().Truncate(time.Second)
 	for _, tc := range []struct {
-		name   string
-		status kout.State
-		colSub string // substring expected in the generated SQL column name
+		name      string
+		status    kout.State
+		wantQuery string
 	}{
-		{"published", kout.StatePublished, "published_at"},
-		{"dead", kout.StateDead, "dead_at"},
+		{
+			name:      "published",
+			status:    kout.StatePublished,
+			wantQuery: "SELECT MIN(published_at) FROM outbox_entries WHERE status = $1",
+		},
+		{
+			name:      "dead",
+			status:    kout.StateDead,
+			wantQuery: "SELECT MIN(dead_at) FROM outbox_entries WHERE status = $1",
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -632,8 +640,7 @@ func TestPGOutboxStore_OldestEligibleAt_Found(t *testing.T) {
 
 			require.Len(t, db.queryRowSQLs, 1)
 			qc := db.queryRowSQLs[0]
-			assert.Contains(t, qc.sql, tc.colSub, "SQL must select the right column for %s", tc.name)
-			assert.Contains(t, qc.sql, "status = $1", "SQL must filter by status parameter")
+			assert.Equal(t, tc.wantQuery, qc.sql)
 			assert.Equal(t, tc.status.String(), qc.args[0], "status arg must be the wire string")
 		})
 	}

--- a/framework/kernel/outbox/consumer_base.go
+++ b/framework/kernel/outbox/consumer_base.go
@@ -370,14 +370,16 @@ func deliveryFrom(r HandleResult) DeliveryOutcome {
 // by exponential backoff + jitter. Safe from duplicates, but all consumption
 // stops until the idempotency backend recovers.
 //
-// Rules:
+// Rules for normal subscriptions:
 //   - handler returns DispositionAck -> pass through as Ack
-//   - handler returns DispositionRequeue -> pass through as Requeue
-//   - handler returns DispositionReject -> pass through as Reject
-//   - handler returns error with non-Ack disposition -> retry with backoff
-//   - DispositionReject (handler-explicit) -> Reject (broker routes to DLX)
+//   - handler returns DispositionReject -> pass through as Reject (broker routes to DLX)
+//   - handler returns DispositionRequeue or any non-Ack transient result -> retry with backoff
 //   - retry budget exhausted -> Reject with ProcessReason="retry_exhausted"
 //   - ctx canceled / shutdown -> Requeue
+//
+// Rules for broker-delay subscriptions (BrokerDelaySchedule non-empty):
+// ConsumerBase runs the handler exactly once and passes Ack / Requeue / Reject
+// through verbatim because the transport owns retry timing and budget.
 //
 // Wrap lifts a business EntryHandler into a SubscriberHandler that includes
 // idempotency claim/release and retry logic. The returned SubscriberHandler


### PR DESCRIPTION
## Summary

Fixes two eventing follow-ups: aligns ConsumerBase retry documentation with the implemented retryLoop behavior, and removes dynamic SQL string construction from Postgres outbox `OldestEligibleAt`.

## Why / 背景

#1323 identified a stale `ConsumerBase.Wrap` rule comment that said handler `DispositionRequeue` passes through, while normal subscriptions actually retry locally and convert retry exhaustion to Reject. Only broker-delay subscriptions pass handler outcomes through verbatim.

#2201 identified that `OldestEligibleAt` used `fmt.Sprintf` to insert a hard-coded column name into SQL. It was not injectable because the column came from a closed switch, but it diverged from this file's const-query style and was noisy for SAST.

## Refs

Closes #1323
Closes #2201
ref: ThreeDotsLabs/watermill message/router retry-vs-subscriber boundary
ref: jackc/pgx query parameter binding style

## Risk / 兼容性

No wire, migration, or runtime behavior change. The SQL text is unchanged except it is now selected from named constants instead of being formatted dynamically.

## Test plan

- [x] `go -C worktrees/fix/1323-outbox-doc-2201-pg-query-consts/adapters/postgres test ./...`
- [x] `go -C worktrees/fix/1323-outbox-doc-2201-pg-query-consts/framework test ./kernel/outbox/...`
- [x] `go -C worktrees/fix/1323-outbox-doc-2201-pg-query-consts/framework test ./...`
- [x] `go -C worktrees/fix/1323-outbox-doc-2201-pg-query-consts/framework build ./...`
- [x] `go -C worktrees/fix/1323-outbox-doc-2201-pg-query-consts/adapters/postgres build ./...`
- [x] `golangci-lint run ./...` in `framework` and `adapters/postgres`
- [x] pre-push hook passed
