### PR TITLE
fix(assembly): #2429 generate assembly import 块按路径整体排序，emit 即 gofumpt-canonical

### DIFF
--- a/cmd/corebundle/modules_gen.go
+++ b/cmd/corebundle/modules_gen.go
@@ -7,8 +7,8 @@ import (
 	cellmodulesauditcore "github.com/ghbvf/gocell/cellmodules/auditcore"
 	cellmodulesconfigcore "github.com/ghbvf/gocell/cellmodules/configcore"
 	cellmodulessyscore "github.com/ghbvf/gocell/cellmodules/syscore"
-	"github.com/ghbvf/gocell/framework/runtime/capability"
 	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
+	"github.com/ghbvf/gocell/framework/runtime/capability"
 	"github.com/ghbvf/gocell/framework/runtime/composition"
 )
 

--- a/framework/kernel/assembly/generator.go
+++ b/framework/kernel/assembly/generator.go
@@ -529,39 +529,71 @@ func cellModuleImportPath(module, cellID string) string {
 	return module + "/cellmodules/" + cellID
 }
 
-// generateModulesGenComposition emits the composition.CellModule form used by
-// platform assemblies (assembly.yaml build.compositionAPI: true).
-// Each cell maps to cellmodules{cellID}.Module() with a matching import alias.
-func (g *Generator) generateModulesGenComposition(
-	assemblyID string, asm *metadata.AssemblyMeta, capConsts []string,
-) ([]byte, error) {
-	moduleCalls := make([]string, 0, len(asm.Cells))
-	importLines := make([]string, 0, len(asm.Cells))
-	seen := make(map[string]bool, len(asm.Cells))
-	for _, ref := range asm.Cells {
-		cm := g.cells.Get(ref.ID)
-		if cm == nil {
-			return nil, errcode.New(errcode.KindNotFound, errcode.ErrMetadataInvalid,
+// compositionImportLines builds the rendered import lines and the Module() call
+// list for the composition modules_gen.go. The import block is sorted by import
+// PATH (not by the rendered line) so it is gofumpt-canonical regardless of
+// cell-declaration order AND regardless of whether a cross-module (#1083)
+// cellmodule path sorts before or after the framework runtime imports: cellmodule
+// lines carry an alias while the framework imports are bare, so a plain string
+// sort over the rendered lines would put every bare `"..."` line ahead of any
+// aliased line and break path order — the defect behind #2429. moduleCalls stay
+// in assembly.yaml cell order for deterministic output; that order is NOT
+// runtime-significant (the former auditcore→accesscore BootstrapLedgerStore
+// handoff was removed in #1423 — cross-cell wiring is now event-driven).
+func (g *Generator) compositionImportLines(
+	assemblyID string, cells []metadata.AssemblyCellRef, hasCapabilities bool,
+) (importLines, moduleCalls []string, err error) {
+	type genImport struct{ path, line string }
+	imports := make([]genImport, 0, len(cells)+3)
+	moduleCalls = make([]string, 0, len(cells))
+	seen := make(map[string]bool, len(cells))
+	for _, ref := range cells {
+		if g.cells.Get(ref.ID) == nil {
+			return nil, nil, errcode.New(errcode.KindNotFound, errcode.ErrMetadataInvalid,
 				msgAssemblyUnknownCell,
 				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf(internalAssemblyCellFmt, assemblyID, ref.ID))))
 		}
 		alias := "cellmodules" + ref.ID
 		if !seen[ref.ID] {
 			seen[ref.ID] = true
-			importLines = append(importLines, fmt.Sprintf("%s %q",
-				alias, cellModuleImportPath(g.moduleOf(ref), ref.ID)))
+			path := cellModuleImportPath(g.moduleOf(ref), ref.ID)
+			imports = append(imports, genImport{path: path, line: fmt.Sprintf("%s %q", alias, path)})
 		}
 		moduleCalls = append(moduleCalls, alias+".Module()")
 	}
-	// Sort import lines by their (alias, path) string so the rendered import
-	// block is gofmt-clean regardless of cell declaration order. The alias is
-	// "platform"+cellID and the path ends in /cellmodules/cellID, so string-sorting
-	// the import lines matches gofmt's path-based ordering. moduleCalls stay in
-	// cell (assembly.yaml) order for deterministic, predictable output — that
-	// order is NOT runtime-significant: the former auditcore→accesscore
-	// BootstrapLedgerStore handoff was removed in #1423 (cross-cell wiring is now
-	// event-driven), so module Provide order carries no runtime dependency.
-	sort.Strings(importLines)
+	// bootstrap (TopologyGroup) and composition (CellModule) are always referenced
+	// by the template body; capability only when the assembly has a non-empty
+	// capability union — emitting it unconditionally would be an unused import for
+	// cap-less assemblies, so it is gated on the same condition as
+	// generatedCapabilities().
+	frameworkImports := []string{
+		"github.com/ghbvf/gocell/framework/runtime/bootstrap",
+		"github.com/ghbvf/gocell/framework/runtime/composition",
+	}
+	if hasCapabilities {
+		frameworkImports = append(frameworkImports, "github.com/ghbvf/gocell/framework/runtime/capability")
+	}
+	for _, p := range frameworkImports {
+		imports = append(imports, genImport{path: p, line: fmt.Sprintf("%q", p)})
+	}
+	sort.Slice(imports, func(i, j int) bool { return imports[i].path < imports[j].path })
+	importLines = make([]string, len(imports))
+	for i, imp := range imports {
+		importLines[i] = imp.line
+	}
+	return importLines, moduleCalls, nil
+}
+
+// generateModulesGenComposition emits the composition.CellModule form used by
+// platform assemblies (assembly.yaml build.compositionAPI: true).
+// Each cell maps to cellmodules{cellID}.Module() with a matching import alias.
+func (g *Generator) generateModulesGenComposition(
+	assemblyID string, asm *metadata.AssemblyMeta, capConsts []string,
+) ([]byte, error) {
+	importLines, moduleCalls, err := g.compositionImportLines(assemblyID, asm.Cells, len(capConsts) > 0)
+	if err != nil {
+		return nil, err
+	}
 	projTopics, err := g.collectOutboxProjectionTopics(asm.Cells)
 	if err != nil {
 		return nil, err

--- a/framework/kernel/assembly/generator_crossmodule_test.go
+++ b/framework/kernel/assembly/generator_crossmodule_test.go
@@ -1,6 +1,8 @@
 package assembly
 
 import (
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +13,11 @@ import (
 )
 
 const acmePayModule = "github.com/acme/payment-cell"
+
+// zzzExtraModule sorts AFTER github.com/ghbvf/gocell/framework/runtime/* (z > g),
+// so its cellmodule import must render after the framework imports — the case the
+// acme fixture (acme < ghbvf) cannot exercise. Used by #2429's sort-order test.
+const zzzExtraModule = "github.com/zzz/extra-cell"
 
 // buildCrossModuleProject builds a compositionAPI assembly that mixes a
 // same-module cell (configcore) and a cross-module cell (payment, sourced from
@@ -126,4 +133,84 @@ func TestModuleOfAndImportPath(t *testing.T) {
 		cellModuleImportPath(g.moduleOf(same), same.ID))
 	assert.Equal(t, acmePayModule+"/cellmodules/payment",
 		cellModuleImportPath(g.moduleOf(cross), cross.ID))
+}
+
+// TestGenerateModulesGen_CrossModuleImportPathSortOrder is #2429's anti-vacuity
+// guard for the WHOLE-block path sort: compositionImportLines must order the
+// import block by import PATH, including a cross-module cellmodule path that sorts
+// AFTER the framework runtime imports. The acme fixture (github.com/acme/... <
+// github.com/ghbvf/...) only exercises a cellmodule that sorts BEFORE framework, so
+// it cannot prove the after-framework case the helper's godoc relies on. Against
+// the pre-#2429 generator (cellmodule imports sorted as one leading block, then
+// framework imports hardcoded last) the zzz cellmodule would render BEFORE
+// composition — so this test is genuinely red there.
+func TestGenerateModulesGen_CrossModuleImportPathSortOrder(t *testing.T) {
+	const currentModule = "github.com/ghbvf/gocell"
+	project := &metadata.ProjectMeta{
+		Cells: map[string]*metadata.CellMeta{
+			metadatatest.CellIDConfigCore:   {ID: metadatatest.CellIDConfigCore},
+			metadatatest.NewCellID("extra"): {ID: metadatatest.NewCellID("extra")},
+		},
+		Slices:    make(map[string]*metadata.SliceMeta),
+		Contracts: make(map[string]*metadata.ContractMeta),
+		Journeys:  make(map[string]*metadata.JourneyMeta),
+		Assemblies: map[string]*metadata.AssemblyMeta{
+			"zzzbundle": {
+				ID: "zzzbundle",
+				Cells: []metadata.AssemblyCellRef{
+					{ID: metadatatest.CellIDConfigCore},
+					{ID: metadatatest.NewCellID("extra"), Module: zzzExtraModule},
+				},
+				Build: metadata.BuildMeta{CompositionAPI: true},
+				File:  "assemblies/zzzbundle/assembly.yaml",
+			},
+		},
+	}
+	// Require a capability so all three framework imports are present — the sort
+	// must interleave bootstrap/capability/composition AND the after-framework
+	// cross-module cellmodule into one ascending block.
+	project.Cells[metadatatest.CellIDConfigCore].Requires = []string{"postgres"}
+
+	out, err := NewGenerator(project, currentModule, "").GenerateModulesGen("zzzbundle")
+	require.NoError(t, err)
+	content := string(out)
+
+	posComposition := indexOfStr(content, `"github.com/ghbvf/gocell/framework/runtime/composition"`)
+	posZzz := indexOfStr(content, zzzExtraModule+"/cellmodules/extra")
+	require.GreaterOrEqual(t, posComposition, 0, "composition import must be present")
+	require.GreaterOrEqual(t, posZzz, 0, "cross-module extra import must be present")
+	assert.Less(t, posComposition, posZzz,
+		"a cross-module cellmodule path sorting after framework/* must render AFTER composition (#2429 whole-block path sort)")
+
+	// Stronger anti-vacuity teeth: the entire import block must be in strict
+	// ascending import-path order — this also re-catches the original
+	// capability-before-bootstrap defect.
+	assertImportBlockSorted(t, content)
+}
+
+// assertImportBlockSorted extracts the single import(...) block from generated Go
+// and asserts the import paths are in ascending order (gofumpt's ordering for a
+// single import group). Each line is either `alias "path"` or bare `"path"`; the
+// path is the quoted segment.
+func assertImportBlockSorted(t *testing.T, content string) {
+	t.Helper()
+	open := indexOfStr(content, "import (")
+	require.GreaterOrEqual(t, open, 0, "generated file must have an import block")
+	rest := content[open+len("import ("):]
+	closeIdx := strings.IndexByte(rest, ')')
+	require.GreaterOrEqual(t, closeIdx, 0, "import block must be closed")
+	var paths []string
+	for _, line := range strings.Split(rest[:closeIdx], "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		q1 := strings.IndexByte(line, '"')
+		q2 := strings.LastIndexByte(line, '"')
+		require.True(t, q1 >= 0 && q2 > q1, "import line must carry a quoted path: %q", line)
+		paths = append(paths, line[q1+1:q2])
+	}
+	require.NotEmpty(t, paths, "import block must list at least one import")
+	assert.True(t, sort.StringsAreSorted(paths),
+		"import block must be in ascending path order (gofumpt-canonical), got: %v", paths)
 }

--- a/framework/kernel/assembly/generator_deploymenttopology_test.go
+++ b/framework/kernel/assembly/generator_deploymenttopology_test.go
@@ -101,6 +101,12 @@ func TestGenerateModulesGen_TopologyGroups_MultiGroup_Golden(t *testing.T) {
 		{Role: "edge", Cells: []string{metadatatest.CellIDAuditCore}, Endpoint: "https://edge.svc:9443"},
 	}}
 	project := buildCompositionProjectForTopology(topo)
+	// #2429: require a capability so the golden carries the runtime/capability import
+	// alongside bootstrap/composition. This byte-locks the gofumpt-canonical import
+	// ordering (bootstrap < capability < composition) — the exact block whose
+	// hardcoded mis-ordering tripped the pre-push gofumpt gate. Without a capability
+	// the import block omits capability and the regression is invisible to the golden.
+	project.Cells[metadatatest.CellIDAccessCore].Requires = []string{"postgres"}
 	gen := NewGenerator(project, "github.com/ghbvf/gocell", "")
 
 	out, err := gen.GenerateModulesGen("topobundle")
@@ -126,11 +132,24 @@ func TestGenerateModulesGen_TopologyGroups_MultiGroup_Golden(t *testing.T) {
 	for _, want := range []string{
 		"[]bootstrap.TopologyGroup{", `Role:     "core"`, `Role:     "edge"`,
 		`"accesscore"`, `"auditcore"`, `"https://core.svc:9443"`, `"https://edge.svc:9443"`,
+		// #2429: the capability import must be present (so the golden actually
+		// exercises the bootstrap < capability < composition ordering it locks).
+		`"github.com/ghbvf/gocell/framework/runtime/capability"`,
 	} {
 		if !bytes.Contains(out, []byte(want)) {
 			t.Errorf("generated output missing %q:\n%s", want, out)
 		}
 	}
+	// #2429: the framework import block must be gofumpt-canonical regardless of the
+	// golden bytes — bootstrap < capability < composition (alphabetical path order).
+	posBootstrap := bytes.Index(out, []byte(`"github.com/ghbvf/gocell/framework/runtime/bootstrap"`))
+	posCapability := bytes.Index(out, []byte(`"github.com/ghbvf/gocell/framework/runtime/capability"`))
+	posComposition := bytes.Index(out, []byte(`"github.com/ghbvf/gocell/framework/runtime/composition"`))
+	require.Positive(t, posBootstrap)
+	require.Positive(t, posCapability)
+	require.Positive(t, posComposition)
+	assert.Less(t, posBootstrap, posCapability, "bootstrap import must precede capability (#2429)")
+	assert.Less(t, posCapability, posComposition, "capability import must precede composition (#2429)")
 }
 
 // TestGenerateModulesGen_TopologyGroups_IllegalCellInTwoGroups is the

--- a/framework/kernel/assembly/generator_modulesgen_test.go
+++ b/framework/kernel/assembly/generator_modulesgen_test.go
@@ -337,6 +337,23 @@ func TestGenerateModulesGen_CompositionFormWithCapabilities(t *testing.T) {
 		"derived capabilities must be sorted (postgres before redis)")
 	assert.Equal(t, 1, strings.Count(content, "capability.Postgres"),
 		"postgres required by multiple cells must emit a single const")
+
+	// #2429: the framework import block must be gofumpt-canonical (alphabetical by
+	// import path): bootstrap < capability < composition. The pre-fix template
+	// hardcoded capability BEFORE bootstrap, producing a non-canonical block that
+	// trips the pre-push gofumpt gate the moment the file is regenerated. Imports
+	// are matched on their quoted path so the capability.Kind references in the
+	// function body cannot satisfy the assertion vacuously.
+	posBootstrap := indexOfStr(content, `"github.com/ghbvf/gocell/framework/runtime/bootstrap"`)
+	posCapability := indexOfStr(content, `"github.com/ghbvf/gocell/framework/runtime/capability"`)
+	posComposition := indexOfStr(content, `"github.com/ghbvf/gocell/framework/runtime/composition"`)
+	require.GreaterOrEqual(t, posBootstrap, 0, "bootstrap import must be present")
+	require.GreaterOrEqual(t, posCapability, 0, "capability import must be present")
+	require.GreaterOrEqual(t, posComposition, 0, "composition import must be present")
+	assert.Less(t, posBootstrap, posCapability,
+		"bootstrap import must precede capability (gofumpt path order, #2429)")
+	assert.Less(t, posCapability, posComposition,
+		"capability import must precede composition (gofumpt path order, #2429)")
 }
 
 // TestGenerateModulesGen_CompositionUnknownCellRef verifies the composition

--- a/framework/kernel/assembly/gentpl/modules_gen_composition.go.tpl
+++ b/framework/kernel/assembly/gentpl/modules_gen_composition.go.tpl
@@ -6,11 +6,6 @@ import (
 {{- range .ModuleImports}}
 	{{.}}
 {{- end}}
-{{- if .Capabilities}}
-	"github.com/ghbvf/gocell/framework/runtime/capability"
-{{- end}}
-	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
-	"github.com/ghbvf/gocell/framework/runtime/composition"
 )
 
 func generatedCellModules() []composition.CellModule {

--- a/framework/kernel/assembly/testdata/modules_gen_topology_groups.go.golden
+++ b/framework/kernel/assembly/testdata/modules_gen_topology_groups.go.golden
@@ -6,6 +6,7 @@ import (
 	cellmodulesaccesscore "github.com/ghbvf/gocell/cellmodules/accesscore"
 	cellmodulesauditcore "github.com/ghbvf/gocell/cellmodules/auditcore"
 	"github.com/ghbvf/gocell/framework/runtime/bootstrap"
+	"github.com/ghbvf/gocell/framework/runtime/capability"
 	"github.com/ghbvf/gocell/framework/runtime/composition"
 )
 
@@ -13,6 +14,18 @@ func generatedCellModules() []composition.CellModule {
 	return []composition.CellModule{
 		cellmodulesaccesscore.Module(),
 		cellmodulesauditcore.Module(),
+	}
+}
+
+// generatedCapabilities lists the assembly-level shared infrastructure
+// capabilities — the sorted union of the assembly cells' cell.yaml `requires`.
+// The composition root provisions each once and injects the resulting
+// runtime/capability provider into consuming modules. Emitted iff the union is
+// non-empty: an assembly whose cells require nothing has no provisioner to call
+// it, so the function (and its capability import) are omitted to avoid dead code.
+func generatedCapabilities() []capability.Kind {
+	return []capability.Kind{
+		capability.Postgres,
 	}
 }
 
@@ -39,7 +52,9 @@ func generatedProjectionSourceTopics() []string {
 // unconditionally. Derived by `gocell generate assembly`; `--verify` red-flags stale
 // output (#1964 per-cell infra seam).
 func generatedPostgresCells() []string {
-	return nil
+	return []string{
+		"accesscore",
+	}
 }
 
 // generatedBrokerCells is the sorted list of cell IDs that produce or consume at


### PR DESCRIPTION
## Summary

修复 `gocell generate assembly` 生成的 composition `modules_gen.go` import 块非 gofumpt-canonical：把三个 framework runtime import 纳入生成器的统一 import 排序集、按 import 路径整体排序，使 emit 即为 gofumpt-clean。

## Why / 背景

`generateModulesGenComposition` 此前只对 cellmodule import 做 `sort.Strings`，而 `capability` / `bootstrap` / `composition` 三个 framework import 硬编码在模板里、顺序为 `capability → bootstrap → composition`，违反 gofumpt 路径字母序。后果：任何 `make generate` 重生成 `cmd/corebundle/modules_gen.go` 后的 push 被 **pre-push gofumpt gate 拦**（#2415 验证 PR #2427 时实测），须手动 `make fmt` 才能推；该 drift pre-existing 于 develop HEAD（CI PR-lane merge-base-scoped，未触及即未红）。

修复后 `capability` 落在 `bootstrap` 与 `composition` 之间，`gofumpt -l` 对该文件 **0 drift**，`gocell generate assembly --all` 幂等无残留。

**为什么按路径整体排序而非只把模板三行重排**：`g.moduleOf(ref)` 是 cross-module funnel（external-repo 开发 #1083），external module 的 cellmodule 路径可能排在 `framework/*` 之后，"cellmodules 块在前、framework 块在后" 的假设会破；且 cellmodule 行带 alias、framework 行裸路径，对渲染行做 string sort 不匹配路径序。故收口到新 helper `compositionImportLines`，把全部 import 收进 `(path, line)` 列表按 `path` 排序。

## Refs

- Closes #2429
- 架构锚点：`tools/codegen/render.go` `FormatGoSource`（"single producer-side formatter outlet"，goimports→gofumpt）——本 PR 让 assembly 生成器的 emit 结果与该 funnel 等价（path-canonical），但**未**把 assembly 接回该 funnel（见下「不在本 PR 范围」）。

## Risk / 兼容性

无。改动面：① 生成器内部 helper（无对外签名变更）；② 模板 import 块 collapse 成单一 range；③ 重生成 `cmd/corebundle/modules_gen.go`（仅 import 行重排，无符号/行为变更）。无 wire / 契约 / migration 影响；无外部消费方。

**不在本 PR 范围（独立 backlog epic）**：架构根因「codegen 输出未经 `FormatGoSource` funnel、`make generate` 与 `make fmt` 解耦」跨 assembly / required-deps / saga-coverage 三个生成器（后两者仅用 `go/format`、无 gofumpt）。统一过 funnel + archtest 强制属 issue「重构」档，跨三生成器，inline 进本 Cx2 = scope creep。本 PR 用「path-canonical emit + golden 字节锁」保证 assembly 结果属性。

## Implementation matrix

| 变更 | contract | generated | cell/slice | tests | docs |
|------|----------|-----------|------------|-------|------|
| import 路径整体排序 | — | `cmd/corebundle/modules_gen.go`（重生成，import 重排） | — | `generator_modulesgen_test.go`（顺序断言）+ `generator_deploymenttopology_test.go`（golden 加 capability fixture 字节锁）+ `generator_crossmodule_test.go`（cross-module 路径晚于 framework 的排序覆盖 + 整块升序 anti-vacuity） | — |

## 内置 review（六维度）

1 reviewer，IN_SCOPE finding 1 条已修：cross-module 排序覆盖盲点（既有 acme fixture 字母序早于 ghbvf，未覆盖 cellmodule 路径晚于 framework 的关键场景）→ 新增 `TestGenerateModulesGen_CrossModuleImportPathSortOrder` + `assertImportBlockSorted`，anti-vacuity 对 HEAD~1 pre-fix 实证 RED。其余 3 条均 P3/Cx1 OUT_OF_SCOPE（named-return 风格、framework import 字面量常量化、indexOfStr 注释）——reviewer 自判非缺陷，framework 字面量项归入 root#2 funnel 重构 epic。

## Test plan

- [x] `go build ./...` 本地通过（framework + cmd/corebundle）
- [x] `go test ./framework/kernel/assembly/...` 本地通过（含 RED→GREEN 顺序断言 + golden 字节锁）
- [x] `golangci-lint run`（pinned）assembly 包 0 issues
- [x] `gofumpt -l cmd/corebundle/modules_gen.go` 0 drift（关键回归判据）
- [x] `gocell generate assembly --all` 幂等（无 "Generated:" 输出 = 无残留 drift）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
