### PR TITLE
refactor(hooks): remove golangci-lint from pre-push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,8 @@ verify:
 # install-hooks points git at the tracked hack/githooks/ dir (per-repo
 # config, shared across all worktrees of this repo). Run once after clone
 # and after `git worktree add`. The pre-push hook runs the fast CI subset
-# (gofumpt / build+vet / codegen staleness) AI co-authors most often skip.
+# (gofumpt / build+vet / codegen staleness) AI co-authors most often skip;
+# CPU-heavy golangci-lint stays in CI / explicit developer commands.
 install-hooks:
 	git config core.hooksPath hack/githooks
 	@echo "core.hooksPath -> hack/githooks (pre-push active)"

--- a/hack/README.md
+++ b/hack/README.md
@@ -33,12 +33,14 @@ inert and there is no local protection.
 `hack/githooks/pre-push` runs the fast, deterministic, offline subset of CI
 that fresh-instance AI co-authors most often skip — gofumpt (scoped to the
 pushed `.go` files), `go build`/`vet` (incl. integration/e2e tags), and
-codegen staleness (`gocell verify generated`). Each tier only fires when
-the push actually touches the files it protects, so a docs-only push pays
-~0s. Honest scope: it checks the working tree (not the pushed commit) and
-`git push --no-verify` bypasses it — a fast feedback loop, not an
-unbypassable gate. See the header comment in `githooks/pre-push` for the
-full rationale and the deliberate CI-mirror deviations.
+codegen staleness (`gocell verify generated`). CPU-heavy golangci-lint is
+left to PR/push CI or explicit developer commands so `git push` is not held
+open by long static-analysis runs. Each tier only fires when the push
+actually touches the files it protects, so a docs-only push pays ~0s.
+Honest scope: it checks the working tree (not the pushed commit) and `git
+push --no-verify` bypasses it — a fast feedback loop, not an unbypassable
+gate. See the header comment in `githooks/pre-push` for the full rationale
+and the deliberate CI-mirror deviations.
 
 ## Adding a new gate
 

--- a/hack/githooks/pre-push
+++ b/hack/githooks/pre-push
@@ -4,10 +4,8 @@
 # memory: ai-robust.md §1). It is NOT a full `make verify` — only the
 # subset that is (a) deterministic offline, (b) sub-10s on a WARM cache,
 # (c) high "forgot to run" rate. Infra-bound gates (go test against
-# testcontainers) stay in CI. CI-faithful golangci-lint (deviation 5) is
-# the only inclusion that breaches the sub-10s budget on cold cache; it
-# is accepted because warm steady-state is ~7s alongside build/vet, and
-# the cold cost is unavoidable CI work that the push pays regardless.
+# testcontainers) and CPU-heavy static analysis stay in CI or explicit
+# developer-triggered commands instead of blocking `git push`.
 #
 # Not a 1:1 CI mirror — five deliberate deviations:
 #   - The gofumpt gate runs `go -C tools run mvdan.cc/gofumpt` (version
@@ -50,43 +48,20 @@
 #     Actions UI + workflow_dispatch rerun) — not in an implicit
 #     pre-push gate. Developers who want PR-time archtest feedback run
 #     `bash hack/verify-archtest.sh` or `make verify` explicitly.
-#   - golangci-lint runs CI-faithfully —
-#     `golangci-lint run --new-from-merge-base=origin/develop` per workspace
-#     module with the version pinned by hack/lib/golangci-lint.sh::
-#     GOLANGCI_LINT_VERSION (the project's single source of truth, which CI's
-#     lint step sources via the same gocell::golangci_lint::ensure; NOT go.mod
-#     like gofumpt — golangci-lint is not a go.mod tool dependency).
-#     Three honest caveats: (a) MEASURED cost is ~7s warm but ~295s
-#     (~5min) COLD — i.e. after `go clean -cache`, a dependency bump, or
-#     first use before golangci-lint's own ~/.cache is populated. This
-#     breaches the sub-10s budget in the cold case; it is accepted
-#     because the analysis is unavoidable work the push will incur in CI
-#     regardless — running it here shifts it earlier AND warms the cache
-#     for every subsequent push, and it rides the parallel fan-out so the
-#     warm steady state adds ≈0 wall time (7s alongside build/vet's ~7s).
-#     (b) base-ref is hard-pinned to origin/develop; PRs targeting
-#     main/release/* are linted against develop's merge-base, not their
-#     real target — a tolerated drift (develop is the integration branch
-#     for the overwhelming majority of PRs; the rare cross-target case is
-#     re-checked by PR-CI's own `--new-from-merge-base=origin/<base>`).
-#     (c) push-mode CI (ci.yml) runs golangci-lint with NO new-issues
-#     filter (full); this hook mirrors PR-mode CI (the gate that actually
-#     blocks merges), so it is intentionally *less* strict than push-CI,
-#     never more — it cannot produce "hook red / CI green". Resolution of
-#     the pinned binary failing (toolchain/install error) is fail-closed
-#     (run_bg sees non-zero → push blocked), per no-soft-fallback.
+#   - golangci-lint is NOT run here. It remains enforced by PR/push CI and
+#     available through explicit developer commands. The former hook-side
+#     inclusion regularly breached the sub-10s contract on cold caches and
+#     could monopolize CPU while Git held the push transaction open.
 #
 # Execution: every gate is independent (no shared mutable state; the Go
 # build/test cache is concurrency-safe across parallel `go` invocations),
-# so all of them — gofumpt / per-module build+vet / golangci-lint / codegen-
-# verify — run in a SINGLE parallel fan-out behind one wait barrier.
+# so all of them — gofumpt / per-module build+vet / codegen-verify — run in
+# a SINGLE parallel fan-out behind one wait barrier.
 # Wall cost is ~max(slowest gate), not the sum of serial tiers. Each gate
 # is still change-gated: a docs-only push launches nothing (~0s); a .go
-# push on a WARM cache pays ~max(build/vet/lint) ≈ 7-15s. Cold-cache is
-# dominated by golangci-lint (~5min measured, see deviation 5 —
-# unavoidable CI work, paid once, then warm); a schema/contract push
-# additionally runs the codegen staleness probe in the same fan-out (no
-# extra wall time unless it is the slowest job).
+# push on a WARM cache pays ~max(build/vet) ≈ 7-15s. A schema/contract
+# push additionally runs the codegen staleness probe in the same fan-out
+# (no extra wall time unless it is the slowest job).
 #
 # Honest scope (ai-robust grading): this is Medium AI-robust — `git push
 # --no-verify` bypasses it and a fresh clone/worktree without
@@ -212,6 +187,7 @@ fail=0
 # (header deviation 1: tools/go.mod is the only SoR, no PATH ambient). Cost: warm ~200ms; cold
 # gofumpt compile +~2-3s; first-ever module download +~1-2s — still well
 # under the build/vet cost that dominates a cold-cache push.
+# shellcheck disable=SC2329 # invoked indirectly via run_bg command arguments.
 gofumpt_gate() {
     local out
     local -a tool_args=()
@@ -234,71 +210,6 @@ gofumpt_gate() {
     return 0
 }
 
-# lint_gate runs CI-faithful golangci-lint in PR mode
-# (`--new-from-merge-base=origin/develop`). See header deviation 5 for the
-# measured cost (warm ~7s / cold ~5min), the base-ref pin rationale, and
-# why mirroring PR-mode (not push-mode) CI cannot produce "hook red / CI
-# green". The binary version is resolved through the project's single
-# source of truth — hack/lib/golangci-lint.sh (GOLANGCI_LINT_VERSION), which
-# CI's lint step sources via the same gocell::golangci_lint::ensure — NOT
-# go.mod (golangci-lint is not a go.mod tool dep,
-# unlike gofumpt; this is the one place the no-PATH-ambient rule routes
-# through the lib instead of `go run`). Fail-closed: any sourcing /
-# resolver / install error returns non-zero so run_bg blocks the push
-# (no-soft-fallback — never silently skip the gate).
-lint_gate() {
-    local bin module_dirs dir build_tags
-    # shellcheck source=/dev/null
-    if ! source "${ROOT}/hack/lib/golangci-lint.sh" 2>/dev/null; then
-        printf 'golangci-lint gate: cannot source hack/lib/golangci-lint.sh\n'
-        return 1
-    fi
-    # shellcheck source=/dev/null
-    if ! source "${ROOT}/hack/lib/modules.sh" 2>/dev/null; then
-        printf 'golangci-lint gate: cannot source hack/lib/modules.sh\n'
-        return 1
-    fi
-    if ! bin="$(gocell::golangci_lint::ensure)"; then
-        printf 'golangci-lint gate: version resolve/install failed (hack/lib/golangci-lint.sh)\n'
-        return 1
-    fi
-    # --new-from-merge-base needs the base ref present locally. Surface the
-    # actionable hint here rather than letting golangci-lint emit a raw git
-    # error (operator-hint parity with the gofumpt/codegen gates). Still
-    # fail-closed: missing base blocks the push — it never falls back to a
-    # full-repo lint (that would flag every pre-existing issue and block
-    # unconditionally) nor silently skips (no-soft-fallback).
-    if ! git rev-parse --verify --quiet "${BASE_BRANCH}^{commit}" >/dev/null; then
-        printf 'golangci-lint gate: %s not found locally (run: git fetch origin develop)\n' "${BASE_BRANCH}"
-        return 1
-    fi
-    # --timeout overrides golangci-lint's default; PR-mode on a multi-commit
-    # merge-base..HEAD range (especially after a develop sync) routinely needs
-    # more than the default on cold-cache. CI invokes the same pinned binary via
-    # hack/lib/golangci-lint.sh (gocell::golangci_lint::ensure) without an
-    # explicit --timeout, so this generous 10m local cap only keeps the hook from
-    # aborting a slow cold-cache range — it does not change which findings the
-    # hook vs. CI report (verdict parity comes from the shared binary + config,
-    # not the timeout).
-    if ! "${bin}" config verify --config "${ROOT}/.golangci.yml"; then
-        return 1
-    fi
-    if ! module_dirs="$(gocell::modules::dirs)"; then
-        printf 'golangci-lint gate: workspace module enumeration failed\n'
-        return 1
-    fi
-    while IFS= read -r dir; do
-        [[ -n "${dir}" && "${dir}" != "." ]] || continue
-        build_tags=""
-        [[ "${dir#./}" == "tools" ]] && build_tags="--build-tags=archtest,releasesmoke"
-        (
-            cd "${ROOT}/${dir}"
-            # shellcheck disable=SC2086 # build_tags is intentionally split into CLI flags.
-            "${bin}" run --config "${ROOT}/.golangci.yml" "--new-from-merge-base=${BASE_BRANCH}" --timeout=10m ${build_tags} ./...
-        ) || return 1
-    done <<<"${module_dirs}"
-}
-
 # ---------------------------------------------------------------------------
 # Single parallel fan-out. Every gate below is independent (no shared
 # mutable state; the Go build/test cache is concurrency-safe across
@@ -314,9 +225,6 @@ lint_gate() {
 #                               go.work funnel (root has no module post-#1565);
 #                               integration and e2e tags are header-documented
 #                               deliberate CI-structure deviations.
-#   Tier 4  golangci-lint     — CI-faithful PR-mode lint
-#                               (--new-from-merge-base=origin/develop);
-#                               warm ~7s, cold ~5min (deviation 5).
 #   Tier 3  codegen staleness — only when a codegen *source* changed; can
 #                               fire with go_changed=0 (schema/tmpl-only
 #                               push), so it has its own gate, not nested
@@ -378,8 +286,6 @@ if [[ ${go_changed} -eq 1 ]]; then
         note "FAIL: go.work module enumeration (hack/lib/modules.sh) failed — go.work modules NOT built/vetted; install jq and fix go.work, then re-push"
         fail=1
     fi
-
-    run_bg "golangci-lint (CI-faithful; run: make fmt / fix lint)" lint_gate
 fi
 
 if [[ ${codegen_changed} -eq 1 ]]; then


### PR DESCRIPTION
## Summary

Remove the golangci-lint gate from the local pre-push hook and update hook documentation to keep CPU-heavy static analysis in CI or explicit developer commands.

## Why / 背景

The pre-push hook currently starts a workspace-wide golangci-lint run for Go changes. That path can consume significant CPU, especially on cold caches, and keeps Git's push transaction open while lint runs. The hook's stated contract is a fast local feedback loop, so this PR keeps the lightweight gates in pre-push and leaves golangci-lint enforcement to PR/push CI.

## Refs

ref: git githooks(5) pre-push sample
ref: kubernetes/kubernetes hack/verify-*.sh diff-mode pattern

## Risk / 兼容性

No runtime or API impact. Local pre-push no longer catches lint findings before network push; PR/push CI still enforces golangci-lint. Developers can still run lint explicitly when needed.

## Test plan

- [x] `bash -n hack/githooks/pre-push`
- [x] `printf '' | bash hack/githooks/pre-push`
- [x] `bash hack/verify-shellcheck.sh`
- [x] `git diff --check`
- [x] `rg` assertion that `hack/githooks/pre-push` no longer contains hook-side golangci-lint execution path (`run_bg ... golangci`, `lint_gate`, `golangci_lint::ensure`, `--new-from-merge-base`)
- [x] Push exercised updated pre-push hook: `pre-push: ok (0s)`
