### PR TITLE
feat(scaffold): #1516 cross-module --cell flag for `gocell scaffold assembly`

### DIFF
--- a/cmd/gocell/app/main_test.go
+++ b/cmd/gocell/app/main_test.go
@@ -226,7 +226,7 @@ func TestSubcommandHelpFlagsRenderHelp(t *testing.T) {
 	}{
 		{"generate", runGenerate, []string{"Usage: gocell generate", "metrics-schema", "owned by gocell"}},
 		{"verify", runVerify, []string{"Usage: gocell verify", "generated", "stale, staged-only"}},
-		{"scaffold", runScaffold, []string{"Usage: gocell scaffold", "cell", "--dry-run"}},
+		{"scaffold", runScaffold, []string{"Usage: gocell scaffold", "cell", "--dry-run", "--cell <id"}},
 		{"check", runCheck, []string{"Usage: gocell check", "contract-health", "unconditional-skip"}},
 		// export now uses the same registry-derived help contract as the
 		// other help-bearing verb trees.

--- a/cmd/gocell/app/scaffold.go
+++ b/cmd/gocell/app/scaffold.go
@@ -291,7 +291,8 @@ var scaffoldSubcommands = []subcommand[func(ctx context.Context, root string, ar
 		name: "assembly",
 		help: []string{
 			"Create assemblies/<id>/assembly.yaml + cmd/<id>/run.go + app.go.",
-			"--id=<id> --cells=<a,b,...> --team=<team> --role=<role>",
+			"--id=<id> (--cells=<a,b,...> | --cell <id[@module]> ...) --team=<team> --role=<role>",
+			"--cell is repeatable; @module emits a cross-module cells[].{id,module} entry.",
 			"[--deploy=k8s|compose|binary] (default: k8s) [--skip-generate] [--dry-run]",
 			scaffoldIDNote,
 		},

--- a/cmd/gocell/app/scaffold.go
+++ b/cmd/gocell/app/scaffold.go
@@ -292,7 +292,10 @@ var scaffoldSubcommands = []subcommand[func(ctx context.Context, root string, ar
 		help: []string{
 			"Create assemblies/<id>/assembly.yaml + cmd/<id>/run.go + app.go.",
 			"--id=<id> (--cells=<a,b,...> | --cell <id[@module]> ...) --team=<team> --role=<role>",
-			"--cell is repeatable; @module emits a cross-module cells[].{id,module} entry.",
+			"--cells and --cell are mutually exclusive; --cell is repeatable and @module",
+			"emits a cross-module cells[].{id,module} entry (which auto-skips the K#10",
+			"derived files until go.work resolves the external module).",
+			"  e.g. --cell enrollcell@github.com/acme/mdm",
 			"[--deploy=k8s|compose|binary] (default: k8s) [--skip-generate] [--dry-run]",
 			scaffoldIDNote,
 		},

--- a/cmd/gocell/app/scaffold_assembly.go
+++ b/cmd/gocell/app/scaffold_assembly.go
@@ -24,16 +24,25 @@ import (
 // Flag set:
 //
 //	--id=<assemblyID>           required
-//	--cells=<a,b,c>             required (comma-separated existing cells)
+//	--cells=<a,b,c>             same-module cell IDs (mutually exclusive with --cell)
+//	--cell=<id[@module]>        repeatable cell entry; @module makes it cross-module
+//	                            (mutually exclusive with --cells)
 //	--team=<team>               required
 //	--role=<role>               required
 //	--deploy=<k8s|compose|binary> default k8s — k8s is omitted from yaml
 //	--dry-run                   render only, no writes
 //	--skip-generate             skip K#10 derived files (modules_gen.go / main.go / boundary.yaml)
+//
+// A cross-module --cell entry (id@module) emits the object form
+// cells[].{id,module} + build.compositionAPI: true, and implicitly skips the
+// K#10 derived files (the cross-module cell metadata is not locally resolvable;
+// see Generator.PlanAssemblyScaffold and #1516).
 func scaffoldAssembly(root string, args []string) error {
 	fs := flag.NewFlagSet("scaffold assembly", flag.ContinueOnError)
 	id := fs.String("id", "", "assembly ID (required)")
-	cells := fs.String("cells", "", "comma-separated cell IDs (required, must already exist)")
+	cells := fs.String("cells", "", "comma-separated same-module cell IDs (mutually exclusive with --cell)")
+	var cellEntries repeatedFlag
+	fs.Var(&cellEntries, "cell", "cell entry <id[@module]> (repeatable; @module = cross-module; mutually exclusive with --cells)")
 	team := fs.String("team", "", "owner team (required)")
 	role := fs.String("role", "", "owner role, e.g. maintainer (required)")
 	deploy := fs.String("deploy", "k8s", "deployment template: one of [k8s compose binary]")
@@ -45,7 +54,7 @@ func scaffoldAssembly(root string, args []string) error {
 		return err
 	}
 
-	asmID, cellList, err := validateAssemblyFlags(*id, *cells, *team, *role)
+	asmID, cellRefs, err := validateAssemblyFlags(*id, *team, *role, *cells, cellEntries)
 	if err != nil {
 		return err
 	}
@@ -67,7 +76,7 @@ func scaffoldAssembly(root string, args []string) error {
 
 	spec := assembly.AssemblyScaffoldSpec{
 		ID:           asmID,
-		Cells:        cellList,
+		Cells:        cellRefs,
 		OwnerTeam:    *team,
 		OwnerRole:    *role,
 		Deploy:       *deploy,
@@ -107,33 +116,65 @@ func scaffoldAssembly(root string, args []string) error {
 		Target: filepath.Join("assemblies", *id),
 	})
 
-	if *skipGenerate {
+	switch {
+	case *skipGenerate:
 		fmt.Printf("scaffold assembly: skipped auto-generate (--skip-generate). "+
 			"Run `gocell generate assembly --id=%s` to materialize "+
 			"modules_gen.go / main.go / boundary.yaml.\n", *id)
+	case hasCrossModuleCell(cellRefs, mod):
+		// Mirrors the generator's derived-file skip for cross-module specs
+		// (Generator.specHasCrossModule): cross-module cell metadata is not locally
+		// resolvable (#1515), so only the assembly.yaml + skeleton are emitted.
+		fmt.Printf("scaffold assembly: cross-module cells present — emitted assembly.yaml "+
+			"(build.compositionAPI: true) + skeleton; K#10 derived files skipped. "+
+			"Run `gocell generate assembly --id=%s` once the cross-module cells are "+
+			"resolvable (go.work / #1515) to materialize modules_gen.go / main.go / boundary.yaml.\n", *id)
 	}
 	return nil
 }
 
+// hasCrossModuleCell reports whether any ref names a cell in a Go module other
+// than the assembly's own (ownModule). It mirrors Generator.crossModule so the
+// CLI hint fires exactly when the generator skipped the derived files.
+func hasCrossModuleCell(refs []assembly.ScaffoldCellRef, ownModule string) bool {
+	for _, r := range refs {
+		if r.Module != "" && r.Module != ownModule {
+			return true
+		}
+	}
+	return false
+}
+
+// repeatedFlag collects a repeatable string flag (e.g. --cell a --cell b) into
+// a slice, in flag order. Go's flag package has no native repeatable flag.
+type repeatedFlag []string
+
+func (r *repeatedFlag) String() string { return strings.Join(*r, ",") }
+
+func (r *repeatedFlag) Set(v string) error {
+	*r = append(*r, v)
+	return nil
+}
+
 // validateAssemblyFlags consolidates the required-field + identifier-pattern
-// + free-text control-char checks for `gocell scaffold assembly` flags.
-// Returns the parsed cell list on success. Lifted out of scaffoldAssembly to
-// keep cognitive complexity inside the project budget.
+// + free-text control-char checks for `gocell scaffold assembly` flags and
+// resolves the cell list from the (mutually exclusive) --cells / --cell inputs.
+// Lifted out of scaffoldAssembly to keep cognitive complexity within budget.
 //
 // Routes through kernel/metadata single-source helpers: MatchAssemblyID (--id),
-// MatchCellID (--cells[] elements), IsValidMetadataText (--team / --role).
-// AssemblyIDPattern / CellIDPattern character set physically excludes path
-// separators and control characters, so the legacy validateScaffoldID
-// defensive layer is not needed on this flag path.
+// CellIDPattern (cell ids via scaffoldid.Parse), MatchAssemblyModulePath (cell
+// module paths), IsValidMetadataText (--team / --role). Module-path hygiene here
+// is an early, precise diagnostic; the authoritative closed funnel is the
+// generator's validateAssemblyScaffoldSpec (a spec built by any caller is
+// re-validated there).
 //
 // ref: kubernetes/apimachinery pkg/util/validation/validation.go — single
 // exported helper IsDNS1123Label invoked from CLI, scaffold, and admission.
-func validateAssemblyFlags(id, cells, team, role string) (scaffoldid.ScaffoldID, []scaffoldid.ScaffoldID, error) {
+func validateAssemblyFlags(
+	id, team, role, cellsCSV string, cellEntries []string,
+) (scaffoldid.ScaffoldID, []assembly.ScaffoldCellRef, error) {
 	if id == "" {
 		return scaffoldid.ScaffoldID{}, nil, fmt.Errorf("--id is required")
-	}
-	if cells == "" {
-		return scaffoldid.ScaffoldID{}, nil, fmt.Errorf("--cells is required")
 	}
 	if team == "" {
 		return scaffoldid.ScaffoldID{}, nil, fmt.Errorf("--team is required")
@@ -162,26 +203,130 @@ func validateAssemblyFlags(id, cells, team, role string) (scaffoldid.ScaffoldID,
 			"--role contains forbidden control characters",
 			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("flag=--role value=%q", role))))
 	}
-	rawCells := splitAndTrim(cells, ",")
-	if len(rawCells) == 0 {
-		return scaffoldid.ScaffoldID{}, nil, fmt.Errorf("--cells must list at least one cell")
+	refs, err := parseScaffoldCells(cellsCSV, cellEntries)
+	if err != nil {
+		return scaffoldid.ScaffoldID{}, nil, err
 	}
-	cellList := make([]scaffoldid.ScaffoldID, 0, len(rawCells))
-	for _, c := range rawCells {
-		parsed, err := scaffoldid.Parse(c)
+	return asmID, refs, nil
+}
+
+// parseScaffoldCells resolves the cell list from the mutually exclusive --cells
+// (same-module CSV shorthand) and --cell (repeatable, cross-module-capable)
+// flags. Exactly one source must be supplied; each is parsed and de-duplicated
+// by its own helper.
+func parseScaffoldCells(cellsCSV string, cellEntries []string) ([]assembly.ScaffoldCellRef, error) {
+	haveCells := strings.TrimSpace(cellsCSV) != ""
+	haveCell := len(cellEntries) > 0
+	switch {
+	case haveCells && haveCell:
+		return nil, errcode.New(errcode.KindInvalid, ErrScaffoldInvalidOpts,
+			"--cells and --cell are mutually exclusive; use --cell for cross-module entries",
+			errcode.WithInternal(errcode.InternalAttr("_", "both --cells and --cell supplied")))
+	case haveCell:
+		return parseCellFlagEntries(cellEntries)
+	case haveCells:
+		return parseCellsCSV(cellsCSV)
+	default:
+		return nil, fmt.Errorf("one of --cells or --cell is required")
+	}
+}
+
+// parseCellFlagEntries parses the repeatable --cell <id[@module]> entries,
+// rejecting duplicate cell ids.
+func parseCellFlagEntries(entries []string) ([]assembly.ScaffoldCellRef, error) {
+	refs := make([]assembly.ScaffoldCellRef, 0, len(entries))
+	seen := make(map[string]bool, len(entries))
+	for _, raw := range entries {
+		ref, err := parseCellEntry(raw)
 		if err != nil {
-			return scaffoldid.ScaffoldID{}, nil, errcode.Wrap(errcode.KindInvalid, ErrScaffoldInvalidOpts,
-				"--cells[] entry does not match metadata CellIDPattern", err,
-				errcode.WithDetails(
-					errcode.PublicString("flag", "--cells[]"),
-					errcode.PublicString("pattern", metadata.CellIDPattern),
-				),
-				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("flag=--cells[] value=%q pattern=%s",
-					c, metadata.CellIDPattern))))
+			return nil, err
 		}
-		cellList = append(cellList, parsed)
+		if err := markSeenCell(seen, ref.ID.String()); err != nil {
+			return nil, err
+		}
+		refs = append(refs, ref)
 	}
-	return asmID, cellList, nil
+	return refs, nil
+}
+
+// parseCellsCSV parses the same-module --cells=a,b,c shorthand into bare-id
+// refs, rejecting duplicates. An embedded '@' fails scaffoldid.Parse, keeping
+// this flag same-module only.
+func parseCellsCSV(cellsCSV string) ([]assembly.ScaffoldCellRef, error) {
+	raws := splitAndTrim(cellsCSV, ",")
+	refs := make([]assembly.ScaffoldCellRef, 0, len(raws))
+	seen := make(map[string]bool, len(raws))
+	for _, raw := range raws {
+		cid, err := scaffoldid.Parse(raw)
+		if err != nil {
+			return nil, wrapBadCellID("--cells[]", raw, err)
+		}
+		if err := markSeenCell(seen, cid.String()); err != nil {
+			return nil, err
+		}
+		refs = append(refs, assembly.ScaffoldCellRef{ID: cid})
+	}
+	if len(refs) == 0 {
+		return nil, fmt.Errorf("--cells must list at least one cell")
+	}
+	return refs, nil
+}
+
+// markSeenCell records id in seen, returning a duplicate-cell error if it was
+// already present.
+func markSeenCell(seen map[string]bool, id string) error {
+	if seen[id] {
+		return errcode.New(errcode.KindInvalid, ErrScaffoldInvalidOpts,
+			"duplicate cell",
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("cell=%q", id))))
+	}
+	seen[id] = true
+	return nil
+}
+
+// parseCellEntry parses one --cell value of the form <id> or <id@module>. The id
+// is validated against CellIDPattern; a non-empty module is validated against
+// MatchAssemblyModulePath (rejecting characters that could break out of the
+// generated cellmodules import literal). An empty module after '@' is rejected.
+func parseCellEntry(raw string) (assembly.ScaffoldCellRef, error) {
+	raw = strings.TrimSpace(raw)
+	idPart, modulePart, hasAt := strings.Cut(raw, "@")
+	cid, err := scaffoldid.Parse(idPart)
+	if err != nil {
+		return assembly.ScaffoldCellRef{}, wrapBadCellID("--cell", idPart, err)
+	}
+	if !hasAt {
+		return assembly.ScaffoldCellRef{ID: cid}, nil
+	}
+	if modulePart == "" {
+		return assembly.ScaffoldCellRef{}, errcode.New(errcode.KindInvalid, ErrScaffoldInvalidOpts,
+			"--cell module is empty after '@' (omit '@' for a same-module cell)",
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("flag=--cell value=%q", raw))))
+	}
+	if !metadata.MatchAssemblyModulePath(modulePart) {
+		return assembly.ScaffoldCellRef{}, errcode.New(errcode.KindInvalid, ErrScaffoldInvalidOpts,
+			"--cell module path has an invalid character",
+			errcode.WithDetails(
+				errcode.PublicString("flag", "--cell"),
+				errcode.PublicString("pattern", metadata.AssemblyModulePathPattern),
+			),
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("flag=--cell module=%q pattern=%s",
+				modulePart, metadata.AssemblyModulePathPattern))))
+	}
+	return assembly.ScaffoldCellRef{ID: cid, Module: modulePart}, nil
+}
+
+// wrapBadCellID wraps a scaffoldid.Parse failure for a cell id supplied via
+// flagName into the shared ERR_SCAFFOLD_INVALID_OPTS diagnostic.
+func wrapBadCellID(flagName, value string, err error) error {
+	return errcode.Wrap(errcode.KindInvalid, ErrScaffoldInvalidOpts,
+		"cell id does not match metadata CellIDPattern", err,
+		errcode.WithDetails(
+			errcode.PublicString("flag", flagName),
+			errcode.PublicString("pattern", metadata.CellIDPattern),
+		),
+		errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("flag=%s value=%q pattern=%s",
+			flagName, value, metadata.CellIDPattern))))
 }
 
 // splitAndTrim splits s by sep and trims whitespace from each segment;

--- a/cmd/gocell/app/scaffold_assembly.go
+++ b/cmd/gocell/app/scaffold_assembly.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/framework/pkg/pathsafe"
 	"github.com/ghbvf/gocell/framework/pkg/scaffoldid"
+	"github.com/ghbvf/gocell/tools/gomodutil"
 )
 
 // scaffoldAssembly is the subcommand entry for `gocell scaffold assembly`.
@@ -125,11 +126,18 @@ func scaffoldAssembly(root string, args []string) error {
 		// Cross-module cell metadata is not locally resolvable, so only the
 		// assembly.yaml (build.compositionAPI: true) + run.go/app.go skeleton are
 		// emitted; the K#10 derived files are deferred (mirrors --skip-generate).
+		// The hint keeps the two distinct prerequisites separate (Go build vs
+		// GoCell metadata discovery) and does not over-promise a working build:
+		// the generated run.go skeleton is the legacy form and still needs manual
+		// composition wiring for cross-module assemblies (tracked on PR #2480).
 		fmt.Printf("scaffold assembly: cross-module cell(s) present — wrote assembly.yaml "+
 			"(build.compositionAPI: true) + skeleton; derived files (modules_gen.go / "+
-			"main.go / boundary.yaml) skipped.\nNext: (1) add the external module(s) to "+
-			"your go.work so the cross-module cells build locally, then (2) run "+
-			"`gocell generate assembly --id=%s` to materialize them.\n", *id)
+			"main.go / boundary.yaml) skipped.\nBefore `gocell generate assembly --id=%s` "+
+			"can materialize them, the cross-module cells must be (a) buildable — add the "+
+			"external module(s) to your go.work — and (b) metadata-discoverable in this "+
+			"project (e.g. workspace mode via .gocell/manifest.yaml; see "+
+			"docs/guides/cell-development-guide.md). The compositionAPI run.go wiring may "+
+			"still need manual completion.\n", *id)
 	}
 	return nil
 }
@@ -306,22 +314,18 @@ func parseCellEntry(raw string) (assembly.ScaffoldCellRef, error) {
 			"--cell module is empty after '@' (omit '@' for a same-module cell)",
 			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("flag=--cell value=%q", raw))))
 	}
-	// '@' is the id@module delimiter; a Go module path never contains '@', so a
-	// second '@' (e.g. id@@module) is a typo rather than a valid module path.
-	if strings.Contains(modulePart, "@") {
-		return assembly.ScaffoldCellRef{}, errcode.New(errcode.KindInvalid, ErrScaffoldInvalidOpts,
-			"--cell module path must not contain '@' (expected <id>@<module>)",
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("flag=--cell value=%q", raw))))
-	}
-	if !metadata.MatchAssemblyModulePath(modulePart) {
-		return assembly.ScaffoldCellRef{}, errcode.New(errcode.KindInvalid, ErrScaffoldInvalidOpts,
-			"--cell module path has an invalid character",
-			errcode.WithDetails(
-				errcode.PublicString("flag", "--cell"),
-				errcode.PublicString("pattern", metadata.AssemblyModulePathPattern),
-			),
-			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("flag=--cell module=%q pattern=%s",
-				modulePart, metadata.AssemblyModulePathPattern))))
+	// The module value flows into the generated "<module>/cellmodules/<id>" import,
+	// so validate it as a Go import path via the single-source gomodutil helper
+	// (the same one --module-path uses). It is stronger than the metadata
+	// char-blocklist: it also rejects '@', whitespace, and trailing/double slashes
+	// that would corrupt the emitted import. The generator-side funnel
+	// (validateAssemblyScaffoldSpec → MatchAssemblyModulePath) stays as the
+	// YAML/import-literal hygiene check that must mirror the assembly.yaml decoder.
+	if err := gomodutil.ValidateModulePath(modulePart); err != nil {
+		return assembly.ScaffoldCellRef{}, errcode.Wrap(errcode.KindInvalid, ErrScaffoldInvalidOpts,
+			"--cell module is not a valid Go module path", err,
+			errcode.WithDetails(errcode.PublicString("flag", "--cell")),
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("flag=--cell module=%q", modulePart))))
 	}
 	return assembly.ScaffoldCellRef{ID: cid, Module: modulePart}, nil
 }

--- a/cmd/gocell/app/scaffold_assembly.go
+++ b/cmd/gocell/app/scaffold_assembly.go
@@ -42,7 +42,7 @@ func scaffoldAssembly(root string, args []string) error {
 	id := fs.String("id", "", "assembly ID (required)")
 	cells := fs.String("cells", "", "comma-separated same-module cell IDs (mutually exclusive with --cell)")
 	var cellEntries repeatedFlag
-	fs.Var(&cellEntries, "cell", "cell entry <id[@module]> (repeatable; @module = cross-module; mutually exclusive with --cells)")
+	fs.Var(&cellEntries, "cell", "cell entry <id[@module]>; repeatable; @module = cross-module; exclusive with --cells")
 	team := fs.String("team", "", "owner team (required)")
 	role := fs.String("role", "", "owner role, e.g. maintainer (required)")
 	deploy := fs.String("deploy", "k8s", "deployment template: one of [k8s compose binary]")
@@ -122,23 +122,25 @@ func scaffoldAssembly(root string, args []string) error {
 			"Run `gocell generate assembly --id=%s` to materialize "+
 			"modules_gen.go / main.go / boundary.yaml.\n", *id)
 	case hasCrossModuleCell(cellRefs, mod):
-		// Mirrors the generator's derived-file skip for cross-module specs
-		// (Generator.specHasCrossModule): cross-module cell metadata is not locally
-		// resolvable (#1515), so only the assembly.yaml + skeleton are emitted.
-		fmt.Printf("scaffold assembly: cross-module cells present — emitted assembly.yaml "+
-			"(build.compositionAPI: true) + skeleton; K#10 derived files skipped. "+
-			"Run `gocell generate assembly --id=%s` once the cross-module cells are "+
-			"resolvable (go.work / #1515) to materialize modules_gen.go / main.go / boundary.yaml.\n", *id)
+		// Cross-module cell metadata is not locally resolvable, so only the
+		// assembly.yaml (build.compositionAPI: true) + run.go/app.go skeleton are
+		// emitted; the K#10 derived files are deferred (mirrors --skip-generate).
+		fmt.Printf("scaffold assembly: cross-module cell(s) present — wrote assembly.yaml "+
+			"(build.compositionAPI: true) + skeleton; derived files (modules_gen.go / "+
+			"main.go / boundary.yaml) skipped.\nNext: (1) add the external module(s) to "+
+			"your go.work so the cross-module cells build locally, then (2) run "+
+			"`gocell generate assembly --id=%s` to materialize them.\n", *id)
 	}
 	return nil
 }
 
 // hasCrossModuleCell reports whether any ref names a cell in a Go module other
-// than the assembly's own (ownModule). It mirrors Generator.crossModule so the
-// CLI hint fires exactly when the generator skipped the derived files.
+// than the assembly's own (ownModule). It uses the same assembly.IsCrossModule
+// predicate the generator uses for its derived-file skip, so the CLI hint fires
+// exactly when the generator skipped the derived files (no duplicated logic).
 func hasCrossModuleCell(refs []assembly.ScaffoldCellRef, ownModule string) bool {
 	for _, r := range refs {
-		if r.Module != "" && r.Module != ownModule {
+		if assembly.IsCrossModule(r.Module, ownModule) {
 			return true
 		}
 	}
@@ -278,6 +280,7 @@ func markSeenCell(seen map[string]bool, id string) error {
 	if seen[id] {
 		return errcode.New(errcode.KindInvalid, ErrScaffoldInvalidOpts,
 			"duplicate cell",
+			errcode.WithDetails(errcode.PublicString("cell", id)),
 			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("cell=%q", id))))
 	}
 	seen[id] = true
@@ -301,6 +304,13 @@ func parseCellEntry(raw string) (assembly.ScaffoldCellRef, error) {
 	if modulePart == "" {
 		return assembly.ScaffoldCellRef{}, errcode.New(errcode.KindInvalid, ErrScaffoldInvalidOpts,
 			"--cell module is empty after '@' (omit '@' for a same-module cell)",
+			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("flag=--cell value=%q", raw))))
+	}
+	// '@' is the id@module delimiter; a Go module path never contains '@', so a
+	// second '@' (e.g. id@@module) is a typo rather than a valid module path.
+	if strings.Contains(modulePart, "@") {
+		return assembly.ScaffoldCellRef{}, errcode.New(errcode.KindInvalid, ErrScaffoldInvalidOpts,
+			"--cell module path must not contain '@' (expected <id>@<module>)",
 			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("flag=--cell value=%q", raw))))
 	}
 	if !metadata.MatchAssemblyModulePath(modulePart) {

--- a/cmd/gocell/app/scaffold_assembly_test.go
+++ b/cmd/gocell/app/scaffold_assembly_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ghbvf/gocell/framework/kernel/metadata"
 )
 
 // TestRunScaffoldAssembly_Basic is a RED test for K#09 `gocell scaffold assembly`:
@@ -412,4 +414,252 @@ l0Dependencies: []
 		t.Fatal(err)
 	}
 	return root
+}
+
+// writeAssemblyTestCell adds a cell.yaml skeleton for cellID under an existing
+// project root (companion to setupAssemblyTestProject for multi-cell fixtures).
+func writeAssemblyTestCell(t *testing.T, root, cellID string) {
+	t.Helper()
+	cellDir := filepath.Join(root, "cells", cellID)
+	if err := os.MkdirAll(cellDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cellYAML := `id: ` + cellID + `
+type: core
+consistencyLevel: L1
+durabilityMode: durable
+owner:
+  team: platform
+  role: cell-owner
+schema:
+  primary: ` + cellID + `
+verify:
+  smoke:
+    - smoke.` + cellID + `.startup
+goStructName: ExampleCell
+l0Dependencies: []
+`
+	if err := os.WriteFile(filepath.Join(cellDir, "cell.yaml"), []byte(cellYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1516 cross-module --cell flag (RED — scaffoldAssembly has no --cell flag yet)
+// ---------------------------------------------------------------------------
+
+const crossModuleMDM = "github.com/ghbvf/gocell-mdm"
+
+// TestRunScaffoldAssembly_CellFlag_SameModule asserts the new repeatable --cell
+// flag with a bare id (no @module) is the same-module form: behaves identically
+// to --cells=<id> (skeleton + K#10 derived files, no compositionAPI).
+func TestRunScaffoldAssembly_CellFlag_SameModule(t *testing.T) {
+	t.Parallel()
+	root := setupAssemblyTestProject(t, "examplecell")
+
+	args := []string{
+		"--id=samemod",
+		"--cell=examplecell",
+		"--team=platform",
+		"--role=maintainer",
+	}
+	if err := scaffoldAssembly(root, args); err != nil {
+		t.Fatalf("scaffoldAssembly --cell same-module: %v", err)
+	}
+	// Full 6-file plan (same-module is unchanged behavior).
+	for _, rel := range sixFileRels("samemod") {
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(rel))); err != nil {
+			t.Errorf("same-module --cell missing %s: %v", rel, err)
+		}
+	}
+	asmYAML, _ := os.ReadFile(filepath.Join(root, "assemblies", "samemod", "assembly.yaml")) //nolint:gosec // tempdir test fixture
+	if strings.Contains(string(asmYAML), "module:") || strings.Contains(string(asmYAML), "compositionAPI") {
+		t.Errorf("same-module --cell must not emit module/compositionAPI; got:\n%s", asmYAML)
+	}
+}
+
+// TestRunScaffoldAssembly_CellFlag_CrossModule asserts that --cell id@module
+// emits object-form cells[].{id,module} + build.compositionAPI: true, and that
+// cross-module entries auto-skip the K#10 derived files (cross-module cell
+// metadata is not locally resolvable — #1515 boundary) with an actionable hint.
+func TestRunScaffoldAssembly_CellFlag_CrossModule(t *testing.T) {
+	t.Parallel()
+	root := setupAssemblyTestProject(t, "examplecell")
+
+	args := []string{
+		"--id=mdm",
+		"--cell=examplecell",
+		"--cell=enrollcell@" + crossModuleMDM,
+		"--team=mdm",
+		"--role=maintainer",
+	}
+	var runErr error
+	out := captureStdout(t, func() { runErr = scaffoldAssembly(root, args) })
+	if runErr != nil {
+		t.Fatalf("scaffoldAssembly --cell cross-module: %v", runErr)
+	}
+
+	asmYAML, err := os.ReadFile(filepath.Join(root, "assemblies", "mdm", "assembly.yaml")) //nolint:gosec // tempdir test fixture
+	if err != nil {
+		t.Fatalf("read assembly.yaml: %v", err)
+	}
+	got := string(asmYAML)
+	for _, want := range []string{"enrollcell", crossModuleMDM, "compositionAPI: true"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("cross-module assembly.yaml missing %q; got:\n%s", want, got)
+		}
+	}
+
+	// Cross-module ⟹ K#10 derived files auto-skipped; skeleton still written.
+	for _, rel := range []string{"assemblies/mdm/assembly.yaml", "cmd/mdm/run.go", "cmd/mdm/app.go"} {
+		if _, statErr := os.Stat(filepath.Join(root, filepath.FromSlash(rel))); statErr != nil {
+			t.Errorf("cross-module skeleton missing %s: %v", rel, statErr)
+		}
+	}
+	for _, rel := range []string{"cmd/mdm/modules_gen.go", "cmd/mdm/main.go", "assemblies/mdm/generated/boundary.yaml"} {
+		if _, statErr := os.Stat(filepath.Join(root, filepath.FromSlash(rel))); statErr == nil {
+			t.Errorf("cross-module must auto-skip derived file %s, but it exists", rel)
+		}
+	}
+	if !strings.Contains(out, "gocell generate assembly") {
+		t.Errorf("cross-module scaffold must print an actionable generate hint; got:\n%s", out)
+	}
+}
+
+// TestRunScaffoldAssembly_CrossModule_RoundTripParse is the correctness guard
+// for YAML synthesis: re-parse the generated assembly.yaml and assert the
+// AssemblyCellRef{ID,Module} set + Build.CompositionAPI round-trip exactly
+// (stronger than string-contains; catches flow-mapping/quoting drift).
+func TestRunScaffoldAssembly_CrossModule_RoundTripParse(t *testing.T) {
+	t.Parallel()
+	root := setupAssemblyTestProject(t, "examplecell")
+	writeAssemblyTestCell(t, root, "enrollcell") // present locally (workspace mode) so full-project Parse resolves
+
+	args := []string{
+		"--id=mdm",
+		"--cell=examplecell",
+		"--cell=enrollcell@" + crossModuleMDM,
+		"--team=mdm",
+		"--role=maintainer",
+		"--skip-generate", // round-trip only needs the assembly.yaml
+	}
+	if err := scaffoldAssembly(root, args); err != nil {
+		t.Fatalf("scaffoldAssembly cross-module round-trip: %v", err)
+	}
+
+	project, err := metadata.NewParser(root).Parse()
+	if err != nil {
+		t.Fatalf("re-parse project: %v", err)
+	}
+	asm := project.Assemblies["mdm"]
+	if asm == nil {
+		t.Fatalf("parsed project missing assembly mdm; assemblies=%v", project.Assemblies)
+	}
+	want := []metadata.AssemblyCellRef{
+		{ID: "examplecell"},
+		{ID: "enrollcell", Module: crossModuleMDM},
+	}
+	if len(asm.Cells) != len(want) {
+		t.Fatalf("round-trip cells len=%d want %d (%v)", len(asm.Cells), len(want), asm.Cells)
+	}
+	for i, w := range want {
+		if asm.Cells[i].ID != w.ID || asm.Cells[i].Module != w.Module {
+			t.Errorf("round-trip cells[%d]=%+v want %+v", i, asm.Cells[i], w)
+		}
+	}
+	if !asm.Build.CompositionAPI {
+		t.Errorf("round-trip: cross-module assembly must parse back with build.compositionAPI=true")
+	}
+}
+
+// TestRunScaffoldAssembly_CellFlag_BadModule rejects malformed module strings
+// (control/space/quote/backslash) and an empty module after '@'.
+func TestRunScaffoldAssembly_CellFlag_BadModule(t *testing.T) {
+	t.Parallel()
+	root := setupAssemblyTestProject(t, "examplecell")
+
+	cases := []struct {
+		name string
+		cell string
+	}{
+		{"space_in_module", "examplecell@github.com/acme/bad cell"},
+		{"quote_in_module", "examplecell@github.com/acme/\"x"},
+		{"backslash_in_module", "examplecell@github.com/acme/x\\y"},
+		{"empty_module_after_at", "examplecell@"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := scaffoldAssembly(root, []string{
+				"--id=mdm", "--cell=" + tc.cell, "--team=mdm", "--role=maintainer", "--dry-run",
+			})
+			if err == nil {
+				t.Fatalf("expected rejection for --cell=%q, got nil", tc.cell)
+			}
+			if !strings.Contains(err.Error(), "ERR_SCAFFOLD_INVALID_OPTS") {
+				t.Errorf("expected ERR_SCAFFOLD_INVALID_OPTS; got %v", err)
+			}
+		})
+	}
+}
+
+// TestRunScaffoldAssembly_DuplicateCells rejects duplicate cell ids within
+// either flag, naming the offending cell.
+func TestRunScaffoldAssembly_DuplicateCells(t *testing.T) {
+	t.Parallel()
+	root := setupAssemblyTestProject(t, "examplecell")
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"dup_in_cell", []string{"--cell=examplecell", "--cell=examplecell"}},
+		{"dup_in_cells", []string{"--cells=examplecell,examplecell"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			args := append([]string{"--id=mdm", "--team=mdm", "--role=maintainer", "--dry-run"}, tc.args...)
+			err := scaffoldAssembly(root, args)
+			if err == nil {
+				t.Fatalf("expected duplicate-cell rejection, got nil")
+			}
+			if !strings.Contains(err.Error(), "examplecell") {
+				t.Errorf("duplicate error must name the cell; got %v", err)
+			}
+		})
+	}
+}
+
+// TestRunScaffoldAssembly_CellsAndCellMutuallyExclusive rejects supplying both
+// --cells and --cell (ambiguous startup order).
+func TestRunScaffoldAssembly_CellsAndCellMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+	root := setupAssemblyTestProject(t, "examplecell")
+
+	err := scaffoldAssembly(root, []string{
+		"--id=mdm", "--cells=examplecell", "--cell=examplecell",
+		"--team=mdm", "--role=maintainer", "--dry-run",
+	})
+	if err == nil {
+		t.Fatal("expected mutual-exclusivity rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "ERR_SCAFFOLD_INVALID_OPTS") {
+		t.Errorf("expected ERR_SCAFFOLD_INVALID_OPTS; got %v", err)
+	}
+}
+
+// TestRunScaffoldAssembly_NeitherCellsNorCell rejects supplying neither flag.
+func TestRunScaffoldAssembly_NeitherCellsNorCell(t *testing.T) {
+	t.Parallel()
+	root := setupAssemblyTestProject(t, "examplecell")
+
+	err := scaffoldAssembly(root, []string{
+		"--id=mdm", "--team=mdm", "--role=maintainer", "--dry-run",
+	})
+	if err == nil {
+		t.Fatal("expected error when neither --cells nor --cell is given, got nil")
+	}
 }

--- a/cmd/gocell/app/scaffold_assembly_test.go
+++ b/cmd/gocell/app/scaffold_assembly_test.go
@@ -478,6 +478,33 @@ func TestRunScaffoldAssembly_CellFlag_SameModule(t *testing.T) {
 	}
 }
 
+// TestRunScaffoldAssembly_CellFlag_ExplicitSameModule asserts that --cell with
+// an explicit module equal to the assembly's own module is treated as
+// same-module: full 6-file plan, no compositionAPI, no module object form.
+func TestRunScaffoldAssembly_CellFlag_ExplicitSameModule(t *testing.T) {
+	t.Parallel()
+	root := setupAssemblyTestProject(t, "examplecell")
+
+	args := []string{
+		"--id=explicitsame",
+		"--cell=examplecell@github.com/ghbvf/gocell", // == go.mod module
+		"--team=platform",
+		"--role=maintainer",
+	}
+	if err := scaffoldAssembly(root, args); err != nil {
+		t.Fatalf("scaffoldAssembly --cell explicit same-module: %v", err)
+	}
+	for _, rel := range sixFileRels("explicitsame") {
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(rel))); err != nil {
+			t.Errorf("explicit same-module --cell missing %s: %v", rel, err)
+		}
+	}
+	asmYAML, _ := os.ReadFile(filepath.Join(root, "assemblies", "explicitsame", "assembly.yaml")) //nolint:gosec // tempdir test fixture
+	if strings.Contains(string(asmYAML), "compositionAPI") {
+		t.Errorf("module == own module must not emit compositionAPI; got:\n%s", asmYAML)
+	}
+}
+
 // TestRunScaffoldAssembly_CellFlag_CrossModule asserts that --cell id@module
 // emits object-form cells[].{id,module} + build.compositionAPI: true, and that
 // cross-module entries auto-skip the K#10 derived files (cross-module cell
@@ -586,6 +613,7 @@ func TestRunScaffoldAssembly_CellFlag_BadModule(t *testing.T) {
 		{"quote_in_module", "examplecell@github.com/acme/\"x"},
 		{"backslash_in_module", "examplecell@github.com/acme/x\\y"},
 		{"empty_module_after_at", "examplecell@"},
+		{"double_at", "examplecell@@github.com/acme/x"},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/cmd/gocell/app/scaffold_assembly_test.go
+++ b/cmd/gocell/app/scaffold_assembly_test.go
@@ -503,6 +503,9 @@ func TestRunScaffoldAssembly_CellFlag_ExplicitSameModule(t *testing.T) {
 	if strings.Contains(string(asmYAML), "compositionAPI") {
 		t.Errorf("module == own module must not emit compositionAPI; got:\n%s", asmYAML)
 	}
+	if strings.Contains(string(asmYAML), "module:") {
+		t.Errorf("module == own module must normalize to scalar shorthand (no redundant module:); got:\n%s", asmYAML)
+	}
 }
 
 // TestRunScaffoldAssembly_CellFlag_CrossModule asserts that --cell id@module

--- a/docs/architecture/202606030230-adr-assembly-cross-module-composition.md
+++ b/docs/architecture/202606030230-adr-assembly-cross-module-composition.md
@@ -126,9 +126,20 @@ string, so set membership is inherently a runtime guard.
 - **Operator-SDK module-cache metadata read** (`go list -json` to read a
   dependency module's cell.yaml): no in-repo consumer until examples/ split into
   modules (M11 #1092). Tracked as a backlog issue.
-- **Scaffold `--module` flag** (cross-module assembly scaffolding): `gocell
-  scaffold assembly` emits same-module string-form cells; cross-module entries
-  are hand-authored. Backlog.
+- ~~**Scaffold `--module` flag** (cross-module assembly scaffolding)~~ —
+  **landed in #1516.** `gocell scaffold assembly` now takes a repeatable
+  `--cell <id[@module]>` flag (mutually exclusive with the same-module `--cells`
+  CSV shorthand). A cross-module entry emits the object form
+  `cells[].{id,module}` + `build.compositionAPI: true` and implicitly skips the
+  K#10 derived files (modules_gen.go / main.go / boundary.yaml), since the
+  cross-module cell metadata is not locally resolvable — that read remains the
+  Operator-SDK module-cache item above (#1515). The scaffolded `assembly.yaml`
+  therefore validates in-repo only once the cross-module cells are discoverable
+  (go.work / #1515); the scaffold's responsibility ends at emitting correct YAML.
+  Generated imports still route through the single `cellModuleImportPath` funnel
+  (no duplication). Module-path hygiene is enforced by the scaffold spec's closed
+  funnel (`validateAssemblyScaffoldSpec` → `metadata.MatchAssemblyModulePath`),
+  the same validator the assembly.yaml decoder uses.
 - **M12b** (metric-label closed-set defense at the write point +
   `CELL-ID-CLOSED-SET-01` archtest): mostly already present (`_runtime` sentinel +
   cardinality cap); remains in #1093.

--- a/framework/kernel/assembly/generator.go
+++ b/framework/kernel/assembly/generator.go
@@ -227,10 +227,14 @@ type AssemblyScaffoldSpec struct {
 	// scaffoldid.Parse — callers cannot supply an unvalidated raw string
 	// (SCAFFOLD-INPUT-CONTRACT-TYPED-ID-01).
 	ID scaffoldid.ScaffoldID
-	// Cells lists the cell IDs that compose this assembly, in startup order.
-	// Each entry must reference an existing cells/{cellID}/cell.yaml. Typed
-	// for the same reason as ID.
-	Cells []scaffoldid.ScaffoldID
+	// Cells lists the cells that compose this assembly, in startup order. Each
+	// entry is a ScaffoldCellRef carrying a typed cell ID plus an optional Go
+	// module path. A same-module entry (empty Module) must reference an existing
+	// cells/{cellID}/cell.yaml; a cross-module entry (foreign Module) is NOT
+	// required to exist locally — its module-cache metadata read is #1515's
+	// scope and its existence is ultimately established when the generated
+	// modules_gen.go is built (#1516).
+	Cells []ScaffoldCellRef
 	// OwnerTeam, OwnerRole identify the maintainers of this assembly.
 	// Both required; written verbatim to assembly.yaml owner.
 	OwnerTeam string
@@ -242,8 +246,25 @@ type AssemblyScaffoldSpec struct {
 	Deploy string
 	// SkipGenerate when true causes PlanAssemblyScaffold to return only the
 	// 3 skeleton PlannedFiles (assembly.yaml + cmd/{id}/run.go + cmd/{id}/app.go),
-	// skipping in-memory codegen for the 3 K#10 derived files.
+	// skipping in-memory codegen for the 3 K#10 derived files. Cross-module cells
+	// force this behavior implicitly (see PlanAssemblyScaffold) because their
+	// metadata is not locally resolvable.
 	SkipGenerate bool
+}
+
+// ScaffoldCellRef is one cell entry in an AssemblyScaffoldSpec: a typed cell ID
+// plus an optional Go module path. ID stays typed (scaffoldid.ScaffoldID) so the
+// (^[a-z][a-z0-9]+$) constraint is established at construction time
+// (SCAFFOLD-INPUT-CONTRACT-TYPED-ID-01). Module is empty for the common
+// same-module case; a non-empty Module references a cell developed in an
+// independent Go module (#1086/#1516) and is rendered as the object form
+// `{id, module}` in assembly.yaml. Module hygiene (no characters that could break
+// out of the generated import string literal) is enforced by the single closed
+// funnel validateAssemblyScaffoldSpec via metadata.MatchAssemblyModulePath — the
+// same validator the assembly.yaml decoder uses.
+type ScaffoldCellRef struct {
+	ID     scaffoldid.ScaffoldID
+	Module string
 }
 
 // scaffoldAssemblyContext is the template context for the K#09 scaffold
@@ -253,12 +274,23 @@ type AssemblyScaffoldSpec struct {
 // that wraps user input through yamlsafe.Quote.
 type scaffoldAssemblyContext struct {
 	ID             yamlsafe.Scalar
-	Cells          []yamlsafe.Scalar
+	Cells          []scaffoldAssemblyCellYAML // per-cell {id[, module]} entries for the assembly.yaml cells block
 	OwnerTeam      yamlsafe.Scalar
 	OwnerRole      yamlsafe.Scalar
 	DeployTemplate yamlsafe.Scalar             // empty when --deploy=k8s (default — omitted from yaml)
+	CompositionAPI bool                        // true when any cell is cross-module — emits build.compositionAPI: true
 	HelperName     string                      // run{ID-PascalCase} for runXxx() in run.go (Go identifier, not YAML scalar)
 	CellModules    []scaffoldAssemblyCellEntry // {StructName + Module suffix, cellID} pairs for run.go stubs
+}
+
+// scaffoldAssemblyCellYAML is one rendered cells[] entry. Module is the zero
+// yamlsafe.Scalar for the same-module scalar shorthand (`- id`); a non-empty
+// Module triggers the cross-module object form (`- {id: ID, module: MODULE}`).
+// Both fields route through yamlsafe.Quote so YAML metacharacters in user input
+// cannot break out of the (flow-mapping) scalar (YAML-QUOTE-FUNNEL-01).
+type scaffoldAssemblyCellYAML struct {
+	ID     yamlsafe.Scalar
+	Module yamlsafe.Scalar
 }
 
 // scaffoldAssemblyCellEntry pairs a generated *Module struct name with the
@@ -511,7 +543,27 @@ func (g *Generator) generateModulesGenLegacy(
 // than the assembly's own (g.module). An empty ref.Module, or one equal to
 // g.module, is same-module.
 func (g *Generator) isCrossModule(ref metadata.AssemblyCellRef) bool {
-	return ref.Module != "" && ref.Module != g.module
+	return g.crossModule(ref.Module)
+}
+
+// crossModule is the single predicate behind every cross-module decision: a
+// non-empty module that differs from the assembly's own module. Used by
+// isCrossModule (codegen) and the scaffold path (existence-skip, compositionAPI,
+// derived-file skip) so all three stay aligned.
+func (g *Generator) crossModule(module string) bool {
+	return module != "" && module != g.module
+}
+
+// specHasCrossModule reports whether any cell in the scaffold spec is
+// cross-module — the trigger for compositionAPI emission and the implicit
+// derived-file skip (cross-module cell metadata is not locally resolvable).
+func (g *Generator) specHasCrossModule(spec AssemblyScaffoldSpec) bool {
+	for _, c := range spec.Cells {
+		if g.crossModule(c.Module) {
+			return true
+		}
+	}
+	return false
 }
 
 // moduleOf returns the Go module path a cell's cellmodules/ package lives in:
@@ -949,7 +1001,12 @@ func (g *Generator) PlanAssemblyScaffold(spec AssemblyScaffoldSpec) ([]pathsafe.
 		return nil, err
 	}
 
-	if spec.SkipGenerate {
+	// Cross-module cells force the skeleton-only plan: their cellmodules/ metadata
+	// is not locally resolvable (that read is #1515's scope), and the composition
+	// modules_gen.go they require is incompatible with the legacy run.go skeleton.
+	// The CLI surfaces an actionable "run gocell generate assembly" hint, mirroring
+	// the explicit --skip-generate contract (#1516).
+	if spec.SkipGenerate || g.specHasCrossModule(spec) {
 		return plan, nil
 	}
 
@@ -1062,12 +1119,14 @@ func synthesizeAssemblyMeta(spec AssemblyScaffoldSpec) *metadata.AssemblyMeta {
 		// which the boundary sourceFingerprint depends on.
 		deployTemplate = "k8s"
 	}
-	// Scaffolded assemblies are always same-module (cross-module authoring is a
-	// hand-edit / future scaffold flag, tracked in backlog); synthesize bare
-	// same-module cell refs via the metadata.CellRefs constructor.
+	// synthesizeAssemblyMeta is only reached for same-module scaffolds:
+	// PlanAssemblyScaffold short-circuits (skeleton-only plan) when any cell is
+	// cross-module, so the derived-file path that calls this never sees a foreign
+	// module. Every spec.Cells entry here is therefore same-module — synthesize
+	// bare same-module refs via the metadata.CellRefs constructor (#1516).
 	cellIDs := make([]string, len(spec.Cells))
 	for i, c := range spec.Cells {
-		cellIDs[i] = c.String()
+		cellIDs[i] = c.ID.String()
 	}
 	return &metadata.AssemblyMeta{
 		ID:    spec.ID.String(),
@@ -1126,12 +1185,15 @@ func (g *Generator) buildScaffoldContext(spec AssemblyScaffoldSpec) (scaffoldAss
 	}
 
 	cellModuleEntries := make([]scaffoldAssemblyCellEntry, 0, len(spec.Cells))
-	quotedCells := make([]yamlsafe.Scalar, 0, len(spec.Cells))
-	for _, cellID := range spec.Cells {
-		cellIDStr := cellID.String()
+	cellYAMLs := make([]scaffoldAssemblyCellYAML, 0, len(spec.Cells))
+	for _, ref := range spec.Cells {
+		cellIDStr := ref.ID.String()
 		cellMeta := g.cells.Get(cellIDStr)
-		// Cell existence already validated; fall back to cellID when
-		// GoStructName is unset so legacy cells still produce a compilable stub.
+		// Same-module cell existence is validated upstream; cross-module cells are
+		// not locally present (g.cells.Get == nil) so structName falls back to the
+		// cell id. The run.go stub it feeds is only material for same-module
+		// (legacy) scaffolds — cross-module scaffolds skip the derived files that
+		// reference it.
 		structName := cellIDStr
 		if cellMeta != nil && !cellMeta.GoStructName.IsZero() {
 			structName = cellMeta.GoStructName.String()
@@ -1140,15 +1202,23 @@ func (g *Generator) buildScaffoldContext(spec AssemblyScaffoldSpec) (scaffoldAss
 			Name: structName + "Module",
 			ID:   cellIDStr,
 		})
-		quotedCells = append(quotedCells, yamlsafe.Quote(cellIDStr))
+		// Module is the zero Scalar for same-module (scalar shorthand); a non-empty
+		// Module renders the cross-module object form. Both routed through
+		// yamlsafe.Quote (YAML-QUOTE-FUNNEL-01) — safe in flow-mapping context.
+		entry := scaffoldAssemblyCellYAML{ID: yamlsafe.Quote(cellIDStr)}
+		if ref.Module != "" {
+			entry.Module = yamlsafe.Quote(ref.Module)
+		}
+		cellYAMLs = append(cellYAMLs, entry)
 	}
 
 	return scaffoldAssemblyContext{
 		ID:             yamlsafe.Quote(spec.ID.String()),
-		Cells:          quotedCells,
+		Cells:          cellYAMLs,
 		OwnerTeam:      yamlsafe.Quote(spec.OwnerTeam),
 		OwnerRole:      yamlsafe.Quote(spec.OwnerRole),
 		DeployTemplate: deployTemplate,
+		CompositionAPI: g.specHasCrossModule(spec),
 		HelperName:     helperName,
 		CellModules:    cellModuleEntries,
 	}, nil
@@ -1182,14 +1252,19 @@ func (g *Generator) renderAssemblyScaffoldFiles(
 	return plan, nil
 }
 
-// validateAssemblyScaffoldSpec checks required fields and verifies that every
-// cell in spec.Cells exists in the parsed project. Identifier pattern
-// validation is no longer performed here: spec.ID and spec.Cells[] are typed
-// (scaffoldid.ScaffoldID), so the AssemblyIDPattern (`^[a-z][a-z0-9]+$`)
-// constraint is established at construction time via scaffoldid.Parse
-// (SCAFFOLD-INPUT-CONTRACT-TYPED-ID-01). Free-text rules (OwnerTeam /
-// OwnerRole) still route through kernel/metadata.IsValidMetadataText —
-// the metadata package is the sole declaration site.
+// validateAssemblyScaffoldSpec is the single closed funnel every scaffold spec
+// traverses before rendering. Identifier pattern validation is established at
+// construction time via the typed ID (scaffoldid.ScaffoldID,
+// SCAFFOLD-INPUT-CONTRACT-TYPED-ID-01); this funnel adds the runtime-value
+// guards: required fields + free-text hygiene (OwnerTeam / OwnerRole via
+// kernel/metadata.IsValidMetadataText) and the per-cell checks in
+// validateScaffoldCells — module-path hygiene, duplicate-cell rejection, and
+// same-module existence. Putting module hygiene HERE (not only at the CLI flag
+// layer) closes the funnel: a spec built by any caller — not just the CLI —
+// cannot reach rendering with a module string that could break out of the
+// generated import literal (mirrors how the assembly.yaml decoder validates via
+// the same metadata.MatchAssemblyModulePath). AI-robust: Medium runtime
+// fail-closed guard, peer to the decoder + Owner guards.
 //
 // ref: kubernetes/apimachinery pkg/util/validation/validation.go —
 // IsDNS1123Label single-helper validation; same pattern applied here.
@@ -1225,15 +1300,41 @@ func validateAssemblyScaffoldSpec(g *Generator, spec AssemblyScaffoldSpec) error
 			"assembly scaffold: --deploy must be one of [k8s compose binary]",
 			errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("deploy=%q", spec.Deploy))))
 	}
-	// spec.Cells is []scaffoldid.ScaffoldID — the AssemblyIDPattern
-	// (^[a-z][a-z0-9]+$) is identical to CellIDPattern, so a typed entry has
-	// already passed pattern validation at scaffoldid.Parse time. We still
-	// verify each cell exists in the parsed project.
-	for _, cellID := range spec.Cells {
-		if g.cells.Get(cellID.String()) == nil {
+	return g.validateScaffoldCells(spec.Cells)
+}
+
+// validateScaffoldCells runs the per-cell scaffold guards: duplicate-cell
+// rejection, cross-module module-path hygiene, and same-module existence. Cell
+// ID pattern is already established by the typed ScaffoldCellRef.ID. Lifted out
+// of validateAssemblyScaffoldSpec to keep cognitive complexity within budget.
+func (g *Generator) validateScaffoldCells(cells []ScaffoldCellRef) error {
+	seen := make(map[string]bool, len(cells))
+	for _, ref := range cells {
+		id := ref.ID.String()
+		if seen[id] {
 			return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
-				"assembly scaffold: --cells references unknown cell",
-				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("cell=%q", cellID.String()))))
+				"assembly scaffold: duplicate cell",
+				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("cell=%q", id))))
+		}
+		seen[id] = true
+
+		if g.crossModule(ref.Module) {
+			// Cross-module: module-path hygiene via the same single-source validator
+			// the assembly.yaml decoder uses; existence is NOT checked here (the cell
+			// lives in another module, resolved at `go build` / #1515 time).
+			if !metadata.MatchAssemblyModulePath(ref.Module) {
+				return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+					"assembly scaffold: cell module path has invalid character",
+					errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("cell=%q module=%q", id, ref.Module))))
+			}
+			continue
+		}
+
+		// Same-module (or explicit module == own module): must exist locally.
+		if g.cells.Get(id) == nil {
+			return errcode.New(errcode.KindInvalid, errcode.ErrValidationFailed,
+				"assembly scaffold: cell references unknown cell",
+				errcode.WithInternal(errcode.InternalAttr("_", fmt.Sprintf("cell=%q", id))))
 		}
 	}
 	return nil

--- a/framework/kernel/assembly/generator.go
+++ b/framework/kernel/assembly/generator.go
@@ -1213,11 +1213,14 @@ func (g *Generator) buildScaffoldContext(spec AssemblyScaffoldSpec) (scaffoldAss
 			Name: structName + "Module",
 			ID:   cellIDStr,
 		})
-		// Module is the zero Scalar for same-module (scalar shorthand); a non-empty
-		// Module renders the cross-module object form. Both routed through
-		// yamlsafe.Quote (YAML-QUOTE-FUNNEL-01) — safe in flow-mapping context.
+		// Module is the zero Scalar for same-module (scalar shorthand); only a
+		// genuinely cross-module ref renders the object form. The render gate uses
+		// the same g.crossModule predicate as the compositionAPI / derived-file-skip
+		// decisions, so an explicit module == own module normalizes to the scalar
+		// shorthand (no redundant `module:`) instead of diverging. Both fields route
+		// through yamlsafe.Quote (YAML-QUOTE-FUNNEL-01) — safe in flow-mapping context.
 		entry := scaffoldAssemblyCellYAML{ID: yamlsafe.Quote(cellIDStr)}
-		if ref.Module != "" {
+		if g.crossModule(ref.Module) {
 			entry.Module = yamlsafe.Quote(ref.Module)
 		}
 		cellYAMLs = append(cellYAMLs, entry)

--- a/framework/kernel/assembly/generator.go
+++ b/framework/kernel/assembly/generator.go
@@ -270,8 +270,9 @@ type ScaffoldCellRef struct {
 // scaffoldAssemblyContext is the template context for the K#09 scaffold
 // templates (assembly-yaml / run-go / app-go). User-input fields are typed
 // as yamlsafe.Scalar so the type system rejects raw string interpolation
-// into the inline YAML template; buildScaffoldContext is the single funnel
-// that wraps user input through yamlsafe.Quote.
+// into the inline YAML template; buildScaffoldContext is the construction
+// site that wraps user input through yamlsafe.Quote (the funnel enforcement
+// itself is asserted on buildScaffoldContext by archtest YAML-QUOTE-FUNNEL-01).
 type scaffoldAssemblyContext struct {
 	ID             yamlsafe.Scalar
 	Cells          []scaffoldAssemblyCellYAML // per-cell {id[, module]} entries for the assembly.yaml cells block
@@ -551,7 +552,17 @@ func (g *Generator) isCrossModule(ref metadata.AssemblyCellRef) bool {
 // isCrossModule (codegen) and the scaffold path (existence-skip, compositionAPI,
 // derived-file skip) so all three stay aligned.
 func (g *Generator) crossModule(module string) bool {
-	return module != "" && module != g.module
+	return IsCrossModule(module, g.module)
+}
+
+// IsCrossModule reports whether a cell's declared module path names a Go module
+// other than ownModule (the assembly's own module). An empty module, or one
+// equal to ownModule, is same-module. It is the single shared predicate behind
+// the generator's derived-file-skip / compositionAPI decisions and the CLI's
+// cross-module hint, so the two cannot drift — the CLI imports this rather than
+// re-implementing the comparison.
+func IsCrossModule(module, ownModule string) bool {
+	return module != "" && module != ownModule
 }
 
 // specHasCrossModule reports whether any cell in the scaffold spec is

--- a/framework/kernel/assembly/generator.go
+++ b/framework/kernel/assembly/generator.go
@@ -1001,9 +1001,22 @@ func (g *Generator) PlanAssemblyScaffold(spec AssemblyScaffoldSpec) ([]pathsafe.
 	asmDir := filepath.Join("assemblies", spec.ID.String())
 	cmdDir := filepath.Join("cmd", spec.ID.String())
 
+	// The run.go template is selected on the SAME compositionAPI axis that
+	// GenerateModulesGen uses for modules_gen.go (legacy []CellModule ↔
+	// composition []composition.CellModule). run.go and modules_gen.go share
+	// package main and must compile together, so the two selections must stay
+	// symmetric: a cross-module scaffold emits a composition-form run.go whose
+	// helper consumes []composition.CellModule, matching the modules_gen.go that
+	// `gocell generate assembly` later emits. Asymmetry here is exactly the F1
+	// scaffold→generate→compile break (#1516 / PR #2480).
+	runTemplate := "scaffold-run-go.tpl"
+	if g.specHasCrossModule(spec) {
+		runTemplate = "scaffold-run-composition-go.tpl"
+	}
+
 	templateFiles := []scaffoldAssemblyFile{
 		{Path: filepath.Join(asmDir, "assembly.yaml"), Template: "scaffold-assembly-yaml.tpl"},
-		{Path: filepath.Join(cmdDir, "run.go"), Template: "scaffold-run-go.tpl"},
+		{Path: filepath.Join(cmdDir, "run.go"), Template: runTemplate},
 		{Path: filepath.Join(cmdDir, "app.go"), Template: "scaffold-app-go.tpl"},
 	}
 
@@ -1013,10 +1026,13 @@ func (g *Generator) PlanAssemblyScaffold(spec AssemblyScaffoldSpec) ([]pathsafe.
 	}
 
 	// Cross-module cells force the skeleton-only plan: their cellmodules/ metadata
-	// is not locally resolvable (that read is #1515's scope), and the composition
-	// modules_gen.go they require is incompatible with the legacy run.go skeleton.
-	// The CLI surfaces an actionable "run gocell generate assembly" hint, mirroring
-	// the explicit --skip-generate contract (#1516).
+	// is not locally resolvable (that read is #1515's scope), so the K#10 derived
+	// files (modules_gen.go / main.go / boundary.yaml) cannot be rendered here.
+	// The composition-form run.go (selected above) is type-compatible with the
+	// modules_gen.go that `gocell generate assembly` will emit, so the deferred
+	// derivation closes the scaffold→generate→compile loop. The CLI surfaces an
+	// actionable "run gocell generate assembly" hint, mirroring the explicit
+	// --skip-generate contract (#1516).
 	if spec.SkipGenerate || g.specHasCrossModule(spec) {
 		return plan, nil
 	}

--- a/framework/kernel/assembly/generator_concurrency_test.go
+++ b/framework/kernel/assembly/generator_concurrency_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ghbvf/gocell/framework/kernel/metadata"
 	"github.com/ghbvf/gocell/framework/pkg/pathsafe"
-	"github.com/ghbvf/gocell/framework/pkg/scaffoldid"
 )
 
 // TestGenerator_PlanAssemblyScaffold_ConcurrentSafe verifies that concurrent
@@ -55,7 +54,7 @@ func TestGenerator_PlanAssemblyScaffold_ConcurrentSafe(t *testing.T) {
 			defer wg.Done()
 			spec := AssemblyScaffoldSpec{
 				ID:        mustID(t, rawID),
-				Cells:     []scaffoldid.ScaffoldID{mustID(t, "cellalpha"), mustID(t, "cellbeta")},
+				Cells:     mustRefs(t, "cellalpha", "cellbeta"),
 				OwnerTeam: "platform",
 				OwnerRole: "maintainer",
 			}

--- a/framework/kernel/assembly/generator_scaffold_crossmodule_test.go
+++ b/framework/kernel/assembly/generator_scaffold_crossmodule_test.go
@@ -68,7 +68,8 @@ func TestPlanAssemblyScaffold_CrossModule_SkeletonOnly(t *testing.T) {
 
 // TestPlanAssemblyScaffold_ExplicitSameModuleNotCrossModule verifies that a
 // ScaffoldCellRef whose Module equals the assembly's own module is treated as
-// same-module: derived files are NOT skipped and compositionAPI is not emitted.
+// same-module: derived files are NOT skipped, compositionAPI is not emitted, and
+// the redundant `module:` is normalized away to the scalar shorthand.
 func TestPlanAssemblyScaffold_ExplicitSameModuleNotCrossModule(t *testing.T) {
 	t.Parallel()
 	root, pm := scaffoldTestProject(t)
@@ -83,8 +84,10 @@ func TestPlanAssemblyScaffold_ExplicitSameModuleNotCrossModule(t *testing.T) {
 	plan, err := gen.PlanAssemblyScaffold(spec)
 	require.NoError(t, err)
 	require.Len(t, plan, 6, "explicit same-module ref must keep the full derived plan")
-	assert.NotContains(t, planContent(t, plan, "assembly.yaml"), "compositionAPI",
-		"module == own module must not trigger compositionAPI")
+	asm := planContent(t, plan, "assembly.yaml")
+	assert.NotContains(t, asm, "compositionAPI", "module == own module must not trigger compositionAPI")
+	assert.NotContains(t, asm, "module:", "module == own module must render scalar shorthand, no redundant module:")
+	assert.Contains(t, asm, "- examplecell", "must render the same-module scalar form")
 }
 
 // TestScaffoldAssembly_CrossModuleYAMLInjection asserts that a cross-module

--- a/framework/kernel/assembly/generator_scaffold_crossmodule_test.go
+++ b/framework/kernel/assembly/generator_scaffold_crossmodule_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/framework/pkg/pathsafe"
@@ -84,6 +85,61 @@ func TestPlanAssemblyScaffold_ExplicitSameModuleNotCrossModule(t *testing.T) {
 	require.Len(t, plan, 6, "explicit same-module ref must keep the full derived plan")
 	assert.NotContains(t, planContent(t, plan, "assembly.yaml"), "compositionAPI",
 		"module == own module must not trigger compositionAPI")
+}
+
+// TestScaffoldAssembly_CrossModuleYAMLInjection asserts that a cross-module
+// cell's module path — rendered into the flow-mapping `- {id: X, module: Y}`
+// form — cannot break out of the scalar to inject adjacent keys or extra cells.
+// MatchAssemblyModulePath rejects control/space/quote/backtick/backslash upstream;
+// the remaining YAML-significant runes ({ } [ ] : , ' # & * ! | > %) are handled
+// by yamlsafe.Quote. This is the cross-module counterpart of
+// TestScaffoldAssembly_YAMLScalarInjection (which covers owner.team/role).
+func TestScaffoldAssembly_CrossModuleYAMLInjection(t *testing.T) {
+	t.Parallel()
+	// Each module string passes MatchAssemblyModulePath but carries a YAML
+	// metacharacter class that would break the flow-mapping without quoting.
+	modules := []struct {
+		name   string
+		module string
+	}{
+		{"brace_close", "github.com/acme/x}injected"},
+		{"colon_comma", "github.com/acme/x,injected:true"},
+		{"single_quote", "github.com/acme/x'injected"},
+		{"flow_seq", "github.com/acme/[x]injected"},
+		{"yaml_indicators", "github.com/acme/x#&*!|>%"},
+	}
+	for _, tc := range modules {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root, pm := scaffoldTestProject(t)
+			gen := NewGenerator(pm, "github.com/ghbvf/gocell", root)
+			spec := AssemblyScaffoldSpec{
+				ID:        mustID(t, "mdm"),
+				Cells:     []ScaffoldCellRef{{ID: mustID(t, "enrollcell"), Module: tc.module}},
+				OwnerTeam: "platform",
+				OwnerRole: "maintainer",
+			}
+			plan, err := gen.PlanAssemblyScaffold(spec)
+			require.NoError(t, err)
+			asmYAML := []byte(planContent(t, plan, "assembly.yaml"))
+
+			// Top-level / build keys: no injected adjacent keys (reuses the
+			// owner-injection structural guard).
+			assertNoInjectedAdjacentKeys(t, asmYAML)
+
+			// cells round-trips to exactly one {id, module} entry, module verbatim,
+			// no smuggled extra cell or key.
+			var doc struct {
+				Cells []map[string]any `yaml:"cells"`
+			}
+			require.NoError(t, yaml.Unmarshal(asmYAML, &doc), "rendered yaml must parse")
+			require.Len(t, doc.Cells, 1, "exactly one cell — no injected entry")
+			assert.Equal(t, "enrollcell", doc.Cells[0]["id"])
+			assert.Equal(t, tc.module, doc.Cells[0]["module"], "module must round-trip verbatim")
+			assert.Len(t, doc.Cells[0], 2, "cell entry must carry only id + module")
+		})
+	}
 }
 
 // TestValidateScaffoldCells covers existence (same-module), existence-skip

--- a/framework/kernel/assembly/generator_scaffold_crossmodule_test.go
+++ b/framework/kernel/assembly/generator_scaffold_crossmodule_test.go
@@ -1,0 +1,141 @@
+package assembly
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghbvf/gocell/framework/pkg/errcode"
+	"github.com/ghbvf/gocell/framework/pkg/pathsafe"
+)
+
+const scaffoldCrossModule = "github.com/ghbvf/gocell-mdm"
+
+// errMessage extracts the const Message of an *errcode.Error (Error() renders
+// internal details over the message, so message-text assertions need the field).
+func errMessage(err error) string {
+	var ce *errcode.Error
+	if errors.As(err, &ce) {
+		return ce.Message
+	}
+	return err.Error()
+}
+
+// planContent returns the rendered content of the planned file whose path ends
+// with suffix, or fails the test.
+func planContent(t *testing.T, plan []pathsafe.PlannedFile, suffix string) string {
+	t.Helper()
+	for _, f := range plan {
+		if strings.HasSuffix(f.AbsPath, suffix) {
+			return string(f.Content)
+		}
+	}
+	t.Fatalf("planned file ending %q not found in %d files", suffix, len(plan))
+	return ""
+}
+
+// TestPlanAssemblyScaffold_CrossModule_SkeletonOnly verifies that a spec mixing
+// a same-module and a cross-module cell renders only the 3 skeleton files
+// (cross-module implicitly skips the K#10 derived files) and that the
+// assembly.yaml carries the object form + build.compositionAPI: true.
+func TestPlanAssemblyScaffold_CrossModule_SkeletonOnly(t *testing.T) {
+	t.Parallel()
+	root, pm := scaffoldTestProject(t)
+	gen := NewGenerator(pm, "github.com/ghbvf/gocell", root)
+
+	spec := AssemblyScaffoldSpec{
+		ID: mustID(t, "mdm"),
+		Cells: []ScaffoldCellRef{
+			{ID: mustID(t, "examplecell")},
+			{ID: mustID(t, "enrollcell"), Module: scaffoldCrossModule},
+		},
+		OwnerTeam: "platform",
+		OwnerRole: "maintainer",
+	}
+	plan, err := gen.PlanAssemblyScaffold(spec)
+	require.NoError(t, err)
+	require.Len(t, plan, 3, "cross-module scaffold must emit skeleton only (assembly.yaml + run.go + app.go)")
+
+	asm := planContent(t, plan, "assembly.yaml")
+	assert.Contains(t, asm, "- examplecell", "same-module cell keeps scalar shorthand")
+	assert.Contains(t, asm, "- {id: enrollcell, module: "+scaffoldCrossModule+"}", "cross-module cell renders object form")
+	assert.Contains(t, asm, "compositionAPI: true", "cross-module assembly must declare compositionAPI")
+}
+
+// TestPlanAssemblyScaffold_ExplicitSameModuleNotCrossModule verifies that a
+// ScaffoldCellRef whose Module equals the assembly's own module is treated as
+// same-module: derived files are NOT skipped and compositionAPI is not emitted.
+func TestPlanAssemblyScaffold_ExplicitSameModuleNotCrossModule(t *testing.T) {
+	t.Parallel()
+	root, pm := scaffoldTestProject(t)
+	gen := NewGenerator(pm, "github.com/ghbvf/gocell", root)
+
+	spec := AssemblyScaffoldSpec{
+		ID:        mustID(t, "samemod"),
+		Cells:     []ScaffoldCellRef{{ID: mustID(t, "examplecell"), Module: "github.com/ghbvf/gocell"}},
+		OwnerTeam: "platform",
+		OwnerRole: "maintainer",
+	}
+	plan, err := gen.PlanAssemblyScaffold(spec)
+	require.NoError(t, err)
+	require.Len(t, plan, 6, "explicit same-module ref must keep the full derived plan")
+	assert.NotContains(t, planContent(t, plan, "assembly.yaml"), "compositionAPI",
+		"module == own module must not trigger compositionAPI")
+}
+
+// TestValidateScaffoldCells covers existence (same-module), existence-skip
+// (cross-module), duplicate rejection, and module-path hygiene.
+func TestValidateScaffoldCells(t *testing.T) {
+	t.Parallel()
+	root, pm := scaffoldTestProject(t)
+	gen := NewGenerator(pm, "github.com/ghbvf/gocell", root)
+
+	cases := []struct {
+		name    string
+		cells   []ScaffoldCellRef
+		wantErr string // substring; "" = expect success
+	}{
+		{
+			name:  "same_module_exists",
+			cells: []ScaffoldCellRef{{ID: mustID(t, "examplecell")}},
+		},
+		{
+			name:    "same_module_unknown",
+			cells:   []ScaffoldCellRef{{ID: mustID(t, "ghostcell")}},
+			wantErr: "unknown cell",
+		},
+		{
+			name:  "cross_module_skips_existence",
+			cells: []ScaffoldCellRef{{ID: mustID(t, "ghostcell"), Module: scaffoldCrossModule}},
+		},
+		{
+			name: "duplicate_cell",
+			cells: []ScaffoldCellRef{
+				{ID: mustID(t, "examplecell")},
+				{ID: mustID(t, "examplecell")},
+			},
+			wantErr: "duplicate cell",
+		},
+		{
+			name:    "cross_module_bad_path",
+			cells:   []ScaffoldCellRef{{ID: mustID(t, "examplecell"), Module: "github.com/acme/x y"}},
+			wantErr: "invalid character",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := gen.validateScaffoldCells(tc.cells)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, errMessage(err), tc.wantErr)
+		})
+	}
+}

--- a/framework/kernel/assembly/generator_scaffold_crossmodule_test.go
+++ b/framework/kernel/assembly/generator_scaffold_crossmodule_test.go
@@ -66,6 +66,53 @@ func TestPlanAssemblyScaffold_CrossModule_SkeletonOnly(t *testing.T) {
 	assert.Contains(t, asm, "compositionAPI: true", "cross-module assembly must declare compositionAPI")
 }
 
+// TestPlanAssemblyScaffold_CrossModule_RunGoCompositionContract pins F1: a
+// cross-module (build.compositionAPI: true) scaffold must emit a run.go whose
+// module helper consumes []composition.CellModule — the SAME type the
+// composition modules_gen.go returns from generatedCellModules() (asserted by
+// TestGenerateModulesGen_CompositionForm). The legacy run.go skeleton declared a
+// local `CellModule` interface + stub *Module types and consumed []CellModule,
+// which can never compile against the composition modules_gen.go's
+// `func generatedCellModules() []composition.CellModule` — breaking the
+// scaffold→generate→compile loop for cross-module assemblies. run.go and
+// modules_gen.go share `package main`, so the two generatedCellModules() shapes
+// must agree.
+func TestPlanAssemblyScaffold_CrossModule_RunGoCompositionContract(t *testing.T) {
+	t.Parallel()
+	root, pm := scaffoldTestProject(t)
+	gen := NewGenerator(pm, "github.com/ghbvf/gocell", root)
+
+	spec := AssemblyScaffoldSpec{
+		ID: mustID(t, "mdm"),
+		Cells: []ScaffoldCellRef{
+			{ID: mustID(t, "examplecell")},
+			{ID: mustID(t, "enrollcell"), Module: scaffoldCrossModule},
+		},
+		OwnerTeam: "platform",
+		OwnerRole: "maintainer",
+	}
+	plan, err := gen.PlanAssemblyScaffold(spec)
+	require.NoError(t, err)
+
+	runGo := planContent(t, plan, "run.go")
+
+	// Composition-API contract: helper consumes []composition.CellModule and
+	// imports runtime/composition — matching the modules_gen.go `generate
+	// assembly` emits for build.compositionAPI: true.
+	assert.Contains(t, runGo, "[]composition.CellModule",
+		"cross-module run.go helper must consume []composition.CellModule")
+	assert.Contains(t, runGo, `"github.com/ghbvf/gocell/framework/runtime/composition"`,
+		"cross-module run.go must import runtime/composition")
+	// Must NOT carry the legacy local-type contract that collides with the
+	// composition modules_gen.go's generatedCellModules() []composition.CellModule.
+	assert.NotContains(t, runGo, "type CellModule interface",
+		"cross-module run.go must not redeclare a local CellModule type")
+	assert.NotContains(t, runGo, "Module struct{}",
+		"cross-module run.go must not declare stub *Module types")
+	assert.NotContains(t, runGo, "[]CellModule",
+		"cross-module run.go must not consume the legacy local []CellModule")
+}
+
 // TestPlanAssemblyScaffold_ExplicitSameModuleNotCrossModule verifies that a
 // ScaffoldCellRef whose Module equals the assembly's own module is treated as
 // same-module: derived files are NOT skipped, compositionAPI is not emitted, and

--- a/framework/kernel/assembly/generator_scaffold_test.go
+++ b/framework/kernel/assembly/generator_scaffold_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ghbvf/gocell/framework/kernel/metadata"
 	"github.com/ghbvf/gocell/framework/pkg/errcode"
 	"github.com/ghbvf/gocell/framework/pkg/pathsafe"
-	"github.com/ghbvf/gocell/framework/pkg/scaffoldid"
 )
 
 // 目标路径常量，避免同义字面量重复。
@@ -84,7 +83,7 @@ l0Dependencies: []
 
 	spec := AssemblyScaffoldSpec{
 		ID:        mustID(t, "myassembly"),
-		Cells:     []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+		Cells:     mustRefs(t, "examplecell"),
 		OwnerTeam: "platform",
 		OwnerRole: "maintainer",
 		Deploy:    "k8s",
@@ -172,7 +171,7 @@ func TestGenerator_Scaffold_ValidationErrors(t *testing.T) {
 	}{
 		{
 			name:    "empty_id",
-			spec:    AssemblyScaffoldSpec{Cells: []scaffoldid.ScaffoldID{mustID(t, "examplecell")}, OwnerTeam: "t", OwnerRole: "r"},
+			spec:    AssemblyScaffoldSpec{Cells: mustRefs(t, "examplecell"), OwnerTeam: "t", OwnerRole: "r"},
 			wantSub: "ID is required",
 		},
 		{
@@ -182,19 +181,19 @@ func TestGenerator_Scaffold_ValidationErrors(t *testing.T) {
 		},
 		{
 			name:    "empty_team",
-			spec:    AssemblyScaffoldSpec{ID: mustID(t, "asm"), Cells: []scaffoldid.ScaffoldID{mustID(t, "examplecell")}, OwnerRole: "r"},
+			spec:    AssemblyScaffoldSpec{ID: mustID(t, "asm"), Cells: mustRefs(t, "examplecell"), OwnerRole: "r"},
 			wantSub: "OwnerTeam is required",
 		},
 		{
 			name:    "empty_role",
-			spec:    AssemblyScaffoldSpec{ID: mustID(t, "asm"), Cells: []scaffoldid.ScaffoldID{mustID(t, "examplecell")}, OwnerTeam: "t"},
+			spec:    AssemblyScaffoldSpec{ID: mustID(t, "asm"), Cells: mustRefs(t, "examplecell"), OwnerTeam: "t"},
 			wantSub: "OwnerRole is required",
 		},
 		{
 			name: "invalid_deploy",
 			spec: AssemblyScaffoldSpec{
 				ID:        mustID(t, "asm"),
-				Cells:     []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+				Cells:     mustRefs(t, "examplecell"),
 				OwnerTeam: "t", OwnerRole: "r", Deploy: "podman",
 			},
 			wantSub: `deploy="podman"`,
@@ -203,7 +202,7 @@ func TestGenerator_Scaffold_ValidationErrors(t *testing.T) {
 			name: "unknown_cell",
 			spec: AssemblyScaffoldSpec{
 				ID:        mustID(t, "asm"),
-				Cells:     []scaffoldid.ScaffoldID{mustID(t, "nope")},
+				Cells:     mustRefs(t, "nope"),
 				OwnerTeam: "t", OwnerRole: "r",
 			},
 			wantSub: `cell="nope"`,
@@ -232,7 +231,7 @@ func TestGenerator_Scaffold_EmptyProjectRoot(t *testing.T) {
 	gen := NewGenerator(pm, "github.com/ghbvf/gocell", "") // empty projectRoot
 
 	_, err := gen.PlanAssemblyScaffold(AssemblyScaffoldSpec{
-		ID: mustID(t, "asm"), Cells: []scaffoldid.ScaffoldID{mustID(t, "examplecell")}, OwnerTeam: "t", OwnerRole: "r",
+		ID: mustID(t, "asm"), Cells: mustRefs(t, "examplecell"), OwnerTeam: "t", OwnerRole: "r",
 	})
 	if err == nil {
 		t.Fatal("expected error for empty projectRoot, got nil")
@@ -250,7 +249,7 @@ func TestGenerator_Scaffold_DryRun(t *testing.T) {
 	gen := NewGenerator(pm, "github.com/ghbvf/gocell", root)
 
 	plan, err := gen.PlanAssemblyScaffold(AssemblyScaffoldSpec{
-		ID: mustID(t, "dryasm"), Cells: []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+		ID: mustID(t, "dryasm"), Cells: mustRefs(t, "examplecell"),
 		OwnerTeam: "t", OwnerRole: "r",
 	})
 	if err != nil {
@@ -276,7 +275,7 @@ func TestGenerator_Scaffold_ConflictDetection(t *testing.T) {
 	gen := NewGenerator(pm, "github.com/ghbvf/gocell", root)
 
 	spec := AssemblyScaffoldSpec{
-		ID: mustID(t, "conflict"), Cells: []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+		ID: mustID(t, "conflict"), Cells: mustRefs(t, "examplecell"),
 		OwnerTeam: "t", OwnerRole: "r",
 	}
 	plan, err := gen.PlanAssemblyScaffold(spec)
@@ -334,7 +333,7 @@ func TestGeneratorScaffold_SymlinkEscape_Asm(t *testing.T) {
 
 	plan, err := gen.PlanAssemblyScaffold(AssemblyScaffoldSpec{
 		ID:        mustID(t, "symasm"),
-		Cells:     []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+		Cells:     mustRefs(t, "examplecell"),
 		OwnerTeam: "platform",
 		OwnerRole: "maintainer",
 	})
@@ -374,7 +373,7 @@ func TestGeneratorScaffold_SymlinkEscape_Cmd(t *testing.T) {
 
 	plan, err := gen.PlanAssemblyScaffold(AssemblyScaffoldSpec{
 		ID:        mustID(t, "symcmdasm"),
-		Cells:     []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+		Cells:     mustRefs(t, "examplecell"),
 		OwnerTeam: "platform",
 		OwnerRole: "maintainer",
 	})
@@ -409,7 +408,7 @@ func TestGeneratorScaffold_AtomicRollback_OnConflict(t *testing.T) {
 
 	plan, err := gen.PlanAssemblyScaffold(AssemblyScaffoldSpec{
 		ID:        mustID(t, "conflictasm"),
-		Cells:     []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+		Cells:     mustRefs(t, "examplecell"),
 		OwnerTeam: "platform",
 		OwnerRole: "maintainer",
 	})
@@ -467,7 +466,7 @@ l0Dependencies: []
 
 	plan, err := gen.PlanAssemblyScaffold(AssemblyScaffoldSpec{
 		ID:        mustID(t, "myassembly"),
-		Cells:     []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+		Cells:     mustRefs(t, "examplecell"),
 		OwnerTeam: "platform",
 		OwnerRole: "maintainer",
 		Deploy:    "compose",
@@ -502,7 +501,7 @@ func TestPlanAssemblyScaffold_FullPlan_SixFiles(t *testing.T) {
 
 	plan, err := gen.PlanAssemblyScaffold(AssemblyScaffoldSpec{
 		ID:        mustID(t, "sixasm"),
-		Cells:     []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+		Cells:     mustRefs(t, "examplecell"),
 		OwnerTeam: "platform",
 		OwnerRole: "maintainer",
 	})
@@ -533,7 +532,7 @@ func TestPlanAssemblyScaffold_SkipGenerate_ThreeFiles(t *testing.T) {
 
 	plan, err := gen.PlanAssemblyScaffold(AssemblyScaffoldSpec{
 		ID:           mustID(t, "skipasm"),
-		Cells:        []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+		Cells:        mustRefs(t, "examplecell"),
 		OwnerTeam:    "platform",
 		OwnerRole:    "maintainer",
 		SkipGenerate: true,
@@ -565,7 +564,7 @@ func TestPlanAssemblyScaffold_DryRun_NoFilesOnDisk(t *testing.T) {
 
 	plan, err := gen.PlanAssemblyScaffold(AssemblyScaffoldSpec{
 		ID:        mustID(t, "drysixasm"),
-		Cells:     []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+		Cells:     mustRefs(t, "examplecell"),
 		OwnerTeam: "platform",
 		OwnerRole: "maintainer",
 	})
@@ -595,7 +594,7 @@ func TestPlanAssemblyScaffold_GeneratedFilesHaveMarker(t *testing.T) {
 
 	plan, err := gen.PlanAssemblyScaffold(AssemblyScaffoldSpec{
 		ID:        mustID(t, "markerasm"),
-		Cells:     []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+		Cells:     mustRefs(t, "examplecell"),
 		OwnerTeam: "platform",
 		OwnerRole: "maintainer",
 	})
@@ -644,7 +643,7 @@ func TestPlanAssemblyScaffold_FullPlan_RollbackOnLastFileConflict(t *testing.T) 
 
 	plan, err := gen.PlanAssemblyScaffold(AssemblyScaffoldSpec{
 		ID:        mustID(t, "rollbackasm"),
-		Cells:     []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+		Cells:     mustRefs(t, "examplecell"),
 		OwnerTeam: "platform",
 		OwnerRole: "maintainer",
 	})
@@ -703,7 +702,7 @@ func TestPlanAssemblyScaffold_RollbackOnMidPlanWriteFailure(t *testing.T) {
 
 	plan, err := gen.PlanAssemblyScaffold(AssemblyScaffoldSpec{
 		ID:        mustID(t, "wprollbackasm"),
-		Cells:     []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+		Cells:     mustRefs(t, "examplecell"),
 		OwnerTeam: "platform",
 		OwnerRole: "maintainer",
 	})
@@ -780,7 +779,7 @@ func runSlotConflictSubtest(t *testing.T, slotIdx int, rels []string, parentDirs
 
 	plan, err := gen.PlanAssemblyScaffold(AssemblyScaffoldSpec{
 		ID:        mustID(t, "slotasm"),
-		Cells:     []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+		Cells:     mustRefs(t, "examplecell"),
 		OwnerTeam: "platform",
 		OwnerRole: "maintainer",
 	})

--- a/framework/kernel/assembly/generator_validate_test.go
+++ b/framework/kernel/assembly/generator_validate_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/ghbvf/gocell/framework/kernel/metadata"
-	"github.com/ghbvf/gocell/framework/pkg/scaffoldid"
 )
 
 // projectWithCell builds a minimal ProjectMeta containing one cell named id,
@@ -70,7 +69,7 @@ func TestValidateAssemblyScaffoldSpec_OwnerTextRule(t *testing.T) {
 			gen := NewGenerator(project, "github.com/ghbvf/gocell", t.TempDir())
 			spec := AssemblyScaffoldSpec{
 				ID:        mustID(t, "myassembly"),
-				Cells:     []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+				Cells:     mustRefs(t, "examplecell"),
 				OwnerTeam: tc.team,
 				OwnerRole: tc.role,
 			}

--- a/framework/kernel/assembly/generator_yaml_safety_test.go
+++ b/framework/kernel/assembly/generator_yaml_safety_test.go
@@ -9,7 +9,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/ghbvf/gocell/framework/pkg/pathsafe"
-	"github.com/ghbvf/gocell/framework/pkg/scaffoldid"
 )
 
 // TestScaffoldAssembly_YAMLScalarInjection asserts that user-provided
@@ -103,7 +102,7 @@ func renderInjectionAssemblyYAML(t *testing.T, team, role string) []byte {
 	gen := NewGenerator(pm, "github.com/ghbvf/gocell", root)
 	spec := AssemblyScaffoldSpec{
 		ID:        mustID(t, "myassembly"),
-		Cells:     []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+		Cells:     mustRefs(t, "examplecell"),
 		OwnerTeam: team,
 		OwnerRole: role,
 		Deploy:    "k8s",
@@ -197,7 +196,7 @@ func TestScaffoldAssembly_YAMLScalarFile_ColonInOwner(t *testing.T) {
 
 	spec := AssemblyScaffoldSpec{
 		ID:        mustID(t, "myassembly"),
-		Cells:     []scaffoldid.ScaffoldID{mustID(t, "examplecell")},
+		Cells:     mustRefs(t, "examplecell"),
 		OwnerTeam: injectedTeam,
 		OwnerRole: "maintainer",
 	}

--- a/framework/kernel/assembly/generator_yaml_safety_test.go
+++ b/framework/kernel/assembly/generator_yaml_safety_test.go
@@ -163,7 +163,7 @@ func assertNoInjectedAdjacentKeys(t *testing.T, asmYAML []byte) {
 		assertKeysAllowed(t, "owner", ownerMap, "team", "role")
 	}
 	if buildMap, ok := topLevel["build"].(map[string]any); ok {
-		assertKeysAllowed(t, "build", buildMap, "entrypoint", "binary", "deployTemplate")
+		assertKeysAllowed(t, "build", buildMap, "entrypoint", "binary", "deployTemplate", "compositionAPI")
 	}
 }
 

--- a/framework/kernel/assembly/gentpl/scaffold-assembly-yaml.tpl
+++ b/framework/kernel/assembly/gentpl/scaffold-assembly-yaml.tpl
@@ -1,12 +1,21 @@
 id: {{.ID}}
 cells:
 {{- range .Cells}}
-  - {{.}}
+{{- if .Module}}
+  - {id: {{.ID}}, module: {{.Module}}}
+{{- else}}
+  - {{.ID}}
+{{- end}}
 {{- end}}
 owner:
   team: {{.OwnerTeam}}
   role: {{.OwnerRole}}
-{{- if .DeployTemplate}}
+{{- if or .CompositionAPI .DeployTemplate}}
 build:
+{{- if .CompositionAPI}}
+  compositionAPI: true
+{{- end}}
+{{- if .DeployTemplate}}
   deployTemplate: {{.DeployTemplate}}
+{{- end}}
 {{- end}}

--- a/framework/kernel/assembly/gentpl/scaffold-run-composition-go.tpl
+++ b/framework/kernel/assembly/gentpl/scaffold-run-composition-go.tpl
@@ -1,0 +1,79 @@
+// run.go is the handwritten runtime half behind the generated assembly
+// entrypoint for {{.ID}}. The generated main.go owns the assembly ID and
+// cell order; this file owns environment loading and runtime option wiring.
+//
+// COMPOSITION-API scaffold (build.compositionAPI: true): this assembly composes
+// cells from other Go modules, so `gocell generate assembly --id={{.ID}}` emits a
+// modules_gen.go whose generatedCellModules() returns []composition.CellModule
+// (cellmodules/{cell}.Module() calls). This run.go therefore consumes
+// []composition.CellModule — NOT the legacy local CellModule interface — so it
+// stays type-compatible with that modules_gen.go (the two share package main).
+// The cross-module scaffold is skeleton-only: run `gocell generate assembly` to
+// produce modules_gen.go / main.go / boundary.yaml, then `go build ./cmd/{{.ID}}`
+// compiles. Once business deps are loaded, follow the canonical three-layer
+// composition root pattern (see cmd/CLAUDE.md):
+//
+//  1. Env injection + module factory ({{.HelperName}}Modules)
+//  2. composition.New().With(modules...).Build(ctx, shared, runtimeOptsFn) assembles cells + bootstrap.Option
+//  3. Three listeners + bootstrap.New(opts...).Run(ctx)
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ghbvf/gocell/framework/runtime/composition"
+)
+
+// {{.HelperName}} is the hand-written runtime helper for the {{.ID}}
+// assembly. Implement env loading + composition Build before serving real
+// cells; the scaffold leaves this as a not-implemented stub so that — after
+// `gocell generate assembly --id={{.ID}}` produces modules_gen.go —
+// `go build ./cmd/{{.ID}}/...` succeeds while signaling that integration is
+// pending.
+func {{.HelperName}}(ctx context.Context, assemblyID string, assemblyCellIDs []string) error {
+	modules, err := {{.HelperName}}Modules(assemblyID, assemblyCellIDs)
+	if err != nil {
+		return err
+	}
+	_ = modules
+	// Scaffold stub: blocks until the context is cancelled (SIGINT/SIGTERM).
+	// Replace with composition.New().With(modules...).Build(ctx, shared, runtimeOptsFn)
+	// + bootstrap.New(opts...).Run(ctx) (see cmd/CLAUDE.md three-layer pattern)
+	// once SharedDeps and listener wiring are ready.
+	<-ctx.Done()
+	return nil
+}
+
+// {{.HelperName}}Modules wraps generatedCellModules() (modules_gen.go) with a
+// drift check against assembly.yaml.cells. Mismatch fails-fast and points the
+// operator at `gocell generate assembly --id={{.ID}}`. The composition-API form
+// returns []composition.CellModule, matching the modules_gen.go that
+// `gocell generate assembly` emits for a build.compositionAPI: true assembly.
+func {{.HelperName}}Modules(assemblyID string, cellIDs []string) ([]composition.CellModule, error) {
+	mods := generatedCellModules()
+	if err := assertModuleIDsMatch(assemblyID, cellIDs, mods); err != nil {
+		return nil, err
+	}
+	return mods, nil
+}
+
+// assertModuleIDsMatch fails-fast when assembly.yaml.cells (cellIDs) drifts
+// from the generated module list. The two should be 1:1 in declaration order;
+// any mismatch indicates a missing `gocell generate assembly` run.
+func assertModuleIDsMatch(assemblyID string, cellIDs []string, mods []composition.CellModule) error {
+	hint := fmt.Sprintf("run `gocell generate assembly --id=%s`", assemblyID)
+	if len(cellIDs) != len(mods) {
+		return fmt.Errorf(
+			"%s: assembly.yaml cells (%d) ↔ modules_gen.go (%d) length mismatch; %s",
+			assemblyID, len(cellIDs), len(mods), hint)
+	}
+	for i, want := range cellIDs {
+		if got := mods[i].ID(); got != want {
+			return fmt.Errorf(
+				"%s: assembly.yaml cells[%d]=%q ↔ modules_gen.go=%q drift; %s",
+				assemblyID, i, want, got, hint)
+		}
+	}
+	return nil
+}

--- a/framework/kernel/assembly/planset_helpers_test.go
+++ b/framework/kernel/assembly/planset_helpers_test.go
@@ -32,3 +32,15 @@ func mustID(t testing.TB, raw string) scaffoldid.ScaffoldID {
 	}
 	return id
 }
+
+// mustRefs builds a same-module []ScaffoldCellRef from known-valid cell ids —
+// the terse fixture constructor for AssemblyScaffoldSpec.Cells. Cross-module
+// fixtures construct ScaffoldCellRef{ID: mustID(...), Module: ...} literals.
+func mustRefs(t testing.TB, ids ...string) []ScaffoldCellRef {
+	t.Helper()
+	refs := make([]ScaffoldCellRef, len(ids))
+	for i, id := range ids {
+		refs[i] = ScaffoldCellRef{ID: mustID(t, id)}
+	}
+	return refs
+}

--- a/framework/kernel/assembly/synthesize_field_guard_test.go
+++ b/framework/kernel/assembly/synthesize_field_guard_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ghbvf/gocell/framework/kernel/metadata"
 	"github.com/ghbvf/gocell/framework/kernel/metadata/metadatatest"
-	"github.com/ghbvf/gocell/framework/pkg/scaffoldid"
 )
 
 // synthesisFieldExemptions lists AssemblyMeta yaml-bearing field paths that
@@ -78,7 +77,7 @@ func TestAssemblyMetaSynthesisFieldGuard(t *testing.T) {
 
 	spec := AssemblyScaffoldSpec{
 		ID:        mustID(t, "myasm"),
-		Cells:     []scaffoldid.ScaffoldID{mustID(t, "mycell")},
+		Cells:     mustRefs(t, "mycell"),
 		OwnerTeam: "platform",
 		OwnerRole: "maintainer",
 		Deploy:    "binary", // pick non-default so DeployTemplate is non-zero
@@ -174,7 +173,7 @@ func TestAssemblyMetaSynthesisFieldGuard_DefaultK8sDerivation(t *testing.T) {
 
 	spec := AssemblyScaffoldSpec{
 		ID:        mustID(t, "myasm"),
-		Cells:     []scaffoldid.ScaffoldID{mustID(t, "mycell")},
+		Cells:     mustRefs(t, "mycell"),
 		OwnerTeam: "platform",
 		OwnerRole: "maintainer",
 		Deploy:    "", // empty → must derive to "k8s" mirroring parser

--- a/framework/kernel/assembly/synthesize_field_guard_test.go
+++ b/framework/kernel/assembly/synthesize_field_guard_test.go
@@ -20,12 +20,14 @@ import (
 // requires, not an assembly-level field.)
 var synthesisFieldExemptions = map[string]string{
 	// build.compositionAPI selects the runtime/composition.CellModule
-	// modules_gen form. It is an in-tree opt-in reserved for the platform
-	// corebundle (#1085); newly scaffolded assemblies always use the legacy
-	// local-CellModule form (compositionAPI=false), so AssemblyScaffoldSpec
-	// has no field to derive it from and the zero value (false) is the
-	// intended scaffold output.
-	"build.compositionAPI": "scaffold uses legacy modules_gen; composition API form is in-tree corebundle opt-in (#1085), not scaffold input",
+	// modules_gen form. synthesizeAssemblyMeta is only reached for SAME-module
+	// scaffolds: PlanAssemblyScaffold short-circuits to a skeleton-only plan when
+	// any cell is cross-module (#1516), so the derived-file path that calls
+	// synthesize never sees a cross-module cell and the legacy local-CellModule
+	// form (compositionAPI=false) is always correct here. The cross-module
+	// compositionAPI: true output is emitted via the template path
+	// (buildScaffoldContext.CompositionAPI), not through synthesizeAssemblyMeta.
+	"build.compositionAPI": "synthesize is same-module-only; cross-module short-circuits before synthesis (#1516)",
 
 	// topology.groups is the deployment-partition graph (#1962, groups model
 	// #2278). Newly scaffolded assemblies have no explicit topology (all cells


### PR DESCRIPTION
## Summary

`gocell scaffold assembly` 新增 repeatable `--cell <id[@module]>` flag，可直接生成跨模块
`cells[].{id,module}` 对象形条目；`--cells=a,b` 同模块简写保持兼容（二者互斥）。

## Why / 背景

M5（#1086, PR #1514）已给 `assembly.yaml` 的 `cells:` 增加 `{id, module}` 跨模块形式，但
`gocell scaffold assembly` 只能生成 same-module 字符串形式，跨模块条目需手写。MDM external-cell
track（#2299/#2304）已让跨模块 assembly authoring 成为活跃工作流——本 PR 让 scaffold 直接产出
跨模块 `assembly.yaml`，MDM 起步组合平台 cell 时不再手写。目标是小而显式的脚手架能力，不是第二套
assembly DSL。

行为：

- `--cell id@module`（cross-module）→ object 形 `cells[].{id,module}` + `build.compositionAPI: true`，
  并**隐式跳过** K#10 派生文件（modules_gen.go / main.go / boundary.yaml）——跨模块 cell 的元数据
  本仓不可解析（属 #1515 的 module-cache 读取范畴），且现有 run.go 骨架是 legacy 形态、与 composition
  形态的 modules_gen.go 不兼容。CLI 打印 actionable `gocell generate assembly` 提示（非静默）。
- `--cell id`（无 @）/ `--cells=a,b` → same-module，行为不变（全 6 文件 plan）。
- `--cells` 与 `--cell` 互斥；坏 cell id / 坏 module 字符串 / `id@`（空 module）/ 重复 cell 均报
  actionable `ERR_SCAFFOLD_INVALID_OPTS`。

## Refs

- Closes #1516
- 历史来源 / 边界：ADR `docs/architecture/202606030230-adr-assembly-cross-module-composition.md`
  §Deferred（本 PR 将该条标记为已实现；module-cache 读取仍 deferred = #1515）。
- 并行边界：#1515 owns module-cache 元数据读取 + CellMeta 源模块追踪；本 PR 不依赖之。
- `ref: kubernetes/apimachinery pkg/util/validation/validation.go`（单 helper 校验，沿用本文件既定风格）。

## Risk / 兼容性

- **Go API（轴 A SemVer）破坏式**：`assembly.AssemblyScaffoldSpec.Cells` 由 `[]scaffoldid.ScaffoldID`
  改为 `[]assembly.ScaffoldCellRef`；`validateAssemblyFlags` 换签名。项目无外部消费方，已在同 PR 原子
  更新全部构造点（assembly 包测试 + cmd/gocell），无 deprecation 别名 / 双路径。
- **wire 契约 / migration**：无（未改 `assembly.yaml` schema —— `{id,module}` 形式 #1086 已存在；本 PR
  只新增 scaffold 产出该形式的能力）。无 contract / event / command 扇出。
- **已知边界（诚实披露，非缺陷）**：跨模块生成的 `assembly.yaml` 在本仓 `gocell validate` 会触发
  REF-08（`references non-existent cell`，因 cell 不在本仓 `project.Cells`），仅在 go.work / #1515 让
  该 cell 可发现后才通过——与派生文件同源的 #1515 依赖。**未削弱 REF-08**（那是静默漏洞）；scaffold 的
  职责止于产出正确 YAML。
- **AI-robust**：唯一新增 enforcement = module-hygiene 校验收口到 `validateAssemblyScaffoldSpec` 闭环
  funnel（所有 spec 必经，复用 `metadata.MatchAssemblyModulePath`，与 assembly.yaml decoder + Owner 守卫
  同级），**Medium**，无 Soft 新增。生成 import 仍经唯一 `cellModuleImportPath` funnel（未复制）。

## Test plan

- [x] `go build ./...` 本地通过（framework / cmd/gocell / tools/codegen / tools/archtest）
- [x] `go test ./...` 本地通过（cmd/gocell 全量 + framework/kernel/assembly + metadata；新逻辑覆盖率 92–100%）
- [x] `golangci-lint run ./...` 0 issues（framework + cmd/gocell，pin v2.11.4）
- [x] archtest `YAML-QUOTE-FUNNEL-01` + `SCAFFOLD-WRITE-FUNNEL-01` 通过（`-tags=archtest`）
- [x] round-trip：重解析生成的 `assembly.yaml` 断言 `AssemblyCellRef{ID,Module}` + `compositionAPI` 还原
