### PR TITLE
fix(http): move BodyLimit before auth

### DIFF
--- a/docs/architecture/202606021000-1043-adr-http-idempotency-middleware.md
+++ b/docs/architecture/202606021000-1043-adr-http-idempotency-middleware.md
@@ -75,34 +75,42 @@ draft §2.7（同 key + 不同 payload 是语义不可处理的客户端错误�
 > 回退 409」因 Kind 集合无 `KindUnprocessable` 而采用；#1450 引入该 Kind 后取代。详见文末
 > §"Amendment 2026-06-04：422 升级 + per-field diff"。
 
-### 3. Middleware 位序 — Auth 之后、handler 之前（BodyLimit 之内）
+### 3. Middleware 位序 — BodyLimit 之后、Auth 之后、handler 之前
 
 `buildMux` 中的完整顺序（外层 → 内层）：
 
 ```
-...→ Auth（JWT/ServiceToken）→ BodyLimit → [Idempotency] → route dispatcher
+...→ RateLimit/CircuitBreaker → BodyLimit → listener/default auth → JWT Auth → [Idempotency] → route dispatcher
 ```
 
-具体实现：`router.go::buildMux` 在 `BodyLimit` 之后、`composeHandler()`
+具体实现：`router.go::buildMux` 在 `BodyLimit`、listener/default auth middleware、
+JWT `AuthMiddleware` 之后，`composeHandler()`
 之前调用 `r.use(idemhttp.Middleware(r.clock, r.idempotencyStore))`（当 `idempotencyStore != nil` 时）。
 
 位序理由：
 
-1. **Auth 必须先于 Idempotency**：Middleware 需要已认证的 Principal 提取 Subject/TenantID；
+1. **BodyLimit 必须先于 listener/default auth 与 JWT Auth**：超限请求体在进入
+   ServiceToken、mTLS/operator、JWT 等认证链前直接以 413 拒绝，避免未认证的大 body
+   消耗认证侧资源。public route 只绕过 JWT，不绕过 BodyLimit。
+2. **Auth 必须先于 Idempotency**：Middleware 需要已认证的 Principal 提取 Subject/TenantID；
    无 Principal 时直接 passthrough（fail-safe，不报错）。若 Idempotency 错误地放在 Auth
    之前，`extractIdentity` 取不到 Principal → passthrough，不构成安全漏洞，但失去幂等追踪。
-2. **BodyLimit 必须先于 Idempotency**（即 BodyLimit 是 Idempotency 的外层）：BodyLimit
+3. **BodyLimit 必须先于 Idempotency**（即 BodyLimit 是 Idempotency 的外层）：BodyLimit
    在超限时直接 413 拒绝，防止超大请求体在 `recordOrRelease` 的 `bufferingWriter` 路径
    消耗 lease——lease 一旦 Claim 就算耗费，oversized 请求不应消耗 lease。注意 `shouldRecord`
    只在 2xx/3xx 时记录（见 §决策 6），4xx 不记录；但 BodyLimit 拒绝在 Idempotency 内层
    时会先 Claim 再被 413，lease 被消耗，后续重试需等待 lease 过期（`DefaultLeaseTTL`
    5 分钟）。BodyLimit 外层可完全避免此问题。
-3. **body fingerprint 读取必须在 BodyLimit 之后**：`readBodyFingerprint` 用 `io.ReadAll`
+4. **body fingerprint 读取必须在 BodyLimit 之后**：`readBodyFingerprint` 用 `io.ReadAll`
    读全量 body 再还原 `r.Body`，BodyLimit 已保证 body 大小有界。
+
+> **Amendment 2026-06-19（#1988）**：BodyLimit 从 auth 内层前移到 listener/default auth
+> 和 JWT Auth 之前，形成 request-size-first gate。该调整不改变 Auth 必须先于 Idempotency、
+> BodyLimit 必须先于 Idempotency 的幂等约束，只收敛认证前的超限请求体资源面。
 
 **位序不用 archtest 守护**：路径锚点是 Soft（字符串排序位置），`ai-robust.md` 禁止
 Soft 立项。位序正确性由 `router_behavioral_test.go` 的 integration-style 测试覆盖（验证
-BodyLimit 拒绝不消耗 lease、Auth 缺失时 passthrough）——行为测试 > 结构 AST 测试。
+BodyLimit 拒绝不消耗 lease、超限请求不进入 auth/default middleware、Auth 缺失时 passthrough）——行为测试 > 结构 AST 测试。
 
 ### 4. 激活方式 — listener-wide install + header-gated + method-gated
 

--- a/framework/runtime/http/router/router.go
+++ b/framework/runtime/http/router/router.go
@@ -198,7 +198,8 @@ func WithRequestIDOptions(opts ...middleware.RequestIDOption) Option {
 }
 
 // WithRateLimiter enables per-IP rate limiting in the default middleware chain.
-// When provided, the rate limiter is placed after observability and before auth.
+// When provided, the rate limiter is placed after observability and before
+// BodyLimit/auth.
 //
 // Both bare-nil and typed-nil (non-nil interface holding a nil pointer) are
 // rejected by NewForListener so the rate limiter is never silently absent.
@@ -264,10 +265,10 @@ func WithIdempotencyMetrics(obs idemhttp.MetricsObserver) Option {
 }
 
 // WithAuthMiddleware enables authentication middleware with an explicitly
-// injected verifier. The middleware is placed in the mux chain after any
-// rate-limiter/circuit-breaker and before BodyLimit. Public endpoints declared
-// via auth.Mount with Public:true inside cell RouteGroups bypass JWT
-// verification; FinalizeAuth compiles them into the router's auth predicates.
+// injected verifier. The middleware is placed in the mux chain after BodyLimit
+// and listener-level default middleware. Public endpoints declared via
+// auth.Mount with Public:true inside cell RouteGroups bypass JWT verification;
+// FinalizeAuth compiles them into the router's auth predicates.
 //
 // In the per-listener model this option is most commonly used for the
 // PrimaryListener router. InternalListener routers use auth.NewAuthServiceToken
@@ -387,8 +388,9 @@ func WithSuppressNoAuthVerifierWarn() Option {
 }
 
 // WithDefaultMiddleware appends middleware functions to the router's default
-// middleware chain. These are installed AFTER the early-responder layer and
-// BEFORE the per-router protections (rate-limiter, circuit-breaker, auth).
+// middleware chain. These are installed AFTER BodyLimit and BEFORE JWT auth /
+// idempotency. Rate-limit and circuit-breaker guards still run before
+// BodyLimit.
 //
 // Bootstrap uses this to install the listener-level auth middleware derived
 // from the ListenerAuth chain (e.g. mTLS peer-cert check, ServiceToken HMAC
@@ -401,8 +403,8 @@ func WithDefaultMiddleware(mws ...func(http.Handler) http.Handler) Option {
 
 // Router wraps a single *http.ServeMux root for ONE physical listener.
 // The observability middleware chain is baked in at construction time, and
-// the listener's default Policy is applied as an inner layer before any
-// cell routes are registered.
+// listener-level default middleware is applied as an inner layer after
+// request-size protection and before JWT auth / cell routes.
 //
 // Bootstrap creates one Router per declared listener (primary/internal/health)
 // via NewForListener. The old shared-root multiplexer design has been replaced
@@ -452,10 +454,10 @@ type Router struct {
 	cellIDClosedSet             map[string]struct{}
 	clientErrorLogSamplingEvery int
 	trustedProxies              []string
-	// defaultMiddleware are installed AFTER early-responders and BEFORE
-	// rate-limiter / circuit-breaker / auth. Bootstrap populates this by
-	// converting the listener's AuthPlan chain (mTLS, ServiceToken, etc.)
-	// via applyListenerAuthChain then passing them with WithDefaultMiddleware.
+	// defaultMiddleware are installed AFTER BodyLimit and BEFORE JWT auth /
+	// idempotency. Bootstrap populates this by converting the listener's AuthPlan
+	// chain (mTLS, ServiceToken, etc.) via applyListenerAuthChain then passing
+	// them with WithDefaultMiddleware.
 	defaultMiddleware []func(http.Handler) http.Handler
 
 	// FinalizeAuth state
@@ -570,8 +572,8 @@ func New(clk clock.Clock, opts ...Option) (*Router, error) {
 // The middleware chain is:
 //
 //	ListenerContext → RequestID → RealIP → Recorder → CellAttribution → [Tracing] → AccessLog → [Metrics]
-//	→ Recovery → SecurityHeaders → [earlyResponders] → [defaultMiddleware]
-//	→ [RateLimit] → [CircuitBreaker] → [Auth] → BodyLimit → [Idempotency] → handlers
+//	→ Recovery → SecurityHeaders → [earlyResponders] → [RateLimit] → [CircuitBreaker]
+//	→ BodyLimit → [defaultMiddleware] → [Auth] → [Idempotency] → handlers
 //
 // ref: go-kratos/kratos app.go WithServer + errgroup (adopted)
 // ref: net/http.ServeMux (one ServeMux per listener)
@@ -626,7 +628,7 @@ func NewForListener(clk clock.Clock, ref kcell.ListenerRef, opts ...Option) (*Ro
 //
 // r.patternRecorderMiddleware installs the *patternRecorder and injects the
 // router's route resolver so all observability layers see a consistent route
-// label even on short-circuit reject paths (auth, rate limit, 405).
+// label even on short-circuit reject paths (auth, rate limit, body limit, 405).
 // patternRecordingMux fills the recorder by asking ServeMux.Handler for the
 // matched pattern before dispatching the leaf handler.
 //
@@ -673,15 +675,15 @@ func (r *Router) buildRealIPMiddleware() (func(http.Handler) http.Handler, error
 }
 
 // buildMux wires the full middleware chain onto r.mux. Observability is baked
-// in first; then defaultMiddleware (from WithDefaultMiddleware, e.g. mTLS /
-// ServiceToken guards derived from the ListenerAuth chain) is applied; then
-// the protection chain (RL/CB/Auth/BodyLimit) wraps the handlers.
+// in first; early responders remain the first policy short-circuit; then the
+// protection chain applies rate-limit/circuit-breaker/body-limit before any
+// listener-level or JWT auth middleware.
 //
 // Chain order (outer to inner):
 //
 //	ListenerContext → RequestID → RealIP → Recorder → CellAttribution → [Tracing] → AccessLog → [Metrics]
-//	→ Recovery → SecurityHeaders → [earlyResponders] → [defaultMiddleware]
-//	→ [RateLimit] → [CircuitBreaker] → [Auth] → BodyLimit → [Idempotency] → handlers
+//	→ Recovery → SecurityHeaders → [earlyResponders] → [RateLimit] → [CircuitBreaker]
+//	→ BodyLimit → [defaultMiddleware] → [Auth] → [Idempotency] → handlers
 func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) error {
 	// Lazy public predicate so Tracing/RequestID honor public routes declared
 	// later via auth.Mount / FinalizeAuth.
@@ -732,15 +734,6 @@ func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) error {
 		r.use(earlyResponderMiddleware(er))
 	}
 
-	// --- Default middleware layer (listener-level auth guards from AuthPlan chain) ---
-	// Bootstrap populates r.defaultMiddleware via WithDefaultMiddleware after
-	// converting the ListenerAuth chain (mTLS, ServiceToken, etc.) through
-	// applyListenerAuthChain. Applied AFTER early-responders so framework
-	// isolation contracts fire before the auth gate.
-	if len(r.defaultMiddleware) > 0 {
-		r.use(r.defaultMiddleware...)
-	}
-
 	// --- Protection chain (per-router options) ---
 	if r.rateLimiter != nil {
 		r.use(middleware.RateLimit(r.rateLimiter))
@@ -752,10 +745,19 @@ func (r *Router) buildMux(realIPMW func(http.Handler) http.Handler) error {
 		}
 		r.use(cb)
 	}
+	r.use(middleware.BodyLimit(r.bodyLimit, r.metricsCollector, r.cellIDClosedSet))
+
+	// --- Default middleware layer (listener-level auth guards from AuthPlan chain) ---
+	// Bootstrap populates r.defaultMiddleware via WithDefaultMiddleware after
+	// converting the ListenerAuth chain (mTLS, ServiceToken, etc.) through
+	// applyListenerAuthChain. Applied AFTER BodyLimit so unauthenticated oversized
+	// bodies are rejected before any listener-level auth parses request metadata.
+	if len(r.defaultMiddleware) > 0 {
+		r.use(r.defaultMiddleware...)
+	}
 	if r.authVerifier != nil {
 		r.use(auth.AuthMiddleware(r.clock, r.authVerifier, r.buildAuthOpts()...))
 	}
-	r.use(middleware.BodyLimit(r.bodyLimit, r.metricsCollector, r.cellIDClosedSet))
 	if r.idempotencyStore != nil {
 		// lazyIdempotencyExempt reads the compiled exempt matcher lazily so
 		// FinalizeAuth (which runs AFTER buildMux) can compile the set from

--- a/framework/runtime/http/router/router_dual_mux_test.go
+++ b/framework/runtime/http/router/router_dual_mux_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -181,6 +182,83 @@ func TestPerListener_PrimaryRouter_WithAuthMiddleware_Enforces(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, rec.Code,
 		"/api/v1/* without JWT must return 401 on PrimaryListener router")
+}
+
+func TestPerListener_PrimaryRouter_BodyLimitRejectsBeforeAuth(t *testing.T) {
+	verifier := &dualMuxMockVerifier{
+		claims: kauth.Claims{Subject: "user-1", Roles: []string{"admin"}},
+	}
+	rtr, err := NewForListener(
+		clock.Real(), kcell.PrimaryListener,
+		WithBodyLimit(4),
+		WithAuthMiddleware(verifier),
+	)
+	require.NoError(t, err)
+
+	rtr.Handle("POST /api/v1/protected", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("handler must not run when body limit rejects")
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/protected", strings.NewReader("too-large"))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.ContentLength = int64(len("too-large"))
+	rec := httptest.NewRecorder()
+	rtr.Handler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	assert.Equal(t, int64(0), verifier.called.Load(), "BodyLimit must reject before JWT auth verifies the bearer token")
+}
+
+func TestPerListener_InternalRouter_BodyLimitRejectsBeforeDefaultMiddleware(t *testing.T) {
+	var defaultAuthCalls atomic.Int64
+	rtr, err := NewForListener(
+		clock.Real(), kcell.InternalListener,
+		WithBodyLimit(4),
+		WithDefaultMiddleware(countingMW(&defaultAuthCalls)),
+	)
+	require.NoError(t, err)
+
+	rtr.Handle("POST /internal/v1/protected", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("handler must not run when body limit rejects")
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/v1/protected", strings.NewReader("too-large"))
+	req.ContentLength = int64(len("too-large"))
+	rec := httptest.NewRecorder()
+	rtr.Handler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	assert.Equal(t, int64(0), defaultAuthCalls.Load(), "BodyLimit must reject before listener-level auth/default middleware")
+}
+
+func TestPerListener_PrimaryRouter_PublicRoute_BodyLimitStillApplies(t *testing.T) {
+	verifier := &dualMuxMockVerifier{
+		claims: kauth.Claims{Subject: "user-1", Roles: []string{"admin"}},
+	}
+	rtr, err := NewForListener(
+		clock.Real(), kcell.PrimaryListener,
+		WithBodyLimit(4),
+		WithAuthMiddleware(verifier),
+	)
+	require.NoError(t, err)
+
+	rtr.Handle("POST /api/v1/public", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("handler must not run when body limit rejects")
+	}))
+	require.NoError(t, rtr.DeclareAuthMeta(kcell.AuthRouteMeta{
+		Method: http.MethodPost,
+		Path:   "/api/v1/public",
+		Public: true,
+	}))
+	require.NoError(t, rtr.FinalizeAuth())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/public", strings.NewReader("too-large"))
+	req.ContentLength = int64(len("too-large"))
+	rec := httptest.NewRecorder()
+	rtr.Handler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	assert.Equal(t, int64(0), verifier.called.Load(), "public auth bypass must not bypass BodyLimit")
 }
 
 // TestDualMux_FinalizeAuth_InternalPathOnZeroRefAccepted verifies that a


### PR DESCRIPTION
## Summary

Move HTTP `BodyLimit` ahead of listener-level/default auth and JWT auth so oversized unauthenticated requests are rejected with 413 before auth processing.

## Why / 背景

Issue #1988 identified that the primary listener chain ran Auth before BodyLimit, letting oversized unauthenticated request bodies reach auth handling before the size gate. This widens the unauthenticated DoS surface and wastes I/O. The fix also aligns internal/default listener auth with the same request-size-first behavior.

## Refs

Closes #1988

ref: go-kratos middleware/middleware.go
ref: go-zero rest/engine.go

## Risk / 兼容性

No public API change. Visible behavior changes for oversized requests: after rate-limit/circuit-breaker, BodyLimit now returns 413 before listener-level auth or JWT auth can return an auth error. Public JWT-bypass routes still enforce BodyLimit.

## Test plan

- [x] `go -C framework build ./...` 本地通过
- [x] `go -C framework test ./runtime/http/router ./runtime/http/middleware` 本地通过
- [x] `go -C framework test ./...` 本地通过
- [x] `golangci-lint run ./runtime/http/router ./runtime/http/middleware` 0 issues
- [x] pre-push hook passed (`pre-push: ok`)
