### PR TITLE
docs(archtest): remove stale SharedDeps field count

### DIFF
--- a/tools/archtest/shareddeps_fieldset_frozen_test.go
+++ b/tools/archtest/shareddeps_fieldset_frozen_test.go
@@ -49,7 +49,7 @@
 // ## Symbol inventory (lives here, not in ai-robust.md per the charter)
 //
 //   - Frozen type: github.com/ghbvf/gocell/framework/runtime/composition.SharedDeps
-//   - Frozen golden: sharedDepsFrozenExportedFields (25 exported fields)
+//   - Frozen golden: sharedDepsFrozenExportedFields
 //
 // Relationship: advances #1412 (SharedDeps Hard-ization) by covering the
 // field-set dimension. The unexported sealed-construction marker (valid) is
@@ -176,7 +176,7 @@ func TestSharedDepsFieldSetFrozen01_DetectorRejectsPerturbation(t *testing.T) {
 
 	// (c) Same field NAMES but one field RETYPED: proves that type-string drift is
 	// caught at constant field count, not just count drift. Clock is retyped from
-	// clock.Clock → string; all other 24 field names (the full golden set) are
+	// clock.Clock → string; the other golden field names are
 	// preserved so the ONLY divergence is Clock's type. This red case demonstrates
 	// that exportedFieldTypeStrings detects type-string divergence, not just
 	// field-set membership divergence.
@@ -209,7 +209,7 @@ func TestSharedDepsFieldSetFrozen01_DetectorRejectsPerturbation(t *testing.T) {
 	}
 	retyped := exportedFieldTypeStrings(reflect.TypeOf(sharedDepsRetypedClock{}))
 	assert.NotEqual(t, sharedDepsFrozenExportedFields, retyped,
-		"%s anti-vacuity (type drift): a struct with the same 25 field names but Clock "+
+		"%s anti-vacuity (type drift): a struct with the same golden field names but Clock "+
 			"retyped to string must NOT match the golden — proves type-string drift detection, "+
 			"not just field-set membership detection", ruleSharedDepsFieldSetFrozen01)
 


### PR DESCRIPTION
## Summary

删除 `sharedDepsFrozenExportedFields` 相关注释里的硬编码字段数量，避免 SharedDeps 字段集变更后 godoc 再次漂移。

## Why / 背景

#2398 指出 `tools/archtest/shareddeps_fieldset_frozen_test.go` 的 symbol inventory 仍写着 `25 exported fields`，但 reflect golden map 与实际 `composition.SharedDeps` exported fields 已经是 27。字段集单源应是 `sharedDepsFrozenExportedFields` golden map；注释里的数量是派生副本，继续保留会再次漂移。

本 PR 同步清理同文件 anti-vacuity 文案中的 `24/25 field names` 派生计数，只保留“不带数量”的 golden field names 表述。

## Refs

Closes #2398

ref: docs/references/framework-comparison.md tools/archtest reference; ArchUnit FreezingArchRule/ViolationStore; golang.org/x/tools/go/analysis/analysistest golden files

## Risk / 兼容性

无。comment-only 变更，不修改 `SharedDeps` 字段、golden map、反射比较、运行时行为或治理断言语义。

## Test plan

- [x] `go test -tags=archtest ./tools/archtest -run TestSharedDepsFieldSetFrozen01 -count=1`
- [x] `make check-build`
- [x] `git push` pre-push hook passed (`pre-push: ok`, 333s)
- [x] `make test` attempted: full run hit unrelated transient `framework/runtime/websocket TestHub_PingMissReset` timeout; reran `go test ./framework/runtime/websocket -run TestHub_PingMissReset -count=1` and `go test ./framework/runtime/websocket -count=1`, both passed.
