### PR TITLE
fix(metrics): remove provider unregister contract

### DIFF
--- a/adapters/mqtt/metrics.go
+++ b/adapters/mqtt/metrics.go
@@ -67,8 +67,8 @@ const helpCellLabel = "Label: cell = construction-time cell identifier (registra
 //
 // Returns error when p is nil, cellID is empty, or the Provider reports
 // registration failure (e.g. duplicate metric names). Registration is
-// all-or-nothing: a later failure rolls back the metric already registered so
-// the provider is not left holding a partial set.
+// startup-fatal: a later failure rejects the current wiring, and caller-owned
+// provider lifecycle handles cleanup.
 func NewProviderConnectionCollector(p metrics.Provider, cellID string) (ConnectionCollector, error) {
 	if p == nil {
 		return nil, errcode.New(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
@@ -79,25 +79,15 @@ func NewProviderConnectionCollector(p metrics.Provider, cellID string) (Connecti
 			"mqtt: cellID is required for provider connection collector")
 	}
 
-	var registered []metrics.Collector
-	rollback := func(wrapErr error) error {
-		for _, c := range registered {
-			_ = p.Unregister(c)
-		}
-		return wrapErr
-	}
-
 	reconnect, err := p.CounterVec(metrics.CounterOpts{
 		Name:       "mqtt_reconnect_total",
 		Help:       "Total MQTT reconnect events observed by the adapter. " + helpCellLabel,
 		LabelNames: []string{"cell"},
 	})
 	if err != nil {
-		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
-			"mqtt: register reconnect counter", err))
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register reconnect counter", err)
 	}
-	registered = append(registered, reconnect)
-
 	subscribeFail, err := p.CounterVec(metrics.CounterOpts{
 		Name: "mqtt_subscribe_failed_total",
 		Help: "Total number of receive-path SUBSCRIBE failures (initial SUBACK rejection or reconnect re-arm), " +
@@ -106,8 +96,8 @@ func NewProviderConnectionCollector(p metrics.Provider, cellID string) (Connecti
 		LabelNames: []string{"cell", "reason"},
 	})
 	if err != nil {
-		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
-			"mqtt: register subscribe failed counter", err))
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register subscribe failed counter", err)
 	}
 	// subscribeFail is the last registration — nothing after it can fail.
 
@@ -249,17 +239,9 @@ func NewProviderPublisherCollector(p metrics.Provider, cellID string) (Publisher
 			"mqtt: cellID is required for provider publisher collector")
 	}
 
-	// Register the three metrics with all-or-nothing semantics: if a later
-	// registration fails (e.g. a duplicate metric name), roll back the ones
-	// already registered so the provider is not left holding a partial set.
-	var registered []metrics.Collector
-	rollback := func(wrapErr error) error {
-		for _, c := range registered {
-			_ = p.Unregister(c)
-		}
-		return wrapErr
-	}
-
+	// Register the three metrics during startup wiring. If a later registration
+	// fails (e.g. a duplicate metric name), return the error and let the caller
+	// discard the current provider wiring.
 	publishTotal, err := p.CounterVec(metrics.CounterOpts{
 		Name: "mqtt_publish_total",
 		Help: "Total number of MQTT publish attempts that completed successfully (broker PUBACK received). " +
@@ -267,11 +249,9 @@ func NewProviderPublisherCollector(p metrics.Provider, cellID string) (Publisher
 		LabelNames: []string{"cell"},
 	})
 	if err != nil {
-		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
-			"mqtt: register publish total counter", err))
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register publish total counter", err)
 	}
-	registered = append(registered, publishTotal)
-
 	publishFailed, err := p.CounterVec(metrics.CounterOpts{
 		Name: "mqtt_publish_failed_total",
 		Help: "Total number of MQTT publish attempts that failed, classified by reason. " +
@@ -281,11 +261,9 @@ func NewProviderPublisherCollector(p metrics.Provider, cellID string) (Publisher
 		LabelNames: []string{"cell", "reason"},
 	})
 	if err != nil {
-		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
-			"mqtt: register publish failed counter", err))
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register publish failed counter", err)
 	}
-	registered = append(registered, publishFailed)
-
 	ackDuration, err := p.HistogramVec(metrics.HistogramOpts{
 		Name: "mqtt_publish_ack_duration_seconds",
 		Help: "End-to-end MQTT publish ack round-trip duration in seconds, from Publish() call to broker PUBACK. " +
@@ -294,12 +272,9 @@ func NewProviderPublisherCollector(p metrics.Provider, cellID string) (Publisher
 		Buckets:    mqttDurationBuckets,
 	})
 	if err != nil {
-		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
-			"mqtt: register publish ack duration histogram", err))
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register publish ack duration histogram", err)
 	}
-	// ackDuration is the last registration — nothing after it can fail, so it
-	// need not be appended to the rollback set.
-
 	return &providerPublisherCollector{
 		cellID:        cellID,
 		publishTotal:  publishTotal,
@@ -436,7 +411,7 @@ var _ SubscriberCollector = NoopSubscriberCollector{}
 //	mqtt_consume_inflight           (gauge,     labels: cell)
 //
 // ref: adapters/mqtt/metrics.go providerPublisherCollector — same inject-at-
-// construction + all-or-nothing registration pattern.
+// construction + startup-fatal registration pattern.
 type providerSubscriberCollector struct {
 	cellID          string
 	consumeTotal    metrics.CounterVec
@@ -505,8 +480,8 @@ var (
 //
 // Returns an error when p is nil, cellID is empty, or the Provider reports a
 // registration failure (e.g. duplicate metric names). Registration is
-// all-or-nothing: a later failure rolls back the metrics already registered so
-// the provider is not left holding a partial set.
+// startup-fatal: a later failure rejects the current wiring, and caller-owned
+// provider lifecycle handles cleanup.
 func NewProviderSubscriberCollector(p metrics.Provider, cellID string) (SubscriberCollector, error) {
 	if p == nil {
 		return nil, errcode.New(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
@@ -517,57 +492,36 @@ func NewProviderSubscriberCollector(p metrics.Provider, cellID string) (Subscrib
 			"mqtt: cellID is required for provider subscriber collector")
 	}
 
-	var registered []metrics.Collector
-	rollback := func(wrapErr error) error {
-		for _, c := range registered {
-			_ = p.Unregister(c)
-		}
-		return wrapErr
-	}
-
 	consumeTotal, cErr := p.CounterVec(subConsumeTotalOpts)
 	if cErr != nil {
-		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
-			"mqtt: register consume total counter", cErr))
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register consume total counter", cErr)
 	}
-	registered = append(registered, consumeTotal)
-
 	consumeFailed, cErr := p.CounterVec(subConsumeFailedOpts)
 	if cErr != nil {
-		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
-			"mqtt: register consume failed counter", cErr))
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register consume failed counter", cErr)
 	}
-	registered = append(registered, consumeFailed)
-
 	dlxTotal, cErr := p.CounterVec(subDlxTotalOpts)
 	if cErr != nil {
-		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
-			"mqtt: register dlx counter", cErr))
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register dlx counter", cErr)
 	}
-	registered = append(registered, dlxTotal)
-
 	dlxFailed, cErr := p.CounterVec(subDlxFailedOpts)
 	if cErr != nil {
-		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
-			"mqtt: register dlx failed counter", cErr))
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register dlx failed counter", cErr)
 	}
-	registered = append(registered, dlxFailed)
-
 	consumeDur, err := p.HistogramVec(subConsumeDurOpts)
 	if err != nil {
-		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
-			"mqtt: register consume duration histogram", err))
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register consume duration histogram", err)
 	}
-	registered = append(registered, consumeDur)
-
 	consumeInflight, err := p.GaugeVec(subConsumeInflightOpts)
 	if err != nil {
-		return nil, rollback(errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
-			"mqtt: register consume inflight gauge", err))
+		return nil, errcode.Wrap(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid,
+			"mqtt: register consume inflight gauge", err)
 	}
-	// consumeInflight is the last registration — nothing after it can fail, so it
-	// need not be appended to the rollback set.
-
 	return &providerSubscriberCollector{
 		cellID:          cellID,
 		consumeTotal:    consumeTotal,

--- a/adapters/mqtt/metrics_test.go
+++ b/adapters/mqtt/metrics_test.go
@@ -54,6 +54,16 @@ func TestNewProviderConnectionCollector_RegistrationFailure(t *testing.T) {
 	require.True(t, errors.As(err, &ec))
 }
 
+func TestNewProviderConnectionCollector_SubscribeFailureRegistrationFailure(t *testing.T) {
+	t.Parallel()
+	provider := &connErrProvider{err: errors.New("duplicate counter"), failAtCounter: 2}
+	_, err := NewProviderConnectionCollector(provider, "testcell")
+	require.Error(t, err)
+	var ec *errcode.Error
+	require.True(t, errors.As(err, &ec))
+	assert.Equal(t, 2, provider.counterCalls)
+}
+
 // TestProviderConnectionCollector_RecordReconnect_CounterLabel pins that
 // RecordReconnect emits exactly one Inc with label cell=testcell.
 func TestProviderConnectionCollector_RecordReconnect_CounterLabel(t *testing.T) {
@@ -124,11 +134,19 @@ func TestProviderConnectionCollector_RecordSubscribeFailure(t *testing.T) {
 // Test doubles
 // ---------------------------------------------------------------------------
 
-// connErrProvider returns a fixed error from CounterVec.
-type connErrProvider struct{ err error }
+// connErrProvider returns a fixed error from CounterVec at a configured call.
+type connErrProvider struct {
+	err           error
+	failAtCounter int
+	counterCalls  int
+}
 
-func (p *connErrProvider) CounterVec(_ metrics.CounterOpts) (metrics.CounterVec, error) {
-	return nil, p.err
+func (p *connErrProvider) CounterVec(opts metrics.CounterOpts) (metrics.CounterVec, error) {
+	p.counterCalls++
+	if p.failAtCounter == 0 || p.counterCalls == p.failAtCounter {
+		return nil, p.err
+	}
+	return metrics.NopProvider{}.CounterVec(opts)
 }
 
 func (p *connErrProvider) HistogramVec(_ metrics.HistogramOpts) (metrics.HistogramVec, error) {
@@ -138,7 +156,6 @@ func (p *connErrProvider) HistogramVec(_ metrics.HistogramOpts) (metrics.Histogr
 func (p *connErrProvider) GaugeVec(_ metrics.GaugeOpts) (metrics.GaugeVec, error) {
 	return nil, p.err
 }
-func (p *connErrProvider) Unregister(_ metrics.Collector) error { return nil }
 
 // connSpyProvider records counter registrations and Inc/Add operations.
 type connSpyProvider struct {
@@ -167,8 +184,6 @@ func (p *connSpyProvider) HistogramVec(_ metrics.HistogramOpts) (metrics.Histogr
 func (p *connSpyProvider) GaugeVec(_ metrics.GaugeOpts) (metrics.GaugeVec, error) {
 	return metrics.NopProvider{}.GaugeVec(metrics.GaugeOpts{})
 }
-
-func (p *connSpyProvider) Unregister(_ metrics.Collector) error { return nil }
 
 func (p *connSpyProvider) ops() []connSpyRecord {
 	out := make([]connSpyRecord, len(p.records))
@@ -330,6 +345,34 @@ func TestNoopPublisherCollector_Methods(t *testing.T) {
 	})
 }
 
+func TestNewProviderPublisherCollector_RegistrationFailure_ReturnsError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name          string
+		failAtCounter int
+		failHistogram bool
+	}{
+		{name: "publish_total", failAtCounter: 1},
+		{name: "publish_failed", failAtCounter: 2},
+		{name: "ack_duration", failHistogram: true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			provider := &pubRegistrationFailureProvider{
+				failAtCounter: tc.failAtCounter,
+				failHistogram: tc.failHistogram,
+			}
+			_, err := NewProviderPublisherCollector(provider, "testcell")
+			require.Error(t, err)
+			var ec *errcode.Error
+			require.True(t, errors.As(err, &ec))
+			assert.Equal(t, errcode.KindInternal, ec.Kind)
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Publisher test doubles
 // ---------------------------------------------------------------------------
@@ -363,12 +406,35 @@ func (p *pubSpyProvider) GaugeVec(_ metrics.GaugeOpts) (metrics.GaugeVec, error)
 	return metrics.NopProvider{}.GaugeVec(metrics.GaugeOpts{})
 }
 
-func (p *pubSpyProvider) Unregister(_ metrics.Collector) error { return nil }
-
 func (p *pubSpyProvider) ops() []pubSpyRecord {
 	out := make([]pubSpyRecord, len(p.records))
 	copy(out, p.records)
 	return out
+}
+
+type pubRegistrationFailureProvider struct {
+	failAtCounter int
+	failHistogram bool
+	counterCalls  int
+}
+
+func (p *pubRegistrationFailureProvider) CounterVec(opts metrics.CounterOpts) (metrics.CounterVec, error) {
+	p.counterCalls++
+	if p.failAtCounter > 0 && p.counterCalls == p.failAtCounter {
+		return nil, errors.New("duplicate counter")
+	}
+	return metrics.NopProvider{}.CounterVec(opts)
+}
+
+func (p *pubRegistrationFailureProvider) HistogramVec(opts metrics.HistogramOpts) (metrics.HistogramVec, error) {
+	if p.failHistogram {
+		return nil, errors.New("duplicate histogram")
+	}
+	return metrics.NopProvider{}.HistogramVec(opts)
+}
+
+func (p *pubRegistrationFailureProvider) GaugeVec(opts metrics.GaugeOpts) (metrics.GaugeVec, error) {
+	return metrics.NopProvider{}.GaugeVec(opts)
 }
 
 type pubSpyCounterVec struct {
@@ -465,67 +531,61 @@ func TestNewProviderSubscriberCollector_Registration(t *testing.T) {
 	require.NotNil(t, col)
 }
 
-// TestNewProviderSubscriberCollector_RegistrationFailure_RollsBack verifies that
-// a Provider returning an error from a later registration rolls back the metrics
-// already registered (all-or-nothing semantics) and wraps the error.
-func TestNewProviderSubscriberCollector_RegistrationFailure_RollsBack(t *testing.T) {
+// TestNewProviderSubscriberCollector_RegistrationFailure_ReturnsError verifies
+// that a Provider returning an error from a later registration rejects the
+// current wiring and wraps the error.
+func TestNewProviderSubscriberCollector_RegistrationFailure_ReturnsError(t *testing.T) {
 	t.Parallel()
-	// Fail on the histogram (5th registration) so all four counters
-	// (consume_total, consume_failed, dlx_total, dlx_failed) were registered and
-	// must be unregistered. The gauge (6th) is never reached.
-	spy := &subRollbackProvider{failHistogram: true}
+	spy := &subRegistrationFailureProvider{failHistogram: true}
 	_, err := NewProviderSubscriberCollector(spy, "testcell")
 	require.Error(t, err)
 	var ec *errcode.Error
 	require.True(t, errors.As(err, &ec))
-	assert.Equal(t, 4, spy.unregisterCount, "all four counters must be rolled back on histogram failure")
+	assert.Equal(t, 4, spy.counterCount, "all four counters should be attempted before histogram failure")
 }
 
-// TestNewProviderSubscriberCollector_GaugeRegistrationFailure_RollsBack verifies
-// that a failure on the gauge (the last, 6th registration) rolls back the 4
-// counters + histogram already registered (5 total).
-func TestNewProviderSubscriberCollector_GaugeRegistrationFailure_RollsBack(t *testing.T) {
+// TestNewProviderSubscriberCollector_GaugeRegistrationFailure_ReturnsError
+// verifies that a failure on the gauge rejects the current wiring and wraps the
+// error.
+func TestNewProviderSubscriberCollector_GaugeRegistrationFailure_ReturnsError(t *testing.T) {
 	t.Parallel()
-	spy := &subRollbackProvider{failGauge: true}
+	spy := &subRegistrationFailureProvider{failGauge: true}
 	_, err := NewProviderSubscriberCollector(spy, "testcell")
 	require.Error(t, err)
 	var ec *errcode.Error
 	require.True(t, errors.As(err, &ec))
 	assert.Equal(t, errcode.KindInternal, ec.Kind)
-	assert.Equal(t, 5, spy.unregisterCount,
-		"4 counters + histogram must be rolled back on gauge failure")
+	assert.Equal(t, 4, spy.counterCount, "all four counters should be attempted before gauge failure")
 }
 
-// TestNewProviderSubscriberCollector_CounterRegistrationFailure_RollsBack covers
+// TestNewProviderSubscriberCollector_CounterRegistrationFailure_ReturnsError covers
 // each of the four counter registration error branches: when the Nth CounterVec
-// call fails, the N-1 already-registered counters must be unregistered (rollback)
-// and the error wrapped as an errcode.Error. Pins the per-counter failure paths
-// (consume_total / consume_failed / dlx_total / dlx_failed) that the inlined
-// errcode.Wrap branches introduced.
-func TestNewProviderSubscriberCollector_CounterRegistrationFailure_RollsBack(t *testing.T) {
+// call fails, the error is wrapped as an errcode.Error. Pins the per-counter
+// failure paths (consume_total / consume_failed / dlx_total / dlx_failed) that
+// the inlined errcode.Wrap branches introduced.
+func TestNewProviderSubscriberCollector_CounterRegistrationFailure_ReturnsError(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name             string
-		failAtCounter    int // 1-based: fail the Nth CounterVec call
-		wantUnregistered int // counters registered before the failing one
+		name          string
+		failAtCounter int // 1-based: fail the Nth CounterVec call
 	}{
-		{"consume_total", 1, 0},
-		{"consume_failed", 2, 1},
-		{"dlx_total", 3, 2},
-		{"dlx_failed", 4, 3},
+		{"consume_total", 1},
+		{"consume_failed", 2},
+		{"dlx_total", 3},
+		{"dlx_failed", 4},
 	}
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			spy := &subRollbackProvider{failAtCounter: tc.failAtCounter}
+			spy := &subRegistrationFailureProvider{failAtCounter: tc.failAtCounter}
 			_, err := NewProviderSubscriberCollector(spy, "testcell")
 			require.Error(t, err)
 			var ec *errcode.Error
 			require.True(t, errors.As(err, &ec))
 			assert.Equal(t, errcode.KindInternal, ec.Kind)
-			assert.Equal(t, tc.wantUnregistered, spy.unregisterCount,
-				"counters registered before the failing one must be rolled back")
+			assert.Equal(t, tc.failAtCounter, spy.counterCount,
+				"counter registration should stop at the failing call")
 		})
 	}
 }
@@ -720,21 +780,20 @@ func TestNoopSubscriberCollector_Methods(t *testing.T) {
 // Subscriber test doubles
 // ---------------------------------------------------------------------------
 
-// subRollbackProvider registers metrics successfully until a configured failure
-// point, recording how many Unregister calls the rollback issues. Registration
-// order is 4 counters → histogram → gauge. failAtCounter (1-based, 0=disabled)
+// subRegistrationFailureProvider registers metrics successfully until a configured failure
+// point. Registration order is 4 counters → histogram → gauge. failAtCounter
+// (1-based, 0=disabled)
 // fails the Nth CounterVec call; failHistogram fails the histogram (after all 4
 // counters); failGauge fails the gauge (after the 4 counters + histogram) so the
 // last-registration error branch is exercised.
-type subRollbackProvider struct {
-	failHistogram   bool
-	failGauge       bool
-	failAtCounter   int
-	counterCount    int
-	unregisterCount int
+type subRegistrationFailureProvider struct {
+	failHistogram bool
+	failGauge     bool
+	failAtCounter int
+	counterCount  int
 }
 
-func (p *subRollbackProvider) CounterVec(opts metrics.CounterOpts) (metrics.CounterVec, error) {
+func (p *subRegistrationFailureProvider) CounterVec(opts metrics.CounterOpts) (metrics.CounterVec, error) {
 	p.counterCount++
 	if p.failAtCounter > 0 && p.counterCount == p.failAtCounter {
 		return nil, errors.New("duplicate counter")
@@ -742,23 +801,18 @@ func (p *subRollbackProvider) CounterVec(opts metrics.CounterOpts) (metrics.Coun
 	return &subSpyCounterVec{name: opts.Name, labelNames: opts.LabelNames}, nil
 }
 
-func (p *subRollbackProvider) HistogramVec(opts metrics.HistogramOpts) (metrics.HistogramVec, error) {
+func (p *subRegistrationFailureProvider) HistogramVec(opts metrics.HistogramOpts) (metrics.HistogramVec, error) {
 	if p.failHistogram {
 		return nil, errors.New("duplicate histogram")
 	}
 	return metrics.NopProvider{}.HistogramVec(opts)
 }
 
-func (p *subRollbackProvider) GaugeVec(opts metrics.GaugeOpts) (metrics.GaugeVec, error) {
+func (p *subRegistrationFailureProvider) GaugeVec(opts metrics.GaugeOpts) (metrics.GaugeVec, error) {
 	if p.failGauge {
 		return nil, errors.New("duplicate gauge")
 	}
 	return metrics.NopProvider{}.GaugeVec(opts)
-}
-
-func (p *subRollbackProvider) Unregister(_ metrics.Collector) error {
-	p.unregisterCount++
-	return nil
 }
 
 type subSpyRecord struct {
@@ -791,8 +845,6 @@ func (p *subSpyProvider) GaugeVec(opts metrics.GaugeOpts) (metrics.GaugeVec, err
 	p.gaugeRegs = append(p.gaugeRegs, opts)
 	return &subSpyGaugeVec{parent: p, name: opts.Name, labelNames: opts.LabelNames}, nil
 }
-
-func (p *subSpyProvider) Unregister(_ metrics.Collector) error { return nil }
 
 func (p *subSpyProvider) ops() []subSpyRecord {
 	out := make([]subSpyRecord, len(p.records))

--- a/adapters/oidc/metrics_test.go
+++ b/adapters/oidc/metrics_test.go
@@ -137,8 +137,6 @@ func (p *refreshErrProvider) GaugeVec(_ metrics.GaugeOpts) (metrics.GaugeVec, er
 	return nil, p.err
 }
 
-func (p *refreshErrProvider) Unregister(_ metrics.Collector) error { return nil }
-
 // refreshSpyProvider records counter registrations and Inc/Add operations so
 // tests can assert exact metric emissions without a real backend.
 type refreshSpyProvider struct {
@@ -169,8 +167,6 @@ func (p *refreshSpyProvider) HistogramVec(_ metrics.HistogramOpts) (metrics.Hist
 func (p *refreshSpyProvider) GaugeVec(_ metrics.GaugeOpts) (metrics.GaugeVec, error) {
 	return metrics.NopProvider{}.GaugeVec(metrics.GaugeOpts{})
 }
-
-func (p *refreshSpyProvider) Unregister(_ metrics.Collector) error { return nil }
 
 func (p *refreshSpyProvider) ops() []refreshSpyRecord {
 	out := make([]refreshSpyRecord, len(p.records))

--- a/adapters/otel/metric_provider.go
+++ b/adapters/otel/metric_provider.go
@@ -126,12 +126,6 @@ func (p *MetricProvider) GaugeVec(opts metrics.GaugeOpts) (metrics.GaugeVec, err
 	}, nil
 }
 
-// Unregister is a no-op for the OTel provider. OTel instruments are
-// registered with the MeterProvider at SDK level; individual instrument
-// deregistration is not part of the OTel API. Returns nil (idempotent,
-// per the Unregister contract).
-func (p *MetricProvider) Unregister(_ metrics.Collector) error { return nil }
-
 // HistogramVec creates a Float64Histogram. Explicit Buckets propagate
 // to OTel as aggregation preferences; callers that want richer aggregation
 // (exponential, quantile) must build their MeterProvider with the relevant

--- a/adapters/prometheus/metric_provider.go
+++ b/adapters/prometheus/metric_provider.go
@@ -35,10 +35,6 @@ type MetricProviderConfig struct {
 // *prom.Registry. Every CounterVec/HistogramVec returned is registered on
 // the configured registry; duplicate registration surfaces as an
 // ErrAdapterPromRegister error, not a panic.
-//
-// Unregister is safe for concurrent use: it uses a RWMutex to protect the
-// internal registry-to-collector map so rollback from NewProviderRelayCollector
-// can be called from any goroutine.
 type MetricProvider struct {
 	cfg  MetricProviderConfig
 	mu   sync.RWMutex
@@ -199,28 +195,6 @@ func (p *MetricProvider) HistogramVec(opts metrics.HistogramOpts) (metrics.Histo
 	p.vecs[vec] = hv
 	p.mu.Unlock()
 	return vec, nil
-}
-
-// Unregister removes a previously registered collector from the Prometheus
-// registry. It is idempotent — passing an unknown Collector (or one already
-// unregistered) returns nil. Concurrent calls are safe.
-//
-// ref: prometheus/client_golang prometheus/registry.go — Registry.Unregister
-// returns bool; we convert "not found" to nil so callers treat it as a no-op.
-func (p *MetricProvider) Unregister(c metrics.Collector) error {
-	p.mu.Lock()
-	promColl, ok := p.vecs[c]
-	if ok {
-		delete(p.vecs, c)
-	}
-	p.mu.Unlock()
-
-	if !ok {
-		// Idempotent: collector was never registered or already removed.
-		return nil
-	}
-	p.cfg.Registry.Unregister(promColl)
-	return nil
 }
 
 type promCounterVec struct {

--- a/adapters/prometheus/metric_provider_test.go
+++ b/adapters/prometheus/metric_provider_test.go
@@ -200,93 +200,10 @@ func TestMetricProvider_NilRegistryRejected(t *testing.T) {
 	}
 }
 
-// TestMetricProvider_Unregister_RemovesAndAllowsReregister verifies the K2
-// atomic-registration rollback contract: Unregister removes a previously
-// registered Collector from both the Provider's internal map and the
-// underlying Prometheus registry, allowing the same name to be registered
-// again without "duplicate collector" error.
-//
-// Without this behavior, the NewProviderRelayCollector rollback loop would
-// leak orphan Prometheus collectors on partial failure and refuse retry.
-func TestMetricProvider_Unregister_RemovesAndAllowsReregister(t *testing.T) {
-	p, reg := newTestProvider(t)
-
-	cv, err := p.CounterVec(metrics.CounterOpts{
-		Name:       "unreg_demo_total",
-		Help:       "demo",
-		LabelNames: []string{"label"},
-	})
-	if err != nil {
-		t.Fatalf("CounterVec: %v", err)
-	}
-
-	// Registering the same name again returns the existing collector (idempotent),
-	// not an error. This is by design — see TestMetricProvider_RegisterDuplicateReturnsExisting.
-	if _, err := p.CounterVec(metrics.CounterOpts{
-		Name:       "unreg_demo_total",
-		Help:       "demo",
-		LabelNames: []string{"label"},
-	}); err != nil {
-		t.Fatalf("duplicate CounterVec should return existing collector, got error: %v", err)
-	}
-
-	// Unregister the first vec. Same name must now be re-registrable.
-	if err := p.Unregister(cv); err != nil {
-		t.Fatalf("Unregister: %v", err)
-	}
-	cv2, err := p.CounterVec(metrics.CounterOpts{
-		Name:       "unreg_demo_total",
-		Help:       "demo",
-		LabelNames: []string{"label"},
-	})
-	if err != nil {
-		t.Fatalf("re-register after Unregister: %v", err)
-	}
-
-	// Touch the new vec so Prometheus Gather emits a sample, then confirm
-	// exactly one family — the registry is in sync with no stale entries.
-	cv2.With(metrics.Labels{"label": "v"}).Inc(context.Background())
-	families, err := reg.Gather()
-	if err != nil {
-		t.Fatalf("Gather: %v", err)
-	}
-	var seen int
-	for _, f := range families {
-		if strings.HasSuffix(f.GetName(), "unreg_demo_total") {
-			seen++
-		}
-	}
-	if seen != 1 {
-		t.Fatalf("expected exactly 1 unreg_demo_total metric family after re-register, got %d", seen)
-	}
-}
-
-// TestMetricProvider_Unregister_IdempotentOnUnknown verifies Unregister
-// returns nil when called with a Collector never registered with this
-// Provider — required by the Provider.Unregister contract (idempotent,
-// nil-safe for double-unregister and orphan collectors).
-func TestMetricProvider_Unregister_IdempotentOnUnknown(t *testing.T) {
-	p, _ := newTestProvider(t)
-
-	cv, err := p.CounterVec(metrics.CounterOpts{
-		Name: "known_total", Help: "h", LabelNames: []string{"x"},
-	})
-	if err != nil {
-		t.Fatalf("CounterVec: %v", err)
-	}
-	if err := p.Unregister(cv); err != nil {
-		t.Fatalf("first Unregister: %v", err)
-	}
-	// Second call must also return nil (idempotent).
-	if err := p.Unregister(cv); err != nil {
-		t.Fatalf("double Unregister must be idempotent, got %v", err)
-	}
-}
-
 // TestMetricProvider_Registered_AlwaysTrue locks in the documented marker
 // semantics of Collector.Registered: the method is a compile-time type-
 // membership marker and always returns true for vecs issued by the Provider,
-// even after Unregister. It is not a runtime state probe.
+// across the Provider lifetime. It is not a runtime state probe.
 func TestMetricProvider_Registered_AlwaysTrue(t *testing.T) {
 	p, _ := newTestProvider(t)
 
@@ -304,21 +221,17 @@ func TestMetricProvider_Registered_AlwaysTrue(t *testing.T) {
 	}
 
 	if !cv.Registered() {
-		t.Error("counter vec Registered() must be true before Unregister")
+		t.Error("counter vec Registered() must be true for provider-created vec")
 	}
 	if !hv.Registered() {
-		t.Error("histogram vec Registered() must be true before Unregister")
+		t.Error("histogram vec Registered() must be true for provider-created vec")
 	}
 
-	// Per the marker contract, Registered remains true post-Unregister; the
-	// registry state changes but the vec value identity does not.
-	_ = p.Unregister(cv)
-	_ = p.Unregister(hv)
 	if !cv.Registered() {
-		t.Error("counter vec Registered() must still be true after Unregister (marker semantics)")
+		t.Error("counter vec Registered() must remain true (marker semantics)")
 	}
 	if !hv.Registered() {
-		t.Error("histogram vec Registered() must still be true after Unregister (marker semantics)")
+		t.Error("histogram vec Registered() must remain true (marker semantics)")
 	}
 }
 
@@ -724,9 +637,9 @@ func TestMetricProvider_ConcurrentCounterVec_RaceDetector(t *testing.T) {
 	if got != 1 {
 		t.Fatalf("expected exactly 1 series after concurrent register, got %d", got)
 	}
-	// Verify sum so a regression where Inc dropped writes (e.g. a future
-	// per-call register/unregister bug) does not pass with series-count
-	// alone. Gather() walks the registry directly — the abstracted
+	// Verify sum so a regression where Inc dropped writes (e.g. future
+	// per-call registry churn) does not pass with series-count alone.
+	// Gather() walks the registry directly — the abstracted
 	// metrics.Counter does not implement prom.Collector so testutil.ToFloat64
 	// is not directly applicable here.
 	gathered, err := reg.Gather()
@@ -862,48 +775,6 @@ func TestMetricProvider_GaugeVec_LabelMismatch_RegisterError(t *testing.T) {
 	}
 }
 
-// TestMetricProvider_GaugeVec_Unregister verifies that Unregister removes a
-// GaugeVec from both the provider's internal map and the Prometheus registry,
-// allowing the same name to be re-registered without conflict.
-func TestMetricProvider_GaugeVec_Unregister(t *testing.T) {
-	p, reg := newTestProvider(t)
-
-	gv, err := p.GaugeVec(metrics.GaugeOpts{
-		Name:       "unreg_gauge",
-		Help:       "h",
-		LabelNames: []string{"k"},
-	})
-	if err != nil {
-		t.Fatalf("GaugeVec: %v", err)
-	}
-	if err := p.Unregister(gv); err != nil {
-		t.Fatalf("Unregister: %v", err)
-	}
-	// Re-register: must succeed (no AlreadyRegisteredError from the prom registry).
-	gv2, err := p.GaugeVec(metrics.GaugeOpts{
-		Name:       "unreg_gauge",
-		Help:       "h",
-		LabelNames: []string{"k"},
-	})
-	if err != nil {
-		t.Fatalf("re-register after Unregister: %v", err)
-	}
-	gv2.With(metrics.Labels{"k": "v"}).Set(context.Background(), 1)
-	families, err := reg.Gather()
-	if err != nil {
-		t.Fatalf("Gather: %v", err)
-	}
-	var seen int
-	for _, f := range families {
-		if strings.HasSuffix(f.GetName(), "unreg_gauge") {
-			seen++
-		}
-	}
-	if seen != 1 {
-		t.Fatalf("expected exactly 1 unreg_gauge metric family after re-register, got %d", seen)
-	}
-}
-
 // TestMetricProvider_ConcurrentGaugeVec_RaceDetector verifies that N goroutines
 // concurrently calling GaugeVec + With + Set are race-free under the -race
 // detector. Exercises the registerOrReuse AlreadyRegisteredError path under
@@ -993,18 +864,16 @@ func (s singletonGauge) Collect(ch chan<- prom.Metric) {
 }
 
 // ---------------------------------------------------------------------------
-// TestMetricProvider_ConcurrentRegisterAndUnregister_RaceDetector (counter)
+// TestMetricProvider_ConcurrentRegister_RaceDetector (counter)
 // ---------------------------------------------------------------------------
 
-// TestMetricProvider_ConcurrentRegisterAndUnregister_RaceDetector verifies
-// that interleaved CounterVec / Unregister calls do not race on the
-// provider's internal vecs map (the RWMutex contract). Each goroutine
-// registers a uniquely-named CounterVec and then unregisters it, with N
-// goroutines running concurrently. The race detector must observe no data
-// race on the vecs map's read/write boundary.
+// TestMetricProvider_ConcurrentRegister_RaceDetector verifies that concurrent
+// CounterVec registration and recording do not race on the provider's internal
+// vecs map. Each goroutine registers a uniquely-named CounterVec and records a
+// sample. The race detector must observe no data race on the vecs map boundary.
 //
 // Run with `go test -race`.
-func TestMetricProvider_ConcurrentRegisterAndUnregister_RaceDetector(t *testing.T) {
+func TestMetricProvider_ConcurrentRegister_RaceDetector(t *testing.T) {
 	p, reg := newTestProvider(t)
 
 	var wg sync.WaitGroup
@@ -1024,26 +893,25 @@ func TestMetricProvider_ConcurrentRegisterAndUnregister_RaceDetector(t *testing.
 				return
 			}
 			cv.With(metrics.Labels{"k": "v"}).Inc(context.Background())
-			if err := p.Unregister(cv); err != nil {
-				firstErr.CompareAndSwap(nil, err)
-			}
 		}(i)
 	}
 	wg.Wait()
 
 	if err := firstErr.Load(); err != nil {
-		t.Fatalf("concurrent register/unregister returned error: %v", err)
+		t.Fatalf("concurrent register returned error: %v", err)
 	}
 
-	// After all unregisters complete, Gather must succeed without panicking.
 	families, err := reg.Gather()
 	if err != nil {
-		t.Fatalf("Gather after concurrent unregister: %v", err)
+		t.Fatalf("Gather after concurrent register: %v", err)
 	}
-	// All unique_total_* series should be gone.
+	var seen int
 	for _, mf := range families {
 		if strings.HasPrefix(mf.GetName(), "gocelltest_unique_total_") {
-			t.Fatalf("unique_total series leaked after unregister: %s", mf.GetName())
+			seen++
 		}
+	}
+	if seen != raceConcurrency {
+		t.Fatalf("unique_total series count = %d, want %d", seen, raceConcurrency)
 	}
 }

--- a/adapters/rabbitmq/publisher_metrics_test.go
+++ b/adapters/rabbitmq/publisher_metrics_test.go
@@ -141,8 +141,6 @@ func (p *errProvider) GaugeVec(_ metrics.GaugeOpts) (metrics.GaugeVec, error) {
 	return nil, p.err
 }
 
-func (p *errProvider) Unregister(_ metrics.Collector) error { return nil }
-
 // publisherSpyProvider records counter registrations and Inc/Add operations so
 // tests can assert exact metric emissions without depending on a real
 // Prometheus or OTel backend.
@@ -174,8 +172,6 @@ func (p *publisherSpyProvider) HistogramVec(_ metrics.HistogramOpts) (metrics.Hi
 func (p *publisherSpyProvider) GaugeVec(_ metrics.GaugeOpts) (metrics.GaugeVec, error) {
 	return metrics.NopProvider{}.GaugeVec(metrics.GaugeOpts{})
 }
-
-func (p *publisherSpyProvider) Unregister(_ metrics.Collector) error { return nil }
 
 func (p *publisherSpyProvider) ops() []spyCounterRecord {
 	out := make([]spyCounterRecord, len(p.records))

--- a/adapters/vault/metrics_recording_test.go
+++ b/adapters/vault/metrics_recording_test.go
@@ -3,7 +3,7 @@ package vault
 // metrics_recording_test.go — adapter-local in-memory metrics.Provider for vault
 // unit tests. Records counter/gauge values so tests assert recorded values without
 // importing adapters/prometheus (#1909). Embeds NopProvider for the
-// HistogramVec/Unregister methods vault never records through. Vecs are stateless
+// HistogramVec method vault never records through. Vecs are stateless
 // handles over a shared sample store keyed by fully-qualified name + sorted-label
 // blob, so a 2nd NewTransitMetrics on the SAME provider reuses the same sample
 // keys (register-once parity) — counters keep accumulating and gauges retain their
@@ -21,7 +21,7 @@ import (
 // recordingProvider is an in-memory, concurrency-safe metrics.Provider for vault
 // unit tests. It records counter/gauge values so tests assert recorded values
 // without importing adapters/prometheus (#1909). It embeds NopProvider for the
-// HistogramVec/Unregister methods vault never records through. Vecs are stateless
+// HistogramVec method vault never records through. Vecs are stateless
 // handles over a shared sample store keyed by fully-qualified name + sorted-label
 // blob, so a 2nd NewTransitMetrics on the SAME provider reuses the same sample
 // keys (register-once parity) — counters keep accumulating and gauges retain

--- a/cellmodules/accesscore/session_cache_test.go
+++ b/cellmodules/accesscore/session_cache_test.go
@@ -20,7 +20,7 @@ import (
 
 // counterNameSpy is a minimal kernelmetrics.Provider that records counter
 // names registered by NewSessionCacheCollector. HistogramVec/GaugeVec
-// delegate to NopProvider; Unregister is a no-op.
+// delegate to NopProvider.
 type counterNameSpy struct {
 	counterNames map[string]struct{}
 }
@@ -41,8 +41,6 @@ func (s *counterNameSpy) HistogramVec(opts kernelmetrics.HistogramOpts) (kernelm
 func (s *counterNameSpy) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetrics.GaugeVec, error) {
 	return kernelmetrics.NopProvider{}.GaugeVec(opts)
 }
-
-func (s *counterNameSpy) Unregister(_ kernelmetrics.Collector) error { return nil }
 
 // spyNopCounterVec is a minimal CounterVec that satisfies the interface.
 type spyNopCounterVec struct{}

--- a/cellmodules/configcore/key_provider_internal_test.go
+++ b/cellmodules/configcore/key_provider_internal_test.go
@@ -24,7 +24,7 @@ var nopMetricsProvider = kernelmetrics.NopProvider{}
 // registration LOCALITY without a real registry or network: only the
 // vault-transit branch constructs adapters/vault.TransitMetrics, so only that
 // branch may touch the provider. The embedded NopProvider supplies the rest of
-// the metrics.Provider surface (HistogramVec / Unregister) and returns working
+// the metrics.Provider surface (HistogramVec) and returns working
 // nop instruments, so NewTransitMetrics' .With(Labels{}) calls still succeed.
 type recordingMetricsProvider struct {
 	kernelmetrics.NopProvider

--- a/docs/architecture/202604252235-001-metrics-provider-abstraction-in-kernel.md
+++ b/docs/architecture/202604252235-001-metrics-provider-abstraction-in-kernel.md
@@ -16,8 +16,8 @@ GoCell 分层依赖规则（CLAUDE.md "依赖规则"）规定：
 - `cells/` 依赖 `kernel/` + `runtime/`
 - `adapters/` 实现 `kernel/` 或 `runtime/` 定义的接口
 
-Metrics 抽象（`Provider / CounterVec / HistogramVec / Counter / Histogram`）当前位于
-`kernel/observability/metrics/`，被以下模块共用：
+Metrics 抽象（`Provider / CounterVec / HistogramVec / GaugeVec / Counter / Histogram / Gauge`）
+当前位于 `kernel/observability/metrics/`，被以下模块共用：
 
 | 消费方 | 用途 |
 |---|---|
@@ -59,9 +59,16 @@ dropped counter，同样是 kernel-internal 消费。
 
 ### 3. 接口最小，不耦合任何后端
 
-`Provider` 仅声明 `CounterVec(opts) CounterVec`、`HistogramVec(opts) HistogramVec`、
-`Unregister(c Collector) bool` 三个方法，不引用 `prometheus/*` 或 `go.opentelemetry.io/*`
-任何类型。kernel 层声明纯抽象 + NopProvider 默认实现，符合"kernel 是底座灵魂"角色定位。
+`Provider` 只暴露 **create-only** 的注册工厂（`CounterVec` / `HistogramVec` / `GaugeVec`，
+各返回 typed vec + `error`），不引用 `prometheus/*` 或 `go.opentelemetry.io/*` 任何类型；
+生命周期归 concrete backend wiring（Prometheus Registry / OTel MeterProvider），Provider
+不暴露 per-instrument 注销。kernel 层声明纯抽象 + NopProvider 默认实现，符合"kernel 是底座
+灵魂"角色定位。
+
+> 接口的**精确**方法集 / 签名以单源 `kernel/observability/metrics/metrics.go` 的 `Provider`
+> 声明为准，本 ADR 不再内联复制签名快照（早期内联快照随代码演进漂移正是本节被 amend 的原因，
+> 见 §Amendments）。`GaugeVec` 的引入与 funnel 守卫见 ADR
+> `202605191500-adr-metrics-gaugevec-funnel.md`。
 
 ### 4. adapter 在外侧实现，依赖方向正确
 
@@ -126,6 +133,30 @@ cmd/corebundle/metrics.go
   - `kernel/outbox/emitter.go`（`gocell_outbox_emit_failopen_dropped_total` Name 字段）
   - `runtime/bootstrap/shutdown_metrics.go`（`gocell_bootstrap_shutdown_*` Name 字段）
   - `kernel/assembly/hook_dispatcher.go`（`gocell_assembly_hook_*` Name 字段）
+
+---
+
+## Amendments
+
+### 2026-06-20 — Provider 收敛为 create-only，移除 `Unregister`（#880）
+
+`Provider` 删除早期内联记录的 `Unregister(c Collector) bool` 方法，接口收敛为 create-only：
+注册工厂 `CounterVec` / `HistogramVec` / `GaugeVec` 在启动期一次性注册，失败按 fatal wiring
+error 处理；instrument 生命周期不再由 Provider 表达，而归 concrete backend
+（Prometheus `Registry` / OTel `MeterProvider`）所有。
+
+动机是 provider-neutral 合约不应承诺 per-instrument 注销——两个后端的生命周期模型本就不一致：
+
+- **OpenTelemetry Go**：同步 instrument 由 `Meter` 创建后直接记录，没有 per-instrument
+  注销；只有异步 callback 的 `Registration` 暴露 `Unregister`。
+- **Prometheus client_golang**：`Unregister` 是 `Registry`/`Registerer` 级的 collector
+  lifecycle 能力，作用于注册表而非单个 instrument。
+
+把一个无法跨后端一致实现的 per-instrument 注销塞进中立接口，只会逼适配层做语义不对齐的
+模拟。kernel 内既有消费方均为启动期一次性注册，无运行期注销需求，故直接移除。
+
+本次同时把 §Rationale.3 由「内联签名快照」改为「指向单源代码 + GaugeVec ADR」，根除快照随
+代码漂移的复发面（本 ADR 此前还遗漏了后续 `GaugeVec` 的加入与工厂的 `error` 返回形状）。
 
 ---
 

--- a/examples/iotdevice/cells/devicecell/command_sweep_behavior_test.go
+++ b/examples/iotdevice/cells/devicecell/command_sweep_behavior_test.go
@@ -207,7 +207,6 @@ func (p *recordingProvider) HistogramVec(metrics.HistogramOpts) (metrics.Histogr
 func (p *recordingProvider) GaugeVec(metrics.GaugeOpts) (metrics.GaugeVec, error) {
 	return recNopGaugeVec{}, nil
 }
-func (p *recordingProvider) Unregister(metrics.Collector) error { return nil }
 
 func (p *recordingProvider) counterValue(name string, l metrics.Labels) int64 {
 	p.mu.Lock()

--- a/examples/iotdevice/cells/devicecell/slices/devicecertcompletion/service_test.go
+++ b/examples/iotdevice/cells/devicecell/slices/devicecertcompletion/service_test.go
@@ -461,8 +461,6 @@ func (p *counterSpyProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetri
 	return kernelmetrics.NopProvider{}.GaugeVec(opts)
 }
 
-func (p *counterSpyProvider) Unregister(_ kernelmetrics.Collector) error { return nil }
-
 type counterSpyVec struct {
 	parent     *counterSpyProvider
 	name       string

--- a/framework/kernel/assembly/hook_dispatcher_test.go
+++ b/framework/kernel/assembly/hook_dispatcher_test.go
@@ -82,8 +82,7 @@ func (s *spyCounterVec) count(reason string) int {
 	return s.v[reason]
 }
 
-// Registered satisfies metrics.Collector so spyCounterVec can be
-// passed to Provider.Unregister in rollback scenarios.
+// Registered satisfies metrics.Collector for the shared vec interface.
 func (s *spyCounterVec) Registered() bool { return true }
 
 // spyProvider satisfies metrics.Provider and returns a captured CounterVec
@@ -105,10 +104,6 @@ func (p *spyProvider) GaugeVec(_ metrics.GaugeOpts) (metrics.GaugeVec, error) {
 	// Unused by the dispatcher but required for the Provider contract.
 	return metrics.NopProvider{}.GaugeVec(metrics.GaugeOpts{})
 }
-
-// Unregister is a no-op for the spy; tests that care about rollback use
-// the failingProvider in relay_collector_test.go instead.
-func (p *spyProvider) Unregister(_ metrics.Collector) error { return nil }
 
 // blockingObserver blocks on OnHookEvent until the test calls release().
 // Used to exercise slow-sink scenarios deterministically. release() is

--- a/framework/kernel/observability/metrics/metrics.go
+++ b/framework/kernel/observability/metrics/metrics.go
@@ -29,16 +29,8 @@ import (
 )
 
 // Collector is a handle to a registered metric family (counter, histogram, or
-// gauge vec). It is returned by CounterVec/HistogramVec/GaugeVec and accepted by
-// Unregister.
-//
-// Callers obtain Collector values only via Provider.CounterVec and
-// Provider.HistogramVec; passing other values to Unregister is undefined
-// behavior (implementations may silently no-op or return an error).
-//
-// CounterVec, HistogramVec, and GaugeVec all embed Collector so that the return
-// values of CounterVec/HistogramVec/GaugeVec can be passed directly to
-// Unregister without explicit type assertions.
+// gauge vec). It is returned by CounterVec/HistogramVec/GaugeVec and used only
+// through the typed vec interfaces below.
 //
 // ref: prometheus/client_golang prometheus/collector.go — Collector is the
 // registration unit. GoCell's Collector is a thinner typed handle that keeps
@@ -46,9 +38,8 @@ import (
 type Collector interface {
 	// Registered is a compile-time type-membership marker, not a runtime
 	// state probe. It always returns true for vecs returned by a Provider;
-	// after Unregister, implementations may still return true because the
-	// collector value itself remains valid — the change is only in the
-	// Provider's registry state, not the vec's identity.
+	// Collector does not expose registry lifecycle; provider shutdown or
+	// replacement is owned by the concrete backend wiring.
 	//
 	// All concrete vec types (prom, otel, nop, test spy) implement this
 	// method; external code must not implement Collector directly.
@@ -60,9 +51,11 @@ type Collector interface {
 // value; at wire time (runtime/bootstrap, cmd/*), a concrete backend is
 // chosen and passed through.
 //
-// Registration is failable (duplicate names, invalid options) so both
-// factory methods return (vec, error). Callers are expected to register
-// at start-up and treat errors as fatal.
+// Registration is failable (duplicate names, invalid options) so factory
+// methods return (vec, error). Callers are expected to register at start-up and
+// treat errors as fatal. Provider is intentionally create-only: lifecycle is
+// owned at the concrete backend boundary (e.g. Prometheus Registry or OTel
+// MeterProvider), not by individual metric instruments.
 type Provider interface {
 	CounterVec(opts CounterOpts) (CounterVec, error)
 	HistogramVec(opts HistogramOpts) (HistogramVec, error)
@@ -76,19 +69,6 @@ type Provider interface {
 	// SetToCurrentTime omitted (no business need; introduces implicit clock
 	// dependency at kernel layer).
 	GaugeVec(opts GaugeOpts) (GaugeVec, error)
-	// Unregister removes a previously registered collector from the provider's
-	// registry. It is safe for concurrent use and idempotent — unregistering a
-	// collector that was never registered (or already unregistered) returns nil
-	// without error.
-	//
-	// Implementations must maintain the invariant that a collector successfully
-	// Unregistered can be re-registered via CounterVec/HistogramVec/GaugeVec
-	// under the same name without conflict.
-	//
-	// ref: prometheus/client_golang Registry.Unregister — bool return simplified
-	// to error for GoCell consistency (nil = success or not-found; non-nil =
-	// hard failure).
-	Unregister(c Collector) error
 }
 
 // CounterOpts declares a counter metric family.
@@ -133,19 +113,15 @@ type Labels map[string]string
 
 // CounterVec returns a pre-bound Counter given a label set. Implementations
 // panic (via MustValidateLabels) when Labels does not exactly match the
-// LabelNames set at registration.
-//
-// CounterVec embeds Collector so that callers can pass it directly to
-// Provider.Unregister without an explicit type cast.
+// LabelNames set at registration. It embeds Collector so all vecs share the
+// provider-owned lifecycle marker.
 type CounterVec interface {
 	Collector
 	With(Labels) Counter
 }
 
-// HistogramVec returns a pre-bound Histogram given a label set.
-//
-// HistogramVec embeds Collector so that callers can pass it directly to
-// Provider.Unregister without an explicit type cast.
+// HistogramVec returns a pre-bound Histogram given a label set. It embeds
+// Collector so all vecs share the provider-owned lifecycle marker.
 type HistogramVec interface {
 	Collector
 	With(Labels) Histogram
@@ -153,10 +129,8 @@ type HistogramVec interface {
 
 // GaugeVec returns a pre-bound Gauge given a label set. Implementations
 // panic (via MustValidateLabels) when Labels does not exactly match the
-// LabelNames set at registration.
-//
-// GaugeVec embeds Collector so that callers can pass it directly to
-// Provider.Unregister without an explicit type cast.
+// LabelNames set at registration. It embeds Collector so all vecs share the
+// provider-owned lifecycle marker.
 type GaugeVec interface {
 	Collector
 	With(Labels) Gauge

--- a/framework/kernel/observability/metrics/metrics_test.go
+++ b/framework/kernel/observability/metrics/metrics_test.go
@@ -166,32 +166,6 @@ func TestNopProvider_AcceptsEmptyLabels(t *testing.T) {
 	cv.With(metrics.Labels{}).Add(context.Background(), 1) // empty map OK
 }
 
-// TestNopProvider_Unregister_IdempotentReturnsNil verifies that
-// NopProvider.Unregister returns nil for any Collector (including nil-like
-// values) and is safe to call multiple times (idempotent contract).
-func TestNopProvider_Unregister_IdempotentReturnsNil(t *testing.T) {
-	p := metrics.NopProvider{}
-
-	cv, err := p.CounterVec(metrics.CounterOpts{Name: "unreg_counter", Help: "h", LabelNames: []string{"x"}})
-	if err != nil {
-		t.Fatalf("CounterVec: %v", err)
-	}
-	hv, err := p.HistogramVec(metrics.HistogramOpts{Name: "unreg_hist", Help: "h", LabelNames: []string{"x"}})
-	if err != nil {
-		t.Fatalf("HistogramVec: %v", err)
-	}
-
-	for _, c := range []metrics.Collector{cv, hv} {
-		if err := p.Unregister(c); err != nil {
-			t.Fatalf("first Unregister: want nil, got %v", err)
-		}
-		// Idempotent: second call must also return nil.
-		if err := p.Unregister(c); err != nil {
-			t.Fatalf("second Unregister (idempotent): want nil, got %v", err)
-		}
-	}
-}
-
 // TestNopCounterVec_Registered_ReturnsTrue verifies that nopCounterVec.Registered
 // is the compile-time membership marker that always returns true.
 func TestNopCounterVec_Registered_ReturnsTrue(t *testing.T) {
@@ -280,19 +254,5 @@ func TestNopGaugeVec_Registered_ReturnsTrue(t *testing.T) {
 	}
 	if !gv.Registered() {
 		t.Fatal("nopGaugeVec.Registered() must return true")
-	}
-}
-
-func TestNopProvider_Unregister_Gauge_Idempotent(t *testing.T) {
-	p := metrics.NopProvider{}
-	gv, err := p.GaugeVec(metrics.GaugeOpts{Name: "unreg_gauge", Help: "h", LabelNames: []string{"x"}})
-	if err != nil {
-		t.Fatalf("GaugeVec: %v", err)
-	}
-	if err := p.Unregister(gv); err != nil {
-		t.Fatalf("first Unregister: want nil, got %v", err)
-	}
-	if err := p.Unregister(gv); err != nil {
-		t.Fatalf("second Unregister: want nil, got %v", err)
 	}
 }

--- a/framework/kernel/observability/metrics/nop.go
+++ b/framework/kernel/observability/metrics/nop.go
@@ -30,10 +30,6 @@ func (NopProvider) GaugeVec(opts GaugeOpts) (GaugeVec, error) {
 	return nopGaugeVec{labels: append([]string(nil), opts.LabelNames...)}, nil
 }
 
-// Unregister is a no-op; the NopProvider does not maintain a registry.
-// Returns nil (idempotent, as per the Unregister contract).
-func (NopProvider) Unregister(_ Collector) error { return nil }
-
 // IsReal reports whether p actually records metrics — i.e. non-nil and not the
 // NopProvider sentinel. It is the single source for the "wire instrumentation
 // only when a real metrics backend is configured" decision, shared by the HTTP

--- a/framework/kernel/outbox/emitter_test.go
+++ b/framework/kernel/outbox/emitter_test.go
@@ -361,8 +361,6 @@ func (p *spyMetricsProvider) GaugeVec(opts metrics.GaugeOpts) (metrics.GaugeVec,
 	return p.gauge, nil
 }
 
-func (p *spyMetricsProvider) Unregister(_ metrics.Collector) error { return nil }
-
 // ---------------------------------------------------------------------------
 // Coverage gap tests — paths not exercised by the initial test suite
 // ---------------------------------------------------------------------------
@@ -428,8 +426,6 @@ func (alwaysFailProvider) HistogramVec(_ metrics.HistogramOpts) (metrics.Histogr
 func (alwaysFailProvider) GaugeVec(_ metrics.GaugeOpts) (metrics.GaugeVec, error) {
 	return nil, errors.New("simulated gauge registration failure")
 }
-
-func (alwaysFailProvider) Unregister(_ metrics.Collector) error { return nil }
 
 // TestNewDirectEmitter_CounterVecRegistrationFailure verifies that a
 // CounterVec registration failure in the constructor is propagated as an error

--- a/framework/kernel/outbox/relay_collector.go
+++ b/framework/kernel/outbox/relay_collector.go
@@ -3,8 +3,6 @@ package outbox
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"slices"
 
 	"github.com/ghbvf/gocell/framework/kernel/observability/metrics"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
@@ -128,36 +126,17 @@ func NewProviderRelayCollector(p metrics.Provider, cellID string, opts ...Provid
 }
 
 // registerRelayMetrics registers all outbox relay metrics on p and returns the
-// fully-built collector. On any partial failure the already-registered metrics
-// are unregistered in LIFO order so the Provider is left clean.
+// fully-built collector. Metrics registration is startup-fatal: on any partial
+// failure the caller rejects the current wiring and owns provider lifecycle
+// cleanup.
 func registerRelayMetrics(p metrics.Provider, cellID string, cfg ProviderRelayCollectorConfig) (*providerRelayCollector, error) {
-	// registered tracks successfully registered collectors in order. On any
-	// partial failure the rollback function unregisters them in LIFO order so
-	// the Provider is left in a clean state, allowing the caller to retry
-	// construction without "duplicate collector" errors.
-	var registered []metrics.Collector
-	rollback := func(origErr error) error {
-		for _, v := range slices.Backward(registered) {
-			if rbErr := p.Unregister(v); rbErr != nil {
-				slog.Error("outbox: unregister during rollback failed",
-					slog.Any("error", rbErr),
-					slog.String("cell", cellID),
-				)
-			}
-		}
-		return origErr
-	}
-
 	// register is the single mechanism through which collectors enter the
-	// `registered` slice. Each metric registration funnels through it so the
-	// "register + check err + append" pattern cannot drift out of sync —
-	// missing the append step is structurally impossible (previously a latent
-	// rollback gap when a future metric was added after `cleaned`).
-	register := func(c metrics.Collector, err error, name string) error {
+	// collector struct. Each metric registration funnels through it so the
+	// "register + check err" pattern cannot drift out of sync.
+	register := func(err error, name string) error {
 		if err != nil {
-			return rollback(fmt.Errorf("outbox: register %s: %w", name, err))
+			return fmt.Errorf("outbox: register %s: %w", name, err)
 		}
-		registered = append(registered, c)
 		return nil
 	}
 
@@ -166,7 +145,7 @@ func registerRelayMetrics(p metrics.Provider, cellID string, cfg ProviderRelayCo
 		Help:       RelayedHelp,
 		LabelNames: []string{"cell", "kind", "outcome"},
 	})
-	if err := register(relayed, err, "outbox_relayed_total"); err != nil {
+	if err := register(err, "outbox_relayed_total"); err != nil {
 		return nil, err
 	}
 
@@ -176,7 +155,7 @@ func registerRelayMetrics(p metrics.Provider, cellID string, cfg ProviderRelayCo
 		LabelNames: []string{"cell", "phase"},
 		Buckets:    cfg.PollBuckets,
 	})
-	if err := register(pollDuration, err, "outbox_poll_duration_seconds"); err != nil {
+	if err := register(err, "outbox_poll_duration_seconds"); err != nil {
 		return nil, err
 	}
 
@@ -186,7 +165,7 @@ func registerRelayMetrics(p metrics.Provider, cellID string, cfg ProviderRelayCo
 		LabelNames: []string{"cell"},
 		Buckets:    cfg.BatchBuckets,
 	})
-	if err := register(batchSize, err, "outbox_batch_size"); err != nil {
+	if err := register(err, "outbox_batch_size"); err != nil {
 		return nil, err
 	}
 
@@ -195,7 +174,7 @@ func registerRelayMetrics(p metrics.Provider, cellID string, cfg ProviderRelayCo
 		Help:       "Total number of stale entries reclaimed by the relay.",
 		LabelNames: []string{"cell"},
 	})
-	if err := register(reclaimed, err, "outbox_reclaimed_total"); err != nil {
+	if err := register(err, "outbox_reclaimed_total"); err != nil {
 		return nil, err
 	}
 
@@ -204,7 +183,7 @@ func registerRelayMetrics(p metrics.Provider, cellID string, cfg ProviderRelayCo
 		Help:       "Total number of entries cleaned up (deleted) by the relay.",
 		LabelNames: []string{"cell", "status"},
 	})
-	if err := register(cleaned, err, "outbox_cleaned_total"); err != nil {
+	if err := register(err, "outbox_cleaned_total"); err != nil {
 		return nil, err
 	}
 

--- a/framework/kernel/outbox/relay_collector_test.go
+++ b/framework/kernel/outbox/relay_collector_test.go
@@ -73,8 +73,6 @@ func (s *spyProvider) GaugeVec(opts metrics.GaugeOpts) (metrics.GaugeVec, error)
 	return &spyGaugeVec{parent: s, name: opts.Name, labels: opts.LabelNames}, nil
 }
 
-func (s *spyProvider) Unregister(_ metrics.Collector) error { return nil }
-
 type spyCounterVec struct {
 	parent *spyProvider
 	name   string
@@ -202,53 +200,33 @@ func TestProviderRelayCollector_ZeroBatchSizeStillObserved(t *testing.T) {
 	}
 }
 
-// TestNewProviderRelayCollector_PartialFailure_RollbackAll verifies that when
-// metric registration fails mid-way (e.g., 3rd metric conflicts), all
-// previously registered metrics are unregistered, preserving Provider clean
-// state for retry or redeployment.
-//
-// Regression test for K2 (OBS-RELAY-REGISTER-ATOMIC-01): sequential
-// registration left orphan metrics on partial failure. The rollback loop in
-// NewProviderRelayCollector must unregister previously registered collectors
-// in LIFO order on any partial failure.
-func TestNewProviderRelayCollector_PartialFailure_RollbackAll(t *testing.T) {
+// TestNewProviderRelayCollector_PartialFailure_ReturnsError verifies that when
+// metric registration fails mid-way (e.g., 3rd metric conflicts), the
+// constructor returns that provider error. Provider lifecycle cleanup is owned
+// by the caller, not by per-instrument unregister.
+func TestNewProviderRelayCollector_PartialFailure_ReturnsError(t *testing.T) {
 	tests := []struct {
-		name        string
-		failOnCall  int // 1-based: which registration call (counter+histogram combined) fails
-		wantRollCnt int // how many Unregister calls expected
+		name           string
+		failOnCall     int // 1-based: which registration call (counter+histogram combined) fails
+		wantRegistered int // completed registrations before the failure
 	}{
-		{name: "fail_on_1st", failOnCall: 1, wantRollCnt: 0},
-		{name: "fail_on_2nd", failOnCall: 2, wantRollCnt: 1},
-		{name: "fail_on_3rd", failOnCall: 3, wantRollCnt: 2},
-		{name: "fail_on_4th", failOnCall: 4, wantRollCnt: 3},
-		// fail_on_5th verifies that 'cleaned' (the 5th metric) is also appended
-		// to the registered slice (F5 fix: LIFO completeness). Before the fix,
-		// cleaned was not appended, so only 3 rollbacks occurred instead of 4.
-		{name: "fail_on_5th", failOnCall: 5, wantRollCnt: 4},
+		{name: "fail_on_1st", failOnCall: 1, wantRegistered: 0},
+		{name: "fail_on_2nd", failOnCall: 2, wantRegistered: 1},
+		{name: "fail_on_3rd", failOnCall: 3, wantRegistered: 2},
+		{name: "fail_on_4th", failOnCall: 4, wantRegistered: 3},
+		{name: "fail_on_5th", failOnCall: 5, wantRegistered: 4},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			p := newFailingProvider(tc.failOnCall)
-			_, err := outbox.NewProviderRelayCollector(p, "rollback-cell")
+			_, err := outbox.NewProviderRelayCollector(p, "partial-failure-cell")
 			if err == nil {
 				t.Fatal("expected error from partial registration, got nil")
 			}
 
-			// All prior registrations must have been rolled back via Unregister.
-			if got := p.unregisteredCount(); got != tc.wantRollCnt {
-				t.Fatalf("want %d Unregister calls, got %d", tc.wantRollCnt, got)
-			}
-
-			// Provider must be in a clean state: re-registering with a
-			// non-failing provider for the same cell must succeed.
-			p2 := newSpyProvider()
-			c2, err := outbox.NewProviderRelayCollector(p2, "rollback-cell")
-			if err != nil {
-				t.Fatalf("re-register after rollback failed: %v", err)
-			}
-			if c2 == nil {
-				t.Fatal("collector must not be nil after clean registration")
+			if got := len(p.registered); got != tc.wantRegistered {
+				t.Fatalf("completed registrations = %d, want %d", got, tc.wantRegistered)
 			}
 		})
 	}
@@ -256,8 +234,8 @@ func TestNewProviderRelayCollector_PartialFailure_RollbackAll(t *testing.T) {
 
 // TestNewProviderRelayCollector_SuccessPath_AllFiveMetricsRegistered asserts
 // that all five outbox metrics (including 'cleaned') are appended to the
-// internal registered slice on the success path. Regression test for F5:
-// 'cleaned' was previously not appended, violating LIFO rollback invariants.
+// test provider's registered slice on the success path. Regression test for F5:
+// 'cleaned' was previously not appended, hiding incomplete startup wiring.
 // Verification strategy: use a counting provider that records how many
 // times CounterVec/HistogramVec were called; on success all 5 must complete.
 func TestNewProviderRelayCollector_SuccessPath_AllFiveMetricsRegistered(t *testing.T) {
@@ -284,10 +262,10 @@ func TestNewProviderRelayCollector_SuccessPath_AllFiveMetricsRegistered(t *testi
 	c.RecordCleanup(context.Background(), 1, 1)
 }
 
-// TestNewProviderRelayCollector_UnregisterLIFOOrder verifies that when
-// registration fails, previously registered collectors are unregistered in
-// reverse (LIFO) order to mirror standard stack-unwinding semantics.
-func TestNewProviderRelayCollector_UnregisterLIFOOrder(t *testing.T) {
+// TestNewProviderRelayCollector_PartialFailureRegistrationOrder verifies that
+// when registration fails, the constructor attempted metrics in the expected
+// order up to the failure point.
+func TestNewProviderRelayCollector_PartialFailureRegistrationOrder(t *testing.T) {
 	// Fail on 4th call; first 3 succeeded (relayed, pollDuration, batchSize).
 	p := newFailingProvider(4)
 	_, err := outbox.NewProviderRelayCollector(p, "lifo-cell")
@@ -295,33 +273,29 @@ func TestNewProviderRelayCollector_UnregisterLIFOOrder(t *testing.T) {
 		t.Fatal("expected error")
 	}
 
-	names := p.unregisteredNames()
-	// Registered order: outbox_relayed_total(1), outbox_poll_duration_seconds(2),
-	// outbox_batch_size(3). Unregister must be reverse: 3, 2, 1.
+	names := p.registeredNames()
 	want := []string{
-		"outbox_batch_size",
-		"outbox_poll_duration_seconds",
 		"outbox_relayed_total",
+		"outbox_poll_duration_seconds",
+		"outbox_batch_size",
 	}
 	if len(names) != len(want) {
-		t.Fatalf("want %d unregistered, got %d: %v", len(want), len(names), names)
+		t.Fatalf("want %d registered, got %d: %v", len(want), len(names), names)
 	}
 	for i, w := range want {
 		if names[i] != w {
-			t.Fatalf("unregister[%d]: want %q got %q", i, w, names[i])
+			t.Fatalf("registered[%d]: want %q got %q", i, w, names[i])
 		}
 	}
 }
 
 // failingProvider is a test Provider that succeeds for the first N-1
-// registration calls, then returns an error on the Nth call, and never
-// errors again. It records which collectors were Unregistered and in what
-// order.
+// registration calls, then returns an error on the Nth call, and never errors
+// again. It records completed registrations.
 type failingProvider struct {
-	failOnCall   int
-	callCount    int
-	registered   []failingCollector
-	unregistered []failingCollector
+	failOnCall int
+	callCount  int
+	registered []failingCollector
 }
 
 type failingCollector struct {
@@ -363,34 +337,12 @@ func (p *failingProvider) GaugeVec(opts metrics.GaugeOpts) (metrics.GaugeVec, er
 	return gv, nil
 }
 
-func (p *failingProvider) Unregister(c metrics.Collector) error {
-	p.unregistered = append(p.unregistered, failingCollector{vec: c, name: collectorName(c)})
-	return nil
-}
-
-func (p *failingProvider) unregisteredCount() int {
-	return len(p.unregistered)
-}
-
-func (p *failingProvider) unregisteredNames() []string {
-	names := make([]string, len(p.unregistered))
-	for i, fc := range p.unregistered {
+func (p *failingProvider) registeredNames() []string {
+	names := make([]string, len(p.registered))
+	for i, fc := range p.registered {
 		names[i] = fc.name
 	}
 	return names
-}
-
-// collectorName extracts the metric name from a registered Collector for
-// assertion purposes. It relies on the NamedCollector interface that the
-// failing spy vecs implement.
-func collectorName(c metrics.Collector) string {
-	type named interface {
-		MetricName() string
-	}
-	if n, ok := c.(named); ok {
-		return n.MetricName()
-	}
-	return "<unknown>"
 }
 
 type spyGaugeVec struct {
@@ -411,8 +363,3 @@ func (spyGauge) Set(_ context.Context, _ float64) {}
 func (spyGauge) Inc(_ context.Context)            {}
 func (spyGauge) Dec(_ context.Context)            {}
 func (spyGauge) Add(_ context.Context, _ float64) {}
-
-// MetricName exposes the name so collectorName can extract it in tests.
-func (v *spyCounterVec) MetricName() string   { return v.name }
-func (v *spyHistogramVec) MetricName() string { return v.name }
-func (v *spyGaugeVec) MetricName() string     { return v.name }

--- a/framework/kernel/projection/metrics_test.go
+++ b/framework/kernel/projection/metrics_test.go
@@ -192,8 +192,6 @@ func (p *projFailProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetrics
 	return kernelmetrics.NopProvider{}.GaugeVec(opts)
 }
 
-func (p *projFailProvider) Unregister(_ kernelmetrics.Collector) error { return nil }
-
 var errProjRegistration = errors.New("duplicate instrument")
 
 // ---------------------------------------------------------------------------
@@ -240,8 +238,6 @@ func (p *projRecordingProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelme
 	p.gauges[opts.Name] = v
 	return v, nil
 }
-
-func (p *projRecordingProvider) Unregister(_ kernelmetrics.Collector) error { return nil }
 
 func (p *projRecordingProvider) gaugeLabels(name string) []string {
 	p.mu.Lock()

--- a/framework/kernel/reconcile/metrics_test.go
+++ b/framework/kernel/reconcile/metrics_test.go
@@ -111,8 +111,6 @@ func (p *recordingProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetric
 	return v, nil
 }
 
-func (p *recordingProvider) Unregister(_ kernelmetrics.Collector) error { return nil }
-
 func (p *recordingProvider) counterLabels(name string) []string {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/framework/kernel/webhook/metrics_test.go
+++ b/framework/kernel/webhook/metrics_test.go
@@ -159,8 +159,8 @@ func TestWebhookMetrics_DeliveryDurationBucketsFrozen(t *testing.T) {
 
 // --- recordingProvider: in-memory metrics.Provider spy for webhook tests. ---
 
-// recordingProvider embeds NopProvider so the unused GaugeVec / Unregister
-// methods are inherited (webhook metrics have no gauges); it overrides only the
+// recordingProvider embeds NopProvider so the unused GaugeVec method is
+// inherited (webhook metrics have no gauges); it overrides only the
 // CounterVec / HistogramVec it needs to record.
 type recordingProvider struct {
 	kernelmetrics.NopProvider

--- a/framework/runtime/audit/chain_verify_runner_test.go
+++ b/framework/runtime/audit/chain_verify_runner_test.go
@@ -117,8 +117,6 @@ func (p *recordingProvider) GaugeVec(o metrics.GaugeOpts) (metrics.GaugeVec, err
 	return &recGaugeVec{p: p, labels: o.LabelNames}, nil
 }
 
-func (p *recordingProvider) Unregister(metrics.Collector) error { return nil }
-
 type recPoint struct{}
 
 func (recPoint) Inc(context.Context)              {}
@@ -379,7 +377,6 @@ func (errorProvider) HistogramVec(metrics.HistogramOpts) (metrics.HistogramVec, 
 func (errorProvider) GaugeVec(metrics.GaugeOpts) (metrics.GaugeVec, error) {
 	return nil, errors.New("metrics registration error")
 }
-func (errorProvider) Unregister(metrics.Collector) error { return nil }
 
 // --- new tests (items H.13-H.20) -------------------------------------------
 

--- a/framework/runtime/auth/metrics_test.go
+++ b/framework/runtime/auth/metrics_test.go
@@ -82,8 +82,6 @@ func (p *lockoutSpyProvider) GaugeVec(opts metrics.GaugeOpts) (metrics.GaugeVec,
 	return metrics.NopProvider{}.GaugeVec(opts)
 }
 
-func (p *lockoutSpyProvider) Unregister(_ metrics.Collector) error { return nil }
-
 func TestNewAuthMetrics_NopProvider(t *testing.T) {
 	am, err := NewAuthMetrics(metrics.NopProvider{})
 	require.NoError(t, err)

--- a/framework/runtime/auth/pdp_metrics_test.go
+++ b/framework/runtime/auth/pdp_metrics_test.go
@@ -51,8 +51,6 @@ func (p *pdpSpyProvider) GaugeVec(opts metrics.GaugeOpts) (metrics.GaugeVec, err
 	return metrics.NopProvider{}.GaugeVec(opts)
 }
 
-func (p *pdpSpyProvider) Unregister(_ metrics.Collector) error { return nil }
-
 type pdpSpyCounterVec struct {
 	mu      sync.Mutex
 	labels  []string

--- a/framework/runtime/auth/refresh/metrics.go
+++ b/framework/runtime/auth/refresh/metrics.go
@@ -33,12 +33,6 @@ func NewProviderGCCollector(p metrics.Provider) (*ProviderGCCollector, error) {
 	if p == nil {
 		return nil, errcode.New(errcode.KindInternal, errcode.ErrObservabilityConfigInvalid, "refresh gc metrics provider must not be nil")
 	}
-	var registered []metrics.Collector
-	cleanup := func() {
-		for _, c := range registered {
-			_ = p.Unregister(c)
-		}
-	}
 
 	runs, err := p.CounterVec(metrics.CounterOpts{
 		Name:       "auth_refresh_gc_runs_total",
@@ -48,17 +42,14 @@ func NewProviderGCCollector(p metrics.Provider) (*ProviderGCCollector, error) {
 	if err != nil {
 		return nil, fmt.Errorf("refresh gc: register auth_refresh_gc_runs_total: %w", err)
 	}
-	registered = append(registered, runs)
 	removed, err := p.CounterVec(metrics.CounterOpts{
 		Name:       "auth_refresh_gc_removed_total",
 		Help:       "Total number of refresh-token rows removed by GC.",
 		LabelNames: []string{"result"},
 	})
 	if err != nil {
-		cleanup()
 		return nil, fmt.Errorf("refresh gc: register auth_refresh_gc_removed_total: %w", err)
 	}
-	registered = append(registered, removed)
 	duration, err := p.HistogramVec(metrics.HistogramOpts{
 		Name:       "auth_refresh_gc_duration_seconds",
 		Help:       "Duration of refresh-token GC runs in seconds.",
@@ -66,7 +57,6 @@ func NewProviderGCCollector(p metrics.Provider) (*ProviderGCCollector, error) {
 		Buckets:    []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5},
 	})
 	if err != nil {
-		cleanup()
 		return nil, fmt.Errorf("refresh gc: register auth_refresh_gc_duration_seconds: %w", err)
 	}
 	return &ProviderGCCollector{runs: runs, removed: removed, duration: duration}, nil

--- a/framework/runtime/auth/refresh/metrics_test.go
+++ b/framework/runtime/auth/refresh/metrics_test.go
@@ -50,18 +50,6 @@ func (p *gcMetricProvider) GaugeVec(opts metrics.GaugeOpts) (metrics.GaugeVec, e
 	return v, nil
 }
 
-func (p *gcMetricProvider) Unregister(c metrics.Collector) error {
-	switch v := c.(type) {
-	case gcCounterVec:
-		delete(p.registered, v.name)
-	case gcHistogramVec:
-		delete(p.registered, v.name)
-	case gcGaugeVec:
-		delete(p.registered, v.name)
-	}
-	return nil
-}
-
 type gcCounterVec struct {
 	name string
 }
@@ -99,13 +87,14 @@ func (gcGauge) Inc(_ context.Context)            {}
 func (gcGauge) Dec(_ context.Context)            {}
 func (gcGauge) Add(_ context.Context, _ float64) {}
 
-func TestNewProviderGCCollector_CleansUpPartialRegistration(t *testing.T) {
+func TestNewProviderGCCollector_ReturnsErrorOnPartialRegistration(t *testing.T) {
 	p := newGCMetricProvider("auth_refresh_gc_removed_total")
 
 	collector, err := NewProviderGCCollector(p)
 	require.Error(t, err)
 	assert.Nil(t, collector)
-	assert.Empty(t, p.registered, "partial metric registration must be unregistered on failure")
+	assert.Contains(t, p.registered, "auth_refresh_gc_runs_total",
+		"metric registered before the failure records the attempted startup wiring")
 }
 
 func TestNewProviderGCCollector_RegistersAndObserves(t *testing.T) {
@@ -124,7 +113,7 @@ func TestNewProviderGCCollector_RegistersAndObserves(t *testing.T) {
 	})
 }
 
-func TestNewProviderGCCollector_RejectsNilProviderAndCleansHistogramFailure(t *testing.T) {
+func TestNewProviderGCCollector_RejectsNilProviderAndReturnsHistogramFailure(t *testing.T) {
 	collector, err := NewProviderGCCollector(nil)
 	require.Error(t, err)
 	assert.Nil(t, collector)
@@ -133,7 +122,8 @@ func TestNewProviderGCCollector_RejectsNilProviderAndCleansHistogramFailure(t *t
 	collector, err = NewProviderGCCollector(p)
 	require.Error(t, err)
 	assert.Nil(t, collector)
-	assert.Empty(t, p.registered, "histogram registration failure must clean up counters")
+	assert.Contains(t, p.registered, "auth_refresh_gc_runs_total")
+	assert.Contains(t, p.registered, "auth_refresh_gc_removed_total")
 }
 
 func TestGCCollectors_NoopsAreSafe(t *testing.T) {

--- a/framework/runtime/auth/servicetoken_test.go
+++ b/framework/runtime/auth/servicetoken_test.go
@@ -918,8 +918,6 @@ func (p *spyProvider) GaugeVec(opts metrics.GaugeOpts) (metrics.GaugeVec, error)
 	return metrics.NopProvider{}.GaugeVec(opts)
 }
 
-func (p *spyProvider) Unregister(_ metrics.Collector) error { return nil }
-
 func (p *spyProvider) assertServiceVerify(t *testing.T, result, reason string) {
 	t.Helper()
 	for _, r := range p.svcVec.recorded {

--- a/framework/runtime/bootstrap/metrics_provider_test.go
+++ b/framework/runtime/bootstrap/metrics_provider_test.go
@@ -49,6 +49,5 @@ func (recordingProvider) HistogramVec(_ kernelmetrics.HistogramOpts) (kernelmetr
 func (recordingProvider) GaugeVec(_ kernelmetrics.GaugeOpts) (kernelmetrics.GaugeVec, error) {
 	return kernelmetrics.NopProvider{}.GaugeVec(kernelmetrics.GaugeOpts{})
 }
-func (recordingProvider) Unregister(_ kernelmetrics.Collector) error { return nil }
 
 var _ kernelmetrics.Provider = recordingProvider{}

--- a/framework/runtime/bootstrap/metrics_wiring_test.go
+++ b/framework/runtime/bootstrap/metrics_wiring_test.go
@@ -56,8 +56,6 @@ func (s *registrationSpy) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetrics.
 	return s.nop.GaugeVec(opts)
 }
 
-func (s *registrationSpy) Unregister(_ kernelmetrics.Collector) error { return nil }
-
 func (s *registrationSpy) counters() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -374,10 +372,6 @@ func (p *alwaysFailCounterProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kern
 	return p.nop.GaugeVec(opts)
 }
 
-func (p *alwaysFailCounterProvider) Unregister(col kernelmetrics.Collector) error {
-	return p.nop.Unregister(col)
-}
-
 // ---------------------------------------------------------------------------
 // R3: autoWireOutboxRejectCollector tests
 // ---------------------------------------------------------------------------
@@ -537,10 +531,6 @@ func (p *countingMetricsProvider) HistogramVec(opts kernelmetrics.HistogramOpts)
 
 func (p *countingMetricsProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetrics.GaugeVec, error) {
 	return p.inner.GaugeVec(opts)
-}
-
-func (p *countingMetricsProvider) Unregister(c kernelmetrics.Collector) error {
-	return p.inner.Unregister(c)
 }
 
 // TestAutoWireOutboxRejectCollector_DoubleCallWithConsumerBase_Idempotent

--- a/framework/runtime/bootstrap/phases_projection_test.go
+++ b/framework/runtime/bootstrap/phases_projection_test.go
@@ -742,8 +742,6 @@ func (p recordingLabelProvider) CounterVec(o kernelmetrics.CounterOpts) (kernelm
 	return p.nop.CounterVec(o)
 }
 
-func (p recordingLabelProvider) Unregister(kernelmetrics.Collector) error { return nil }
-
 type recordingGaugeVec struct {
 	kernelmetrics.GaugeVec
 	withCalls *[]kernelmetrics.Labels
@@ -897,8 +895,6 @@ func (p *projMetricRegProvider) CounterVec(o kernelmetrics.CounterOpts) (kernelm
 	return p.nop.CounterVec(o)
 }
 
-func (p *projMetricRegProvider) Unregister(kernelmetrics.Collector) error { return nil }
-
 // failGaugeProvider returns an error on GaugeVec — projection.RegisterMetrics
 // registers replay_lag (a gauge) first, so this drives the registration-conflict
 // fail-fast path.
@@ -915,8 +911,6 @@ func (p failGaugeProvider) HistogramVec(o kernelmetrics.HistogramOpts) (kernelme
 func (p failGaugeProvider) CounterVec(o kernelmetrics.CounterOpts) (kernelmetrics.CounterVec, error) {
 	return p.nop.CounterVec(o)
 }
-
-func (p failGaugeProvider) Unregister(kernelmetrics.Collector) error { return nil }
 
 // TestBuildProjectionCoordinators_MultiProjection_SharesSingleMetrics is the
 // direct regression guard for #1399: before the fix, buildOneProjection called

--- a/framework/runtime/bootstrap/shutdown_metrics_test.go
+++ b/framework/runtime/bootstrap/shutdown_metrics_test.go
@@ -144,8 +144,6 @@ func (p *fakeMetricsProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetr
 	return kernelmetrics.NopProvider{}.GaugeVec(opts)
 }
 
-func (p *fakeMetricsProvider) Unregister(_ kernelmetrics.Collector) error { return nil }
-
 var _ kernelmetrics.Provider = (*fakeMetricsProvider)(nil)
 
 func (p *fakeMetricsProvider) counter(name string) *fakeCounterVec {

--- a/framework/runtime/observability/metrics/collector_register.go
+++ b/framework/runtime/observability/metrics/collector_register.go
@@ -6,41 +6,28 @@ import (
 	kernelmetrics "github.com/ghbvf/gocell/framework/kernel/observability/metrics"
 )
 
-// registerCounterVec registers one counter and appends it to *registered on
-// success. On failure it tears down every previously-registered counter LIFO
-// (#1181 F11 atomic registration: the provider registry must not retain orphans
-// so a retry can re-register under the same names — mirrors
-// prometheus/client_golang Registry.Unregister) and wraps the error with the
-// metric name. Shared by SagaCollector (saga.go) and SessionCacheCollector
-// (session_cache.go).
+// registerCounterVec registers one counter and wraps provider errors with the
+// metric name. Metrics registration is a startup construction step: callers
+// treat failures as fatal for the current wiring and do not rely on
+// per-instrument rollback across backends.
 func registerCounterVec(
-	p kernelmetrics.Provider, opts kernelmetrics.CounterOpts, registered *[]kernelmetrics.Collector,
+	p kernelmetrics.Provider, opts kernelmetrics.CounterOpts,
 ) (kernelmetrics.CounterVec, error) {
 	cv, err := p.CounterVec(opts)
 	if err != nil {
-		for i := len(*registered) - 1; i >= 0; i-- {
-			_ = p.Unregister((*registered)[i])
-		}
 		return nil, fmt.Errorf("runtime/observability/metrics: register %s: %w", opts.Name, err)
 	}
-	*registered = append(*registered, cv)
 	return cv, nil
 }
 
-// registerGaugeVec registers one gauge and appends it to *registered on success.
-// On failure it tears down every previously-registered collector LIFO (same
-// atomic-registration discipline as registerCounterVec) and wraps the error with
-// the metric name.
+// registerGaugeVec registers one gauge and wraps provider errors with the
+// metric name. See registerCounterVec for the startup-fatal lifecycle contract.
 func registerGaugeVec(
-	p kernelmetrics.Provider, opts kernelmetrics.GaugeOpts, registered *[]kernelmetrics.Collector,
+	p kernelmetrics.Provider, opts kernelmetrics.GaugeOpts,
 ) (kernelmetrics.GaugeVec, error) {
 	gv, err := p.GaugeVec(opts)
 	if err != nil {
-		for i := len(*registered) - 1; i >= 0; i-- {
-			_ = p.Unregister((*registered)[i])
-		}
 		return nil, fmt.Errorf("runtime/observability/metrics: register %s: %w", opts.Name, err)
 	}
-	*registered = append(*registered, gv)
 	return gv, nil
 }

--- a/framework/runtime/observability/metrics/event.go
+++ b/framework/runtime/observability/metrics/event.go
@@ -49,9 +49,10 @@ type EventRouterCollector struct {
 // broker connection establishment.
 var eventRouterReadyWaitBuckets = []float64{0.001, 0.01, 0.1, 0.25, 0.5, 1, 5, 30}
 
-// NewEventRouterCollector registers all three event-router lifecycle metrics on
-// the given provider. On partial failure, already-registered metrics are rolled
-// back LIFO before returning the error.
+// NewEventRouterCollector registers all event-router lifecycle metrics on the
+// given provider. Registration happens during startup wiring; any partial
+// failure is returned as fatal for that wiring, and caller-owned provider
+// lifecycle handles cleanup.
 func NewEventRouterCollector(p kernelmetrics.Provider) (*EventRouterCollector, error) {
 	if p == nil {
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrObservabilityConfigInvalid,
@@ -75,7 +76,6 @@ func NewEventRouterCollector(p kernelmetrics.Provider) (*EventRouterCollector, e
 		LabelNames: []string{"cell", "topic", "reason"},
 	})
 	if err != nil {
-		_ = p.Unregister(active)
 		return nil, fmt.Errorf("runtime/observability/metrics: register event_router_setup_errors_total: %w", err)
 	}
 
@@ -86,8 +86,6 @@ func NewEventRouterCollector(p kernelmetrics.Provider) (*EventRouterCollector, e
 		Buckets:    eventRouterReadyWaitBuckets,
 	})
 	if err != nil {
-		_ = p.Unregister(setupErr)
-		_ = p.Unregister(active)
 		return nil, fmt.Errorf("runtime/observability/metrics: register event_router_ready_wait_seconds: %w", err)
 	}
 
@@ -98,9 +96,6 @@ func NewEventRouterCollector(p kernelmetrics.Provider) (*EventRouterCollector, e
 		LabelNames: []string{"cell", "topic", "reason"},
 	})
 	if err != nil {
-		_ = p.Unregister(readyWait)
-		_ = p.Unregister(setupErr)
-		_ = p.Unregister(active)
 		return nil, fmt.Errorf("runtime/observability/metrics: register event_router_runtime_errors_total: %w", err)
 	}
 

--- a/framework/runtime/observability/metrics/event_test.go
+++ b/framework/runtime/observability/metrics/event_test.go
@@ -129,29 +129,23 @@ func TestEventRouterCollector_NilReceiverDoesNotPanic(t *testing.T) {
 	c.ObserveReadyWait(ctx, "cell", time.Second)
 }
 
-func TestNewEventRouterCollector_RollbackOnPartialFailure(t *testing.T) {
-	// failAfterFirstEventProvider succeeds GaugeVec registration, fails on
-	// CounterVec, so the first Gauge registration must be rolled back.
+func TestNewEventRouterCollector_ReturnsErrorOnPartialFailure(t *testing.T) {
+	// failAfterFirstEventProvider succeeds GaugeVec registration, then fails on
+	// CounterVec. Registration failure rejects the current wiring.
 	p := &eventPartialFailProvider{failOnCounter: true}
 	_, err := obmetrics.NewEventRouterCollector(p)
 	if err == nil {
 		t.Fatal("expected error from partial failure, got nil")
 	}
-	if !p.unregisterCalled {
-		t.Error("expected Unregister to be called on rollback, but it was not")
-	}
 }
 
-func TestNewEventRouterCollector_RollbackOnHistogramFailure(t *testing.T) {
+func TestNewEventRouterCollector_ReturnsErrorOnHistogramFailure(t *testing.T) {
 	// failAfterTwoEventProvider succeeds GaugeVec + CounterVec but fails on
-	// HistogramVec — both prior registrations must be rolled back.
+	// HistogramVec.
 	p := &eventPartialFailProvider{failOnHistogram: true}
 	_, err := obmetrics.NewEventRouterCollector(p)
 	if err == nil {
 		t.Fatal("expected error from histogram failure, got nil")
-	}
-	if p.unregisterCount < 2 {
-		t.Errorf("expected at least 2 Unregister calls on rollback, got %d", p.unregisterCount)
 	}
 }
 
@@ -190,8 +184,6 @@ func (p *eventSpyProvider) HistogramVec(opts kernelmetrics.HistogramOpts) (kerne
 func (p *eventSpyProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetrics.GaugeVec, error) {
 	return &eventSpyGaugeVec{parent: p, name: opts.Name, labelNames: opts.LabelNames}, nil
 }
-
-func (p *eventSpyProvider) Unregister(_ kernelmetrics.Collector) error { return nil }
 
 type eventSpyCounterVec struct {
 	parent     *eventSpyProvider
@@ -264,15 +256,13 @@ func (g *eventSpyGauge) Dec(ctx context.Context)            { g.Add(ctx, -1) }
 func (g *eventSpyGauge) Add(ctx context.Context, d float64) { g.Set(ctx, d) }
 
 // ---------------------------------------------------------------------------
-// eventPartialFailProvider: configurable partial failure for rollback tests.
+// eventPartialFailProvider: configurable partial failure tests.
 // ---------------------------------------------------------------------------
 
 type eventPartialFailProvider struct {
 	kernelmetrics.NopProvider
-	failOnCounter    bool
-	failOnHistogram  bool
-	unregisterCalled bool
-	unregisterCount  int
+	failOnCounter   bool
+	failOnHistogram bool
 }
 
 func (p *eventPartialFailProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetrics.GaugeVec, error) {
@@ -292,10 +282,4 @@ func (p *eventPartialFailProvider) HistogramVec(opts kernelmetrics.HistogramOpts
 		return nil, errors.New("histogram registration failed")
 	}
 	return p.NopProvider.HistogramVec(opts)
-}
-
-func (p *eventPartialFailProvider) Unregister(_ kernelmetrics.Collector) error {
-	p.unregisterCalled = true
-	p.unregisterCount++
-	return nil
 }

--- a/framework/runtime/observability/metrics/idempotency_test.go
+++ b/framework/runtime/observability/metrics/idempotency_test.go
@@ -3,6 +3,7 @@ package metrics_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/ghbvf/gocell/framework/kernel/ctxkeys"
@@ -147,9 +148,7 @@ func TestIdempotencyCollector_CellLabel_FallsBackToRuntime(t *testing.T) {
 }
 
 // TestNewIdempotencyCollector_RegistrationFailure_ReturnsError verifies that a
-// CounterVec registration failure is propagated as a wrapped error (no partial
-// state retained). Unlike SagaCollector there is only one counter so no LIFO
-// rollback is needed, but the error must still be returned.
+// CounterVec registration failure is propagated as a wrapped error.
 func TestNewIdempotencyCollector_RegistrationFailure_ReturnsError(t *testing.T) {
 	p := newSagaSpyProvider()
 	p.failOnName = "idempotency_requests_total"
@@ -157,8 +156,8 @@ func TestNewIdempotencyCollector_RegistrationFailure_ReturnsError(t *testing.T) 
 	if err == nil {
 		t.Fatal("expected an error when CounterVec registration fails")
 	}
-	if p.unregisterCount != 0 {
-		t.Errorf("unregisterCount = %d, want 0 (single counter, no rollback required)", p.unregisterCount)
+	if !strings.Contains(err.Error(), "idempotency_requests_total") {
+		t.Fatalf("error must include metric name, got %v", err)
 	}
 }
 

--- a/framework/runtime/observability/metrics/outbox_test.go
+++ b/framework/runtime/observability/metrics/outbox_test.go
@@ -249,8 +249,6 @@ func (p *outboxSpyProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetric
 	return &outboxSpyGaugeVec{parent: p, name: opts.Name, labelNames: opts.LabelNames}, nil
 }
 
-func (p *outboxSpyProvider) Unregister(_ kernelmetrics.Collector) error { return nil }
-
 type outboxSpyCounterVec struct {
 	parent     *outboxSpyProvider
 	name       string

--- a/framework/runtime/observability/metrics/provider_collector_test.go
+++ b/framework/runtime/observability/metrics/provider_collector_test.go
@@ -186,8 +186,6 @@ func (s *spyProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetrics.Gaug
 	return spyGaugeVec{parent: s, name: opts.Name, labels: opts.LabelNames}, nil
 }
 
-func (s *spyProvider) Unregister(_ kernelmetrics.Collector) error { return nil }
-
 type spyCounterVec struct {
 	parent *spyProvider
 	name   string

--- a/framework/runtime/observability/metrics/saga.go
+++ b/framework/runtime/observability/metrics/saga.go
@@ -75,7 +75,7 @@ var _ executor.Observer = (*SagaCollector)(nil)
 //   - p == nil → errcode.KindInvalid + ErrObservabilityConfigInvalid
 //   - cellID == "" → errcode.KindInvalid + ErrObservabilityConfigInvalid
 //   - any CounterVec registration error is wrapped with the metric name and
-//     rolls back the counters registered earlier in the sequence (atomic).
+//     returned as a startup-fatal wiring error; caller owns provider lifecycle.
 //
 // Caller contract: never pass a nil *SagaCollector — use NopObserver via
 // WithObserver(nil) for explicit disable.
@@ -88,8 +88,6 @@ func NewSagaCollector(p kernelmetrics.Provider, cellID string) (*SagaCollector, 
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrObservabilityConfigInvalid,
 			"runtime/observability/metrics: SagaCollector cellID is required")
 	}
-
-	var registered []kernelmetrics.Collector
 	c := &SagaCollector{cellID: cellID}
 	var err error
 	if c.outcome, err = registerCounterVec(p, kernelmetrics.CounterOpts{
@@ -98,14 +96,14 @@ func NewSagaCollector(p kernelmetrics.Provider, cellID string) (*SagaCollector, 
 			"step_name is intentionally excluded to bound the step×outcome cardinality; " +
 			"per-step drill-down uses saga_step_retry_total.",
 		LabelNames: []string{"cell", "definition_id", "outcome"},
-	}, &registered); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 	if c.retry, err = registerCounterVec(p, kernelmetrics.CounterOpts{
 		Name:       "saga_step_retry_total",
 		Help:       "Total retry attempts emitted by the saga executor (attempt N>1 fired) per definition+step.",
 		LabelNames: []string{"cell", "definition_id", "step_name"},
-	}, &registered); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 	if c.hbFail, err = registerCounterVec(p, kernelmetrics.CounterOpts{
@@ -114,7 +112,7 @@ func NewSagaCollector(p kernelmetrics.Provider, cellID string) (*SagaCollector, 
 			"(infra_error = transient err; stale_lease = ok=false / another coordinator took over). " +
 			"Excludes definition_id and step_name — heartbeat is an infra signal, not per-step.",
 		LabelNames: []string{"cell", "reason"},
-	}, &registered); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 	if c.tick, err = registerCounterVec(p, kernelmetrics.CounterOpts{
@@ -123,7 +121,7 @@ func NewSagaCollector(p kernelmetrics.Provider, cellID string) (*SagaCollector, 
 			"(claimed = ≥1 instance; empty = idle tick; error = ClaimPending failed). " +
 			"Loop liveness; definition_id is not available pre-claim.",
 		LabelNames: []string{"cell", "result"},
-	}, &registered); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 	if c.drive, err = registerCounterVec(p, kernelmetrics.CounterOpts{
@@ -132,7 +130,7 @@ func NewSagaCollector(p kernelmetrics.Provider, cellID string) (*SagaCollector, 
 			"(ok = advanced cleanly; error = stale lease / instance gone / step failure). " +
 			"Per-instance forward-progress throughput.",
 		LabelNames: []string{"cell", "definition_id", "result"},
-	}, &registered); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 	if c.leaderSkip, err = registerCounterVec(p, kernelmetrics.CounterOpts{
@@ -142,7 +140,7 @@ func NewSagaCollector(p kernelmetrics.Provider, cellID string) (*SagaCollector, 
 			"backend_error = distlock I/O fault / lock-acquire failure rate). " +
 			"Sustained contended with drive{result=ok}≈0 means an instance is stuck skipping.",
 		LabelNames: []string{"cell", "definition_id", "reason"},
-	}, &registered); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 	return c, nil

--- a/framework/runtime/observability/metrics/saga_tailer.go
+++ b/framework/runtime/observability/metrics/saga_tailer.go
@@ -51,8 +51,8 @@ var _ tailer.Observer = (*SagaTailerCollector)(nil)
 
 // NewSagaTailerCollector registers the Tailer metrics on the given provider.
 // cellID is the owner cell; empty is an error (no _runtime fallback — a Tailer is
-// always owned by exactly one cell). Registration is atomic: any failure rolls
-// back the collectors registered earlier in the sequence.
+// always owned by exactly one cell). Any registration failure is startup-fatal
+// for the current wiring; caller owns provider lifecycle cleanup.
 //
 // Caller contract: never pass a nil *SagaTailerCollector — use tailer.NopObserver
 // via WithObserver(nil) for explicit disable.
@@ -65,8 +65,6 @@ func NewSagaTailerCollector(p kernelmetrics.Provider, cellID string) (*SagaTaile
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrObservabilityConfigInvalid,
 			"runtime/observability/metrics: SagaTailerCollector cellID is required")
 	}
-
-	var registered []kernelmetrics.Collector
 	c := &SagaTailerCollector{cellID: cellID}
 	var err error
 	if c.lockFail, err = registerCounterVec(p, kernelmetrics.CounterOpts{
@@ -75,7 +73,7 @@ func NewSagaTailerCollector(p kernelmetrics.Provider, cellID string) (*SagaTaile
 			"skipped the tick), labeled by reason (contended = another process holds the lock; " +
 			"ctx_canceled = shutdown; backend_error = distlock I/O fault / lock-acquire failure rate).",
 		LabelNames: []string{"cell", "projection", "reason"},
-	}, &registered); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 	if c.drain, err = registerCounterVec(p, kernelmetrics.CounterOpts{
@@ -84,7 +82,7 @@ func NewSagaTailerCollector(p kernelmetrics.Provider, cellID string) (*SagaTaile
 			"(ok = ≥1 event applied; head_error = head-bound fetch failed; store_error = checkpoint " +
 			"load failed; apply_error = non-stale replay/apply failure). Idle caught-up ticks are not counted.",
 		LabelNames: []string{"cell", "projection", "result"},
-	}, &registered); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 	if c.advance, err = registerCounterVec(p, kernelmetrics.CounterOpts{
@@ -94,21 +92,21 @@ func NewSagaTailerCollector(p kernelmetrics.Provider, cellID string) (*SagaTaile
 			"poison_skip = dead-lettered poison event, checkpoint advanced past it (#2110)). " +
 			"Alert on result=error; exclude result=stale_owner.",
 		LabelNames: []string{"cell", "projection", "result"},
-	}, &registered); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 	if c.pending, err = registerGaugeVec(p, kernelmetrics.GaugeOpts{
 		Name:       "saga_journal_tailer_pending_events",
 		Help:       "Residual saga-journal tailer backlog (HeadSeq − checkpoint) after the last clean tick.",
 		LabelNames: []string{"cell", "projection"},
-	}, &registered); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 	if c.lastSuccess, err = registerGaugeVec(p, kernelmetrics.GaugeOpts{
 		Name:       "saga_journal_tailer_last_success_timestamp_seconds",
 		Help:       "Unix time of the last fully-completed saga-journal tailer tick (drives the stalled-tailer alert).",
 		LabelNames: []string{"cell", "projection"},
-	}, &registered); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 	return c, nil

--- a/framework/runtime/observability/metrics/saga_tailer_test.go
+++ b/framework/runtime/observability/metrics/saga_tailer_test.go
@@ -152,15 +152,14 @@ func TestSagaTailerCollector_LabelSets(t *testing.T) {
 	}
 }
 
-func TestSagaTailerCollector_RegistrationRollback(t *testing.T) {
+func TestSagaTailerCollector_PartialRegistrationFailure_ReturnsError(t *testing.T) {
 	p := newTLSpy()
 	p.failOnName = "saga_journal_tailer_drain_total" // second registration fails
 	if _, err := obmetrics.NewSagaTailerCollector(p, tlCell); err == nil {
 		t.Fatal("want error when a registration fails")
 	}
-	// The first counter must have been rolled back (Unregister called).
-	if p.unregisterCount == 0 {
-		t.Error("want LIFO rollback Unregister on partial registration")
+	if _, ok := p.counterNames["saga_journal_tailer_lock_acquire_failed_total"]; !ok {
+		t.Error("expected first counter registration attempt before partial failure")
 	}
 }
 
@@ -192,14 +191,13 @@ type tlSpyRecord struct {
 }
 
 type tlSpyProvider struct {
-	counterNames    map[string]struct{}
-	counterLabels   map[string][]string
-	counterOps      map[string][]tlSpyRecord
-	gaugeNames      map[string]struct{}
-	gaugeLabels     map[string][]string
-	gaugeOps        map[string][]tlSpyRecord
-	failOnName      string
-	unregisterCount int
+	counterNames  map[string]struct{}
+	counterLabels map[string][]string
+	counterOps    map[string][]tlSpyRecord
+	gaugeNames    map[string]struct{}
+	gaugeLabels   map[string][]string
+	gaugeOps      map[string][]tlSpyRecord
+	failOnName    string
 }
 
 func newTLSpy() *tlSpyProvider {
@@ -233,11 +231,6 @@ func (p *tlSpyProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetrics.Ga
 
 func (p *tlSpyProvider) HistogramVec(opts kernelmetrics.HistogramOpts) (kernelmetrics.HistogramVec, error) {
 	return kernelmetrics.NopProvider{}.HistogramVec(opts)
-}
-
-func (p *tlSpyProvider) Unregister(kernelmetrics.Collector) error {
-	p.unregisterCount++
-	return nil
 }
 
 type tlSpyCounterVec struct {

--- a/framework/runtime/observability/metrics/saga_test.go
+++ b/framework/runtime/observability/metrics/saga_test.go
@@ -395,20 +395,20 @@ func TestNewSagaCollector_NoHistograms(t *testing.T) {
 	}
 }
 
-// TestNewSagaCollector_PartialRegistrationFailure_RollsBack verifies the LIFO
-// atomic-registration rollback (#1181 F11): when the 4th counter (saga_tick_total)
-// fails to register, the 3 already-registered counters are torn down via
-// Unregister so the provider retains no orphans.
-func TestNewSagaCollector_PartialRegistrationFailure_RollsBack(t *testing.T) {
+// TestNewSagaCollector_PartialRegistrationFailure_ReturnsError verifies that
+// when the 4th counter (saga_tick_total) fails to register, the constructor
+// rejects the current wiring and returns the registration error.
+func TestNewSagaCollector_PartialRegistrationFailure_ReturnsError(t *testing.T) {
 	p := newSagaSpyProvider()
 	p.failOnName = "saga_tick_total" // the 4th counter in NewSagaCollector order
 	_, err := obmetrics.NewSagaCollector(p, "auditcore")
 	if err == nil {
 		t.Fatal("expected a registration error when saga_tick_total fails")
 	}
-	// outcome, retry, hbFail were registered before the tick failure → 3 rolled back.
-	if p.unregisterCount != 3 {
-		t.Errorf("unregisterCount = %d, want 3 (LIFO rollback of the 3 prior counters)", p.unregisterCount)
+	for _, name := range []string{"saga_step_outcome_total", "saga_step_retry_total", "saga_heartbeat_failed_total"} {
+		if _, ok := p.counterNames[name]; !ok {
+			t.Errorf("expected prior counter registration attempt for %s", name)
+		}
 	}
 }
 
@@ -430,9 +430,8 @@ type sagaSpyProvider struct {
 	counterOps     map[string][]sagaSpyRecord
 
 	// failOnName, when non-empty, makes CounterVec return an error for that
-	// metric name — exercises the LIFO rollback in NewSagaCollector.
-	failOnName      string
-	unregisterCount int
+	// metric name.
+	failOnName string
 }
 
 func newSagaSpyProvider() *sagaSpyProvider {
@@ -463,17 +462,6 @@ func (p *sagaSpyProvider) HistogramVec(opts kernelmetrics.HistogramOpts) (kernel
 func (p *sagaSpyProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetrics.GaugeVec, error) {
 	p.gaugeNames[opts.Name] = struct{}{}
 	return kernelmetrics.NopProvider{}.GaugeVec(opts)
-}
-
-func (p *sagaSpyProvider) Unregister(c kernelmetrics.Collector) error {
-	p.unregisterCount++
-	// Remove from counterNames so that NotContains assertions work correctly
-	// after a partial-registration rollback (mirrors real provider Unregister
-	// semantics where the counter is removed from the registry).
-	if cv, ok := c.(*sagaSpyCounterVec); ok {
-		delete(p.counterNames, cv.name)
-	}
-	return nil
 }
 
 type sagaSpyCounterVec struct {

--- a/framework/runtime/observability/metrics/session_cache.go
+++ b/framework/runtime/observability/metrics/session_cache.go
@@ -65,7 +65,7 @@ type SessionCacheCollector struct {
 //   - p == nil → errcode.KindInvalid + ErrObservabilityConfigInvalid
 //   - cellID == "" → errcode.KindInvalid + ErrObservabilityConfigInvalid
 //   - any CounterVec registration error is wrapped with the metric name and
-//     rolls back the counters registered earlier in the sequence (atomic).
+//     returned as a startup-fatal wiring error; caller owns provider lifecycle.
 func NewSessionCacheCollector(p kernelmetrics.Provider, cellID string) (*SessionCacheCollector, error) {
 	if p == nil {
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrObservabilityConfigInvalid,
@@ -75,8 +75,6 @@ func NewSessionCacheCollector(p kernelmetrics.Provider, cellID string) (*Session
 		return nil, errcode.New(errcode.KindInvalid, errcode.ErrObservabilityConfigInvalid,
 			"runtime/observability/metrics: SessionCacheCollector cellID is required")
 	}
-
-	var registered []kernelmetrics.Collector
 	c := &SessionCacheCollector{cellID: cellID}
 	var err error
 	if c.hits, err = registerCounterVec(p, kernelmetrics.CounterOpts{
@@ -84,7 +82,7 @@ func NewSessionCacheCollector(p kernelmetrics.Provider, cellID string) (*Session
 		Help: "Total session-cache hits (valid entry served from Redis without consulting the inner store). " +
 			"hits + misses = total Get() calls; read-path errors are a subset of misses.",
 		LabelNames: []string{"cell"},
-	}, &registered); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 	if c.misses, err = registerCounterVec(p, kernelmetrics.CounterOpts{
@@ -92,7 +90,7 @@ func NewSessionCacheCollector(p kernelmetrics.Provider, cellID string) (*Session
 		Help: "Total session-cache misses (no Redis entry; inner store consulted and result lazily populated). " +
 			"hits + misses = total Get() calls; read-path errors are a subset of misses.",
 		LabelNames: []string{"cell"},
-	}, &registered); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 	if c.errors, err = registerCounterVec(p, kernelmetrics.CounterOpts{
@@ -101,7 +99,7 @@ func NewSessionCacheCollector(p kernelmetrics.Provider, cellID string) (*Session
 			"Fail-safe — every read-path error degrades to a miss (errors ⊆ misses) — so this rate distinguishes a cold cache " +
 			"from a degraded Redis. Post-commit revoke DEL failures are a distinct series: session_cache_revoke_del_errors_total.",
 		LabelNames: []string{"cell"},
-	}, &registered); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 	if c.revokeDelErrors, err = registerCounterVec(p, kernelmetrics.CounterOpts{
@@ -111,7 +109,7 @@ func NewSessionCacheCollector(p kernelmetrics.Provider, cellID string) (*Session
 			"is tracked separately from session_cache_errors_total; a non-zero rate means invalidation latency degraded from " +
 			"near-zero to ≤ TTL (security-relevant).",
 		LabelNames: []string{"cell"},
-	}, &registered); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 	return c, nil

--- a/framework/runtime/observability/metrics/session_cache_test.go
+++ b/framework/runtime/observability/metrics/session_cache_test.go
@@ -48,20 +48,17 @@ func TestNewSessionCacheCollector_RegistersFourCounters(t *testing.T) {
 		"expected exactly %d counters, got %v", len(want), p.counterNames)
 }
 
-// TestNewSessionCacheCollector_AtomicRollback asserts that a mid-sequence
-// registration failure rolls back the counters registered earlier (no orphans),
-// mirroring SagaCollector.
-func TestNewSessionCacheCollector_AtomicRollback(t *testing.T) {
+// TestNewSessionCacheCollector_PartialRegistrationFailure_ReturnsError asserts
+// that a mid-sequence registration failure rejects the current wiring and
+// returns the metric-specific error.
+func TestNewSessionCacheCollector_PartialRegistrationFailure_ReturnsError(t *testing.T) {
 	p := newSagaSpyProvider()
 	p.failOnName = "session_cache_misses_total" // fail on the 2nd of 3
 	_, err := obmetrics.NewSessionCacheCollector(p, "accesscore")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "session_cache_misses_total")
-	// hits (registered first) must have been unregistered LIFO.
-	assert.Equal(t, 1, p.unregisterCount, "the first counter must be rolled back")
-	// The rolled-back counter must no longer appear in the registered map.
-	assert.NotContains(t, p.counterNames, "session_cache_hits_total",
-		"rolled-back counter must not remain registered")
+	assert.Contains(t, p.counterNames, "session_cache_hits_total",
+		"counter registered before the failure records the attempted startup wiring")
 }
 
 // TestSessionCacheCollector_RecordsEmitWithCellLabel asserts each Record* method

--- a/framework/runtime/observability/metrics/shutdown.go
+++ b/framework/runtime/observability/metrics/shutdown.go
@@ -3,7 +3,6 @@ package metrics
 import (
 	"context"
 	"fmt"
-	"slices"
 	"time"
 
 	kernelmetrics "github.com/ghbvf/gocell/framework/kernel/observability/metrics"
@@ -113,20 +112,11 @@ type ShutdownCollector struct {
 // metric family (typically a duplicate name in the same registry). Callers
 // treat this as fatal (consistent with relay_collector.go registration pattern).
 //
-// ref: kernel/outbox.NewProviderRelayCollector — rollback-on-partial-failure
-// pattern for metric registration.
+// Metric registration is startup-fatal: if one family cannot be registered, the
+// caller rejects the current wiring and owns provider lifecycle cleanup.
 func NewShutdownCollector(p kernelmetrics.Provider) (*ShutdownCollector, error) {
 	if p == nil {
 		return &ShutdownCollector{disabled: true}, nil
-	}
-
-	// Track registered collectors for rollback on partial failure.
-	var registered []kernelmetrics.Collector
-	rollback := func(origErr error) (*ShutdownCollector, error) {
-		for _, v := range slices.Backward(registered) {
-			_ = p.Unregister(v) // best-effort; ignore unregister errors
-		}
-		return nil, origErr
 	}
 
 	phaseEntries, err := p.CounterVec(kernelmetrics.CounterOpts{
@@ -135,9 +125,8 @@ func NewShutdownCollector(p kernelmetrics.Provider) (*ShutdownCollector, error) 
 		LabelNames: []string{"phase"},
 	})
 	if err != nil {
-		return rollback(fmt.Errorf(shutdownRegisterErrFmt, ShutdownPhaseCounterName, err))
+		return nil, fmt.Errorf(shutdownRegisterErrFmt, ShutdownPhaseCounterName, err)
 	}
-	registered = append(registered, phaseEntries)
 
 	phaseDuration, err := p.HistogramVec(kernelmetrics.HistogramOpts{
 		Name:       ShutdownPhaseDurationName,
@@ -146,9 +135,8 @@ func NewShutdownCollector(p kernelmetrics.Provider) (*ShutdownCollector, error) 
 		Buckets:    defaultShutdownBuckets,
 	})
 	if err != nil {
-		return rollback(fmt.Errorf(shutdownRegisterErrFmt, ShutdownPhaseDurationName, err))
+		return nil, fmt.Errorf(shutdownRegisterErrFmt, ShutdownPhaseDurationName, err)
 	}
-	registered = append(registered, phaseDuration)
 
 	shutdownTotal, err := p.CounterVec(kernelmetrics.CounterOpts{
 		Name:       ShutdownTotalCounterName,
@@ -156,7 +144,7 @@ func NewShutdownCollector(p kernelmetrics.Provider) (*ShutdownCollector, error) 
 		LabelNames: []string{"outcome"},
 	})
 	if err != nil {
-		return rollback(fmt.Errorf(shutdownRegisterErrFmt, ShutdownTotalCounterName, err))
+		return nil, fmt.Errorf(shutdownRegisterErrFmt, ShutdownTotalCounterName, err)
 	}
 
 	return &ShutdownCollector{

--- a/framework/runtime/observability/metrics/shutdown_test.go
+++ b/framework/runtime/observability/metrics/shutdown_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -109,9 +110,32 @@ func (p *shutdownFakeProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmet
 	return kernelmetrics.NopProvider{}.GaugeVec(opts)
 }
 
-func (p *shutdownFakeProvider) Unregister(_ kernelmetrics.Collector) error { return nil }
-
 var _ kernelmetrics.Provider = (*shutdownFakeProvider)(nil)
+
+type shutdownRegistrationFailureProvider struct {
+	failAtCounter int
+	failHistogram bool
+	counterCalls  int
+}
+
+func (p *shutdownRegistrationFailureProvider) CounterVec(opts kernelmetrics.CounterOpts) (kernelmetrics.CounterVec, error) {
+	p.counterCalls++
+	if p.failAtCounter > 0 && p.counterCalls == p.failAtCounter {
+		return nil, errors.New("duplicate counter")
+	}
+	return kernelmetrics.NopProvider{}.CounterVec(opts)
+}
+
+func (p *shutdownRegistrationFailureProvider) HistogramVec(opts kernelmetrics.HistogramOpts) (kernelmetrics.HistogramVec, error) {
+	if p.failHistogram {
+		return nil, errors.New("duplicate histogram")
+	}
+	return kernelmetrics.NopProvider{}.HistogramVec(opts)
+}
+
+func (p *shutdownRegistrationFailureProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetrics.GaugeVec, error) {
+	return kernelmetrics.NopProvider{}.GaugeVec(opts)
+}
 
 // ---------------------------------------------------------------------------
 // Test 6: nil-safety of ShutdownCollector methods (unit level)
@@ -138,6 +162,33 @@ func TestNewShutdownCollector_NilProvider(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, m, "nil provider must return a disabled ShutdownCollector")
 	assert.True(t, m.disabled)
+}
+
+func TestNewShutdownCollector_RegistrationFailure_ReturnsError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name          string
+		failAtCounter int
+		failHistogram bool
+		wantName      string
+	}{
+		{name: "phase_entries", failAtCounter: 1, wantName: ShutdownPhaseCounterName},
+		{name: "phase_duration", failHistogram: true, wantName: ShutdownPhaseDurationName},
+		{name: "shutdown_total", failAtCounter: 2, wantName: ShutdownTotalCounterName},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			provider := &shutdownRegistrationFailureProvider{
+				failAtCounter: tc.failAtCounter,
+				failHistogram: tc.failHistogram,
+			}
+			_, err := NewShutdownCollector(provider)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tc.wantName)
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/framework/runtime/transport/remote_integration_test.go
+++ b/framework/runtime/transport/remote_integration_test.go
@@ -164,7 +164,6 @@ func (cp *countingProvider) HistogramVec(opts kernelmetrics.HistogramOpts) (kern
 func (cp *countingProvider) GaugeVec(opts kernelmetrics.GaugeOpts) (kernelmetrics.GaugeVec, error) {
 	return kernelmetrics.NopProvider{}.GaugeVec(opts)
 }
-func (cp *countingProvider) Unregister(_ kernelmetrics.Collector) error { return nil }
 
 type countingVec struct {
 	base kernelmetrics.CounterVec


### PR DESCRIPTION
## Summary

Remove the public `metrics.Provider.Unregister` contract and make GoCell metrics provider lifecycle startup create-only.

## Why / 背景

Issue #880 identified that `Provider.Unregister` exposed a backend-specific Prometheus registry capability as if it were backend-neutral. OTel could only implement it as a silent no-op, so callers could incorrectly rely on partial-registration rollback semantics that did not exist across providers.

This PR makes registration failures startup-fatal wiring errors: callers discard the current provider/wiring instead of trying to unregister individual instruments and retry on the same provider.

## Refs

Closes #880

ref: opentelemetry-go metric/meter.go API/SDK lifecycle split
ref: prometheus/client_golang prometheus/registry.go registry-owned collector lifecycle

## Risk / 兼容性

Breaking interface change: `framework/kernel/observability/metrics.Provider` no longer has `Unregister`.

No compatibility shim is kept. Internal providers, callsites, and test doubles are updated. Prometheus-specific internal registry rollback in `hook_observer` is unchanged because it is not exposed through the backend-neutral Provider interface.

## Test plan

- [x] Per-module equivalent of `go build ./...` passed: `for d in $(go list -m -f '{{.Dir}}'); do (cd "$d" && go build ./...) || exit $?; done`
- [x] `go test ./adapters/otel ./adapters/prometheus ./framework/kernel/observability/metrics ./framework/runtime/observability/metrics ./framework/kernel/outbox ./framework/runtime/auth/refresh ./adapters/mqtt`
- [x] Per-module equivalent of `go test ./...` passed.
- [x] CI-form PR lint passed via `.github/workflows/_build-lint.yml` module loop with `--new-from-merge-base=origin/develop`; tools module passed separately with `--build-tags=archtest,releasesmoke --concurrency 2` after the all-module run was killed by local resource pressure.
- [x] `go test -tags archtest ./archtest -run 'Test(Metrics|Observability|.*Metrics.*|.*Observability.*)'` from `tools/`
