### PR TITLE
refactor(governance): #2387 confine corecells pgx via depguard + surface BYPASSRLS readyz guard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -454,15 +454,20 @@ linters:
                 one interceptor package. Mirrors grpc-adapter-no-interceptor-import.
         corecells-pgx-confined:
           # Soft→Medium (#2387 F13): the raw pgx driver must stay inside a cell's
-          # postgres-adapter packages. The single `!**/corecells/**/postgres/**`
-          # exclusion covers BOTH the internal adapter impl
-          # (corecells/<cell>/internal/adapters/postgres/**) AND the cell's postgres/
-          # wiring helper (corecells/<cell>/postgres/**) — both end in a `postgres/`
-          # path segment. Everything else under corecells/ (domain / handler /
+          # postgres-adapter packages — and ONLY those. Two precise exclusions
+          # enumerate the real allowed locations (`*` = the single cell-name segment):
+          #   - corecells/<cell>/internal/adapters/postgres/**  (the adapter impl)
+          #   - corecells/<cell>/postgres/**                    (the cell's wiring helper)
+          # An earlier `!**/corecells/**/postgres/**` form was fail-OPEN: it exempted
+          # ANY postgres-named dir at any depth, so a future
+          # corecells/<cell>/internal/domain/postgres/** (or slices/*/postgres/**)
+          # could import the driver and silently escape the guard (#2497 F1). The
+          # enumerated form is fail-CLOSED: anything outside the two adapter locations
+          # is denied. Everything else under corecells/ (domain / handler /
           # application / ports) must go through the cell-local DBTX interface
           # (defined in the internal adapter), never the driver directly.
           # cells-isolation ALLOWS jackc/pgx broadly across corecells (those adapter
-          # pkgs legitimately need it); this deny-overlay subtracts every NON-postgres
+          # pkgs legitimately need it); this deny-overlay subtracts every NON-adapter
           # corecells package so the broad exemption can no longer leak into domain
           # code. A path-level import ban with no type-system Hard form → depguard
           # (ai-robust.md §载体选择; same shape as the corebundle/ssobff eventbus bans
@@ -473,7 +478,8 @@ linters:
           files:
             - "**/corecells/**"
             - "!**/corecells/**/*_test.go"
-            - "!**/corecells/**/postgres/**"
+            - "!**/corecells/*/internal/adapters/postgres/**"
+            - "!**/corecells/*/postgres/**"
           deny:
             - pkg: github.com/jackc/pgx
               desc: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -452,6 +452,36 @@ linters:
                 composition roots wire auth (#1148). Layered on top of
                 cells-isolation (which allows runtime/* broadly); this subtracts the
                 one interceptor package. Mirrors grpc-adapter-no-interceptor-import.
+        corecells-pgx-confined:
+          # Soft→Medium (#2387 F13): the raw pgx driver must stay inside a cell's
+          # postgres-adapter packages. The single `!**/corecells/**/postgres/**`
+          # exclusion covers BOTH the internal adapter impl
+          # (corecells/<cell>/internal/adapters/postgres/**) AND the cell's postgres/
+          # wiring helper (corecells/<cell>/postgres/**) — both end in a `postgres/`
+          # path segment. Everything else under corecells/ (domain / handler /
+          # application / ports) must go through the cell-local DBTX interface
+          # (defined in the internal adapter), never the driver directly.
+          # cells-isolation ALLOWS jackc/pgx broadly across corecells (those adapter
+          # pkgs legitimately need it); this deny-overlay subtracts every NON-postgres
+          # corecells package so the broad exemption can no longer leak into domain
+          # code. A path-level import ban with no type-system Hard form → depguard
+          # (ai-robust.md §载体选择; same shape as the corebundle/ssobff eventbus bans
+          # above). Integration suites import the driver freely → excluded via the
+          # *_test.go negation. Before this rule the confinement was godoc-only (the
+          # "defines its own DBTX ... per layering rules" comments on each cell's
+          # session.go) — a Soft constraint this upgrades to Medium.
+          files:
+            - "**/corecells/**"
+            - "!**/corecells/**/*_test.go"
+            - "!**/corecells/**/postgres/**"
+          deny:
+            - pkg: github.com/jackc/pgx
+              desc: |
+                Outside a cell's postgres-adapter packages
+                (corecells/<cell>/internal/adapters/postgres/** + corecells/<cell>/postgres/**)
+                the raw pgx driver is forbidden; go through the cell-local DBTX
+                interface defined in the internal adapter. Confines the broad pgx
+                exemption cells-isolation grants corecells (#2387 F13, Soft→Medium).
         # Per-example cells-isolation rules. Examples are public-facing demos
         # of the framework's architecture; they must follow the SAME cell
         # discipline as platform cells/ (no cross-layer shortcuts) — otherwise

--- a/adapters/postgres/migrations/053_accesscore_tenant_rls_force.sql
+++ b/adapters/postgres/migrations/053_accesscore_tenant_rls_force.sql
@@ -45,10 +45,12 @@
 -- these tables AND MUST NOT have BYPASSRLS (or be superuser). FORCE ROW LEVEL
 -- SECURITY makes RLS apply even to the table OWNER, but a BYPASSRLS/superuser
 -- role still bypasses ALL row security. The integration suite asserts
--- rolbypassrls=false against a restricted role; the runtime readyz current-role
--- precondition probe + the production restricted app-serving pool wiring are an
--- independent app-pool readiness dimension deferred to a follow-up (it would turn
--- the superuser-based dev /readyz red until the two-role deployment model exists).
+-- rolbypassrls=false against a restricted role; this is now ALSO enforced at
+-- runtime by the readyz probe ProbeAppRoleRestrictedReady
+-- (adapters/postgres.AppRoleRestrictedCheck: "SELECT rolsuper, rolbypassrls FROM
+-- pg_roles WHERE rolname=current_user", fail-closed), wired on every serving pool
+-- via corebundle RequireRestrictedRole=true (ADR #1676). A BYPASSRLS/superuser
+-- serving role now fails /readyz instead of silently leaking across tenants.
 --
 -- ref: adapters/postgres/migrations/052_tenant_rls_force.sql (config-table RLS, copied)
 -- ref: adapters/postgres/migrations/050_accesscore_tenant_id.sql (tenant_id columns)

--- a/adapters/postgres/migrations/059_create_policies.sql
+++ b/adapters/postgres/migrations/059_create_policies.sql
@@ -35,7 +35,9 @@
 -- provisioning, not schema): the application PG role MUST NOT own this table AND
 -- MUST NOT have BYPASSRLS (or be superuser). FORCE ROW LEVEL SECURITY applies RLS
 -- even to the table OWNER, but a BYPASSRLS/superuser role still bypasses ALL row
--- security. Same constraint as migration 053.
+-- security. Same constraint as migration 053. Runtime-enforced by the readyz
+-- probe ProbeAppRoleRestrictedReady (adapters/postgres.AppRoleRestrictedCheck,
+-- ADR #1676): a BYPASSRLS/superuser serving role fails /readyz.
 --
 -- ref: adapters/postgres/migrations/053_accesscore_tenant_rls_force.sql (RLS shape, copied)
 -- ref: adapters/postgres/migrations/019_roles.sql (roles.permissions JSONB precedent)

--- a/adapters/postgres/migrations/066_create_contract_registrations.sql
+++ b/adapters/postgres/migrations/066_create_contract_registrations.sql
@@ -44,6 +44,8 @@
 -- role MUST NOT own these tables AND MUST NOT have BYPASSRLS (or be superuser).
 -- FORCE ROW LEVEL SECURITY applies RLS even to the table OWNER, but a
 -- BYPASSRLS/superuser role still bypasses ALL row security. Same as migration 059.
+-- Runtime-enforced by the readyz probe ProbeAppRoleRestrictedReady
+-- (adapters/postgres.AppRoleRestrictedCheck, ADR #1676).
 --
 -- Non-destructive DDL (CREATE TABLE / ENABLE / FORCE / CREATE POLICY / REVOKE add
 -- no column, drop nothing, rewrite no row): NO `+gocell forward-rebuild` annotation

--- a/corecells/configcore/internal/adapters/postgres/config_repo.go
+++ b/corecells/configcore/internal/adapters/postgres/config_repo.go
@@ -1,6 +1,11 @@
 // Package postgres provides a PostgreSQL implementation of configcore ports.
 // It does NOT import adapters/postgres — it defines its own DBTX interface
 // to match pgx.Tx / pgxpool.Pool, keeping the cell decoupled from the adapter layer.
+//
+// Both halves of that boundary are machine-enforced, not godoc-only: the
+// cells-isolation depguard rule bans any adapters/postgres import here, and
+// corecells-pgx-confined confines the raw jackc/pgx driver to this
+// postgres-adapter package (#2387 F13, Soft→Medium).
 package postgres
 
 import (

--- a/corecells/registrycore/internal/adapters/postgres/session.go
+++ b/corecells/registrycore/internal/adapters/postgres/session.go
@@ -3,6 +3,11 @@
 // defines its own DBTX interface to match pgx.Tx / pgxpool.Pool, keeping the
 // cell decoupled from the adapter layer (per layering rules). The shape mirrors
 // configcore/internal/adapters/postgres.
+//
+// Both halves of that boundary are machine-enforced, not godoc-only: the
+// cells-isolation depguard rule bans any adapters/postgres import here, and
+// corecells-pgx-confined confines the raw jackc/pgx driver to this
+// postgres-adapter package (#2387 F13, Soft→Medium).
 package postgres
 
 import (


### PR DESCRIPTION
## Summary

为 #2387 的两处「Soft→Medium」诉求收口:**F13** 用新 depguard 规则把裸 pgx 驱动 confine 到 cell 的 postgres-adapter 子层(原 godoc-only Soft → Medium);**F14** 的 BYPASSRLS 机器守卫已由 ADR #1676 落地,本 PR **不加冗余守卫**,只修正 migration stale 注释让既有 readyz probe 可见。

## Why / 背景

#2387(源自 PR #2383 review F13/F14)要求补两处机器守卫。核实当前 develop:

- **F14 已落地**:`adapters/postgres.AppRoleRestrictedCheck`(`SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname=current_user`,fail-closed)经 readyz probe `ProbeAppRoleRestrictedReady` + corebundle `RequireRestrictedRole=true` 在每个 serving pool 启用,pool 级覆盖所有 tenant 表(含 registrycore 066)。issue 要的「readyz BYPASSRLS 检查」即此 —— **再加 = 冗余双守卫**。复发根因是 migration `053` 注释仍称该 probe「deferred to a follow-up」(已 stale)→ 修正注释而非加守卫;`059/066` 注释补一行交叉引用现有 probe。
- **F13 的真 Soft**:「裸 pgx 只许在 adapter 子层」此前仅靠 godoc。`cells-isolation` depguard 已 ban `adapters/postgres`,但 `jackc/pgx` 在整个 corecells 放开,domain/handler/ports 可直 import 驱动绕过 cell-local DBTX。新增 `corecells-pgx-confined` deny-overlay 把驱动 confine 到 `corecells/**/postgres/**`(internal adapter impl + cell 的 postgres/ 接线包),其余 corecells 包直 import 即 CI 红。Soft→Medium。

载体选 depguard 而非 issue 字面的 archtest:路径级 import ban 无 type-system Hard 形态,depguard 即天花板(ai-robust.md §载体选择),archtest 叠加是冗余双守卫。

## Refs

Closes #2387
ref: ai-robust.md §载体选择 (路径级 import ban → depguard)
ref: .golangci.yml corebundle-no-direct-eventbus (depguard deny-overlay 先例)
ADR #1676 — restricted app-serving pool + ProbeAppRoleRestrictedReady

## Risk / 兼容性

无。新增 depguard 规则为纯增量 enforcement(当前 0 违例,GREEN);migration 改动**纯注释、不改 DDL**(不影响 replay / 不动 golden);godoc 改动纯注释。无 wire / 契约 / migration schema 变更,无消费方需同步。

## Test plan

- [x] `go build ./...` 本地通过(corecells + adapters/postgres 模块)
- [x] `go test ./...` 本地通过(adapters/postgres 单测全绿;改动无 Go 逻辑)
- [x] `golangci-lint run ./...` corecells **0 issues**(GREEN);**RED check**:临时给 `internal/ports` 加 `_ "github.com/jackc/pgx/v5"` → `corecells-pgx-confined` deny 触发,移除后复绿
- [x] `golangci-lint config verify` 通过(config 无 schema 破坏)
