### PR TITLE
fix(observability): close webhook circuit log context

### DIFF
--- a/framework/kernel/webhook/circuit.go
+++ b/framework/kernel/webhook/circuit.go
@@ -243,10 +243,11 @@ func circuitProbeOutcome(statusCode int, transportErr error) error {
 // URL — does not fast-fail deliveries from other tenants or to healthy targets.
 // The map is bounded (circuitGateMaxEndpoints) as a DoS guard.
 type circuitGate struct {
-	clk      clock.Clock
-	settings CircuitBreakerSettings
-	mu       sync.Mutex
-	breakers map[string]*circuitbreaker.Breaker
+	clk        clock.Clock
+	settings   CircuitBreakerSettings
+	newBreaker func(circuitbreaker.Config, clock.Clock) (*circuitbreaker.Breaker, error)
+	mu         sync.Mutex
+	breakers   map[string]*circuitbreaker.Breaker
 }
 
 // newCircuitGate builds an enabled circuit gate. clk is the dispatcher's clock,
@@ -254,7 +255,12 @@ type circuitGate struct {
 // tests drive. settings must have been validated before calling newCircuitGate.
 func newCircuitGate(clk clock.Clock, settings CircuitBreakerSettings) *circuitGate {
 	clock.MustHaveClock(clk, "webhook.newCircuitGate")
-	return &circuitGate{clk: clk, settings: settings, breakers: make(map[string]*circuitbreaker.Breaker)}
+	return &circuitGate{
+		clk:        clk,
+		settings:   settings,
+		newBreaker: circuitbreaker.New,
+		breakers:   make(map[string]*circuitbreaker.Breaker),
+	}
 }
 
 // Allow gates a delivery for key. It returns allowed=true and a done callback
@@ -262,8 +268,12 @@ func newCircuitGate(clk clock.Clock, settings CircuitBreakerSettings) *circuitGa
 // circuit is closed or admits a half-open probe; allowed=false and a nil done
 // when the circuit is open.
 func (g *circuitGate) Allow(key circuitEndpointKey) (allowed bool, done func(err error)) {
-	b := g.breakerFor(key)
+	b, err := g.breakerFor(key)
 	if b == nil {
+		errText := "<nil>"
+		if err != nil {
+			errText = err.Error()
+		}
 		// Unreachable: breakerFor returns nil only if breaker construction
 		// failed, which happens solely on an empty Name — and logName always
 		// yields a non-empty "<host>#<fingerprint>". Kept as a defensive,
@@ -271,7 +281,9 @@ func (g *circuitGate) Allow(key circuitEndpointKey) (allowed bool, done func(err
 		// construction bug degrades to "no breaker protection", never to
 		// "delivery blocked". Log at Error (correctness failure).
 		slog.Error("webhook: circuit breaker construction failed, failing open",
-			slog.String("warning", "endpoint circuit breaker unavailable"))
+			slog.String("tenant", key.tenant),
+			slog.String("endpoint", key.logName()),
+			slog.String("error", errText))
 		return true, func(error) {}
 	}
 	return b.Allow()
@@ -290,12 +302,12 @@ func (g *circuitGate) size() int {
 // at circuitGateMaxEndpoints distinct (tenant, endpoint) pairs the victim choice
 // is not correctness-critical — a re-observed pair simply rebuilds its breaker,
 // the worst case being one lost open-state that re-trips on the next failure burst.
-func (g *circuitGate) breakerFor(key circuitEndpointKey) *circuitbreaker.Breaker {
+func (g *circuitGate) breakerFor(key circuitEndpointKey) (*circuitbreaker.Breaker, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	rk := key.registryKey()
 	if b, ok := g.breakers[rk]; ok {
-		return b
+		return b, nil
 	}
 	if len(g.breakers) >= circuitGateMaxEndpoints {
 		for k := range g.breakers { // evict one arbitrary entry
@@ -303,15 +315,15 @@ func (g *circuitGate) breakerFor(key circuitEndpointKey) *circuitbreaker.Breaker
 			break
 		}
 	}
-	b, err := circuitbreaker.New(circuitbreaker.Config{
+	b, err := g.newBreaker(circuitbreaker.Config{
 		Name:        key.logName(),                     // safe log label: host#fingerprint, no path/query
 		MaxRequests: uint32(g.settings.HalfOpenProbes), //nolint:gosec // validated > 0
 		Timeout:     g.settings.OpenTimeout,
 		ReadyToTrip: makeCircuitReadyToTrip(g.settings.TripThreshold),
 	}, g.clk)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	g.breakers[rk] = b
-	return b
+	return b, nil
 }

--- a/framework/kernel/webhook/dispatcher_circuit_test.go
+++ b/framework/kernel/webhook/dispatcher_circuit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -14,11 +15,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ghbvf/gocell/framework/kernel/circuitbreaker"
+	"github.com/ghbvf/gocell/framework/kernel/clock"
 	"github.com/ghbvf/gocell/framework/kernel/clock/clockmock"
 	kernelmetrics "github.com/ghbvf/gocell/framework/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/framework/kernel/outbox"
 	"github.com/ghbvf/gocell/framework/pkg/ctxkeys"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/slogcapture"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/sloghelper"
 )
 
 // defaultCB is a test-local shorthand for the default circuit breaker settings,
@@ -309,6 +314,37 @@ func TestCircuitGate_EmptyKeyStillBreaks(t *testing.T) {
 	require.NotNil(t, done, "a working breaker returns a non-nil done callback")
 	assert.NotPanics(t, func() { done(nil) })
 	assert.Equal(t, 1, g.size(), "an empty key still registers a real breaker, not fail-open")
+}
+
+// TestCircuitGate_FailOpenLogsKeyContext verifies the defensive fail-open branch
+// stays diagnosable without logging raw endpoint path/query data.
+func TestCircuitGate_FailOpenLogsKeyContext(t *testing.T) {
+	buf := sloghelper.NewSyncBuffer()
+	slogcapture.InstallDefault(t, slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	g := newCircuitGate(clockmock.New(time.Unix(0, 0)), DefaultCircuitBreakerSettings())
+	g.newBreaker = func(circuitbreaker.Config, clock.Clock) (*circuitbreaker.Breaker, error) {
+		return nil, errors.New("synthetic breaker construction failure")
+	}
+	key := newCircuitEndpointKey("tenant-a", "https://hooks.example.test/tenant-a/hook?token=secret")
+
+	allow, done := g.Allow(key)
+	assert.True(t, allow, "breaker construction failure must fail open")
+	require.NotNil(t, done, "fail-open path still returns a no-op done callback")
+	assert.NotPanics(t, func() { done(nil) })
+
+	entry := sloghelper.FindLogEntry(buf.String(), "webhook: circuit breaker construction failed")
+	require.NotNil(t, entry, "expected fail-open construction error log, logs:\n%s", buf.String())
+	assert.Equal(t, "ERROR", entry["level"])
+	assert.Equal(t, "tenant-a", entry["tenant"])
+	assert.Equal(t, key.logName(), entry["endpoint"])
+	assert.Equal(t, "synthetic breaker construction failure", entry["error"])
+
+	logs := buf.String()
+	assert.NotContains(t, logs, "warning", "warning must not be used as a pseudo-field")
+	assert.NotContains(t, logs, "/tenant-a/hook", "raw endpoint path must not be logged")
+	assert.NotContains(t, logs, "token=", "raw endpoint query must not be logged")
+	assert.NotContains(t, logs, "secret", "raw endpoint query value must not be logged")
 }
 
 // TestCircuitEndpointKey_LogNameSafeAndDistinct verifies the breaker log label

--- a/tools/codegen/contractgen/generator.go
+++ b/tools/codegen/contractgen/generator.go
@@ -2,7 +2,6 @@ package contractgen
 
 import (
 	"fmt"
-	"log/slog"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -321,18 +320,7 @@ func generateOneContract(root string, p *metadata.ProjectMeta, contractID string
 	// server contract is buf's generated pb.<Svc>Server (#1688) — neither has a
 	// per-contract contractgen package.
 	if spec.Kind == "webhook" || spec.Kind == "grpc" {
-		slog.Debug("contractgen: contract emits zero artifacts by design; wiring derives via cellgen / buf",
-			"contractID", contractID, "kind", spec.Kind)
 		return nil
-	}
-
-	// For kind=projection, types_gen.go + iface_gen.go IS the complete product by
-	// design: NewProjectionRequest is generated on the event-contract side, and
-	// cellgen derives reg.RegisterProjection from event-subscribe CUs.
-	if spec.Kind == "projection" {
-		slog.Debug("contractgen: projection contract emits types/iface only by design; "+
-			"NewProjectionRequest is generated on the event-contract side",
-			"contractID", contractID)
 	}
 
 	// Per-artifact emit, driven by the kind × artifact matrix. The applicable-kind
@@ -423,8 +411,6 @@ func RenderContractArtifacts(root string, p *metadata.ProjectMeta, contractID, m
 	// server contract is buf's generated pb.<Svc>Server (#1688) — neither has a
 	// per-contract contractgen package.
 	if spec.Kind == "webhook" || spec.Kind == "grpc" {
-		slog.Debug("contractgen: contract emits zero artifacts by design; wiring derives via cellgen / buf",
-			"contractID", contractID, "kind", spec.Kind)
 		return nil, nil
 	}
 

--- a/tools/codegen/contractgen/generator_test.go
+++ b/tools/codegen/contractgen/generator_test.go
@@ -3,6 +3,7 @@ package contractgen
 import (
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -12,6 +13,8 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/metadata"
 	"github.com/ghbvf/gocell/framework/kernel/metadata/metadatatest"
 	"github.com/ghbvf/gocell/framework/pkg/testutil/fileutil"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/slogcapture"
+	"github.com/ghbvf/gocell/framework/pkg/testutil/sloghelper"
 )
 
 // TestArtifactsForKind locks the kind × artifact matrix — the single source
@@ -118,6 +121,45 @@ func TestContractArtifacts_NamingConvention(t *testing.T) {
 	}
 }
 
+// TestContractGenDesignBreadcrumbLogs_Removed locks #1603's decision: the
+// artifact matrix and docs are the design source, not runtime Debug breadcrumbs.
+func TestContractGenDesignBreadcrumbLogs_Removed(t *testing.T) {
+	buf := sloghelper.NewSyncBuffer()
+	slogcapture.InstallDefault(t, slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	webhookRoot, webhookProject := setupWebhookRoot(t)
+	if _, err := Generate(webhookRoot, webhookProject, Options{Scope: ScopeAll{}, ModulePath: "github.com/ghbvf/gocell"}); err != nil {
+		t.Fatalf("Generate webhook: %v", err)
+	}
+	if _, err := RenderContractArtifacts(
+		webhookRoot, webhookProject, "webhook.stripe.payment-events.v1", "github.com/ghbvf/gocell",
+	); err != nil {
+		t.Fatalf("RenderContractArtifacts webhook: %v", err)
+	}
+
+	grpcRoot, grpcProject := setupGRPCMinimalRoot(t)
+	if _, err := Generate(grpcRoot, grpcProject, Options{Scope: ScopeAll{}, ModulePath: "github.com/ghbvf/gocell"}); err != nil {
+		t.Fatalf("Generate grpc: %v", err)
+	}
+	if _, err := RenderContractArtifacts(grpcRoot, grpcProject, "grpc.device.command.v1", "github.com/ghbvf/gocell"); err != nil {
+		t.Fatalf("RenderContractArtifacts grpc: %v", err)
+	}
+
+	projectionRoot, projectionProject, projectionID := setupProjectionRoot(t)
+	if _, err := Generate(projectionRoot, projectionProject, Options{Scope: ScopeAll{}, ModulePath: "github.com/ghbvf/gocell"}); err != nil {
+		t.Fatalf("Generate projection: %v", err)
+	}
+	if _, err := RenderContractArtifacts(projectionRoot, projectionProject, projectionID, "github.com/ghbvf/gocell"); err != nil {
+		t.Fatalf("RenderContractArtifacts projection: %v", err)
+	}
+
+	logs := buf.String()
+	if strings.Contains(logs, "contractgen: contract emits zero artifacts by design") ||
+		strings.Contains(logs, "contractgen: projection contract emits types/iface only by design") {
+		t.Fatalf("contractgen must not emit design breadcrumb Debug logs, got:\n%s", logs)
+	}
+}
+
 // --- helpers ------------------------------------------------------------------
 
 // copyDirIntoTemp copies the entire directory tree under src into dst,
@@ -163,6 +205,16 @@ func copyFile(src, dst string) error {
 	return copyErr
 }
 
+func goArtifactBaseNames(paths []string) []string {
+	var out []string
+	for _, path := range paths {
+		if strings.HasSuffix(path, ".go") {
+			out = append(out, filepath.Base(path))
+		}
+	}
+	return out
+}
+
 // synthHTTPMinimalFixture returns the absolute path to the synth_http_minimal fixture.
 func synthHTTPMinimalFixture(t *testing.T) string {
 	t.Helper()
@@ -202,6 +254,32 @@ func setupHTTPMinimalRoot(t *testing.T) (string, *metadata.ProjectMeta) {
 		t.Fatalf("parse synth_http_minimal from tmp: %v", err)
 	}
 	return root, p
+}
+
+// setupProjectionRoot returns a minimal in-memory projection contract rooted at
+// a temp directory. Projection contracts need no schema files for contractgen's
+// types/iface-only artifact path.
+func setupProjectionRoot(t *testing.T) (string, *metadata.ProjectMeta, string) {
+	t.Helper()
+	const id = "projection.device.inventory.v1"
+	root := t.TempDir()
+	goMod := "module github.com/ghbvf/gocell\n\ngo 1.22\n"
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	p := &metadata.ProjectMeta{
+		Contracts: map[string]*metadata.ContractMeta{
+			id: {
+				ID:               id,
+				Kind:             "projection",
+				ConsistencyLevel: "L3",
+				Codegen:          true,
+				Transports:       []string{"internal"},
+				File:             "contracts/projection/device/inventory/v1/contract.yaml",
+			},
+		},
+	}
+	return root, p, id
 }
 
 // setupEventRoot copies the synth_event fixture into a fresh t.TempDir()
@@ -668,6 +746,44 @@ func TestRenderContractArtifacts_Event(t *testing.T) {
 		if !fileNames[want] {
 			t.Errorf("missing artifact: %s", want)
 		}
+	}
+}
+
+// TestGenerate_Projection_GoArtifactsRemainTypesIfaceOnly verifies #1603 only
+// removes Debug breadcrumbs; projection Go artifact behavior remains unchanged.
+func TestGenerate_Projection_GoArtifactsRemainTypesIfaceOnly(t *testing.T) {
+	t.Parallel()
+	root, p, projectionID := setupProjectionRoot(t)
+
+	res, err := Generate(root, p, Options{Scope: ScopeContracts{projectionID}, ModulePath: "github.com/ghbvf/gocell"})
+	if err != nil {
+		t.Fatalf("Generate projection: %v", err)
+	}
+	got := goArtifactBaseNames(res.Generated)
+	want := []string{"types_gen.go", "iface_gen.go"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("projection Generate Go artifacts = %v, want %v", got, want)
+	}
+}
+
+// TestRenderContractArtifacts_Projection_GoArtifactsRemainTypesIfaceOnly mirrors
+// Generate for the in-memory render path.
+func TestRenderContractArtifacts_Projection_GoArtifactsRemainTypesIfaceOnly(t *testing.T) {
+	t.Parallel()
+	root, p, projectionID := setupProjectionRoot(t)
+
+	artifacts, err := RenderContractArtifacts(root, p, projectionID, "github.com/ghbvf/gocell")
+	if err != nil {
+		t.Fatalf("RenderContractArtifacts projection: %v", err)
+	}
+	var paths []string
+	for _, a := range artifacts {
+		paths = append(paths, a.Path)
+	}
+	got := goArtifactBaseNames(paths)
+	want := []string{"types_gen.go", "iface_gen.go"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("projection RenderContractArtifacts Go artifacts = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add safe tenant/endpoint/error context to webhook circuit fail-open logs
- remove contractgen Debug design breadcrumbs for zero-artifact and projection contracts
- add regression coverage for fail-open logging and projection Go artifact output

## Why / 背景

Fixes webhook circuit fail-open observability from #2200 without logging raw endpoint path/query data. Closes #1603 by making contractgen artifact behavior covered by matrix/tests instead of runtime Debug breadcrumbs.

## Refs

Closes #2200
Closes #1603
ref: https://github.com/sony/gobreaker/blob/master/gobreaker.go
ref: https://github.com/zeromicro/go-zero

## Risk / 兼容性

无 exported API / schema / generated artifact / wire behavior changes. Webhook circuit behavior remains fail-open on breaker construction failure; the log endpoint field uses the safe host#fingerprint identity.

## Test plan

- [x] `go test ./framework/kernel/webhook ./tools/codegen/contractgen -count=1`
- [x] `go test -tags=archtest ./tools/archtest -run TestSlogCaptureGlobalFunnel -count=1`
- [x] `make check-build`
- [x] changed-package `golangci-lint run` 0 issues for `framework/kernel/webhook` and `tools/codegen/contractgen`
- [x] pre-push hook passed (`pre-push: ok (217s)`)
