### PR TITLE
fix(deploy): replace local RabbitMQ healthcheck probe

### DIFF
--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -47,11 +47,12 @@ services:
       RABBITMQ_DEFAULT_USER: gocell
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD:?RABBITMQ_PASSWORD required}
     healthcheck:
-      # check_port_connectivity (not ping): ping reports healthy once the Erlang
-      # node is up, BEFORE the AMQP 5672 listener binds — corebundle's eager dial
-      # would then race it and fail-close (#1940). This gates on the listener
-      # ports actually accepting.
-      test: ["CMD", "rabbitmq-diagnostics", "-q", "check_port_connectivity"]
+      # TCP probe (not rabbitmq-diagnostics ping): ping reports healthy once the
+      # Erlang node is up, BEFORE the AMQP 5672 listener binds — corebundle's
+      # eager dial would then race it and fail-close (#1940). A plain port check
+      # preserves that listener gate without spawning diagnostics Erlang VMs
+      # every few seconds during long local Docker Desktop sessions (#2437).
+      test: ["CMD", "nc", "-z", "127.0.0.1", "5672"]
       interval: 3s
       timeout: 5s
       retries: 40

--- a/tools/archtest/compose_local_rabbitmq_healthcheck_test.go
+++ b/tools/archtest/compose_local_rabbitmq_healthcheck_test.go
@@ -1,0 +1,98 @@
+//go:build archtest
+
+// INVARIANT: LOCAL-RMQ-HEALTHCHECK-TCP-PROBE-01
+//
+// deploy/docker-compose.local.yml MUST gate RabbitMQ readiness with a lightweight
+// local TCP probe against AMQP port 5672, not rabbitmq-diagnostics. The local
+// stack only needs to know that the listener is accepting connections before
+// corebundle starts; starting a full diagnostics Erlang VM every few seconds can
+// accumulate helper processes during long Docker Desktop sessions (#2437).
+//
+// AI-robust grade: Medium — content-scan over the authoritative local compose
+// file. Hard is not available because Docker Compose cannot express "this
+// specific service healthcheck command must be this token sequence" in schema.
+package archtest
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+const localRMQHealthcheckRuleID = "LOCAL-RMQ-HEALTHCHECK-TCP-PROBE-01"
+
+var localRMQExpectedHealthcheck = []string{"CMD", "nc", "-z", "127.0.0.1", "5672"}
+
+func localRabbitMQHealthcheckCommand(body []byte) ([]string, error) {
+	var doc struct {
+		Services map[string]struct {
+			Healthcheck struct {
+				Test []string `yaml:"test"`
+			} `yaml:"healthcheck"`
+		} `yaml:"services"`
+	}
+	if err := yaml.NewDecoder(bytes.NewReader(body)).Decode(&doc); err != nil {
+		return nil, fmt.Errorf("parse compose yaml: %w", err)
+	}
+	rabbitmq, ok := doc.Services["rabbitmq"]
+	if !ok {
+		return nil, fmt.Errorf("rabbitmq service missing")
+	}
+	if len(rabbitmq.Healthcheck.Test) == 0 {
+		return nil, fmt.Errorf("rabbitmq healthcheck.test missing")
+	}
+	return rabbitmq.Healthcheck.Test, nil
+}
+
+func TestLocalRabbitMQHealthcheckUsesTcpProbe(t *testing.T) {
+	root := findModuleRoot(t)
+	path := filepath.Join(root, "deploy", "docker-compose.local.yml")
+	body, err := os.ReadFile(path) //nolint:gosec // fixed repo path derived from findModuleRoot
+	require.NoError(t, err, "%s: read local compose", localRMQHealthcheckRuleID)
+
+	got, err := localRabbitMQHealthcheckCommand(body)
+	require.NoError(t, err, "%s: extract rabbitmq healthcheck", localRMQHealthcheckRuleID)
+	require.Equal(t, localRMQExpectedHealthcheck, got,
+		"%s: local RabbitMQ healthcheck must use a lightweight TCP probe "+
+			"and must not invoke rabbitmq-diagnostics",
+		localRMQHealthcheckRuleID)
+}
+
+func TestLocalRabbitMQHealthcheckCommand(t *testing.T) {
+	t.Run("extracts-command", func(t *testing.T) {
+		got, err := localRabbitMQHealthcheckCommand([]byte(`
+services:
+  rabbitmq:
+    image: rabbitmq:3-alpine
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "5672"]
+`))
+		require.NoError(t, err)
+		require.Equal(t, localRMQExpectedHealthcheck, got)
+	})
+
+	t.Run("rejects-missing-service", func(t *testing.T) {
+		_, err := localRabbitMQHealthcheckCommand([]byte(`
+services:
+  redis:
+    image: redis:7-alpine
+`))
+		require.ErrorContains(t, err, "rabbitmq service missing")
+	})
+
+	t.Run("rejects-missing-healthcheck-test", func(t *testing.T) {
+		_, err := localRabbitMQHealthcheckCommand([]byte(`
+services:
+  rabbitmq:
+    image: rabbitmq:3-alpine
+    healthcheck:
+      interval: 3s
+`))
+		require.ErrorContains(t, err, "rabbitmq healthcheck.test missing")
+	})
+}


### PR DESCRIPTION
## Summary

Replace the local RabbitMQ Docker Compose healthcheck with a lightweight TCP probe against AMQP port 5672, and add an archtest regression guard for the local compose file.

## Why / 背景

`rabbitmq-diagnostics -q check_port_connectivity` starts a diagnostics Erlang VM for each healthcheck. In long-running local Docker Desktop sessions this can leave many helper VMs around and inflate RabbitMQ container memory/PID usage. The local stack only needs to gate `corebundle` startup until AMQP 5672 accepts connections, so `nc -z 127.0.0.1 5672` preserves the readiness semantics without the diagnostics VM cost.

## Refs

Closes #2437
ref: Docker Compose healthcheck command form / RabbitMQ official `rabbitmq:3-alpine` image includes BusyBox `nc -z`

## Risk / 兼容性

No wire/API/migration impact. Local Docker startup still waits for the AMQP listener before starting `corebundle`.

## Test plan

- [x] `go test -tags=archtest ./tools/archtest -run 'TestLocalRabbitMQHealthcheck' -count=1`
- [x] `bash hack/verify-local-compose.sh`
- [x] `docker compose -f deploy/docker-compose.local.yml --project-directory . config -q` with placeholder env
- [x] `docker run --rm --entrypoint sh rabbitmq:3-alpine -c 'command -v nc && nc -z 127.0.0.1 5672; test $? -ne 127'`
- [x] `bash hack/verify-workspace.sh`
- [x] `bash hack/verify-workspace-test.sh`
- [x] `golangci-lint run --build-tags=archtest,releasesmoke ./archtest/...` in `tools` module (0 issues)
- [x] pre-push hook passed during `git push` (`pre-push: ok`)

Note: a root-level `go build ./...` is not valid in this repo because the root is a `go.work` workspace without a root `go.mod`; `hack/verify-workspace.sh` is the repository-standard per-module build gate.
